### PR TITLE
chore: change wallet behavior

### DIFF
--- a/V2/tezex/src/components/wallet/Wallet.tsx
+++ b/V2/tezex/src/components/wallet/Wallet.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useEffect, useState } from "react";
-import connectWallet from "../../functions/beacon";
+import connectWallet, { reconnectWallet } from "../../functions/beacon";
 import { useWallet, useWalletOps } from "../../hooks/wallet";
 import { useNetwork } from "../../hooks/network";
 import { WalletInfo } from "../../contexts/wallet";
@@ -50,6 +50,19 @@ export const Wallet: FC<IWallet> = (props) => {
     }
   }, [walletOps?.getTransactionStatus, transactionStatus]);
 
+  // use effect to reconnect the wallet if user refreshes the page
+  useEffect(() => {
+    const autoReconnect = async () => {
+      try {
+        await reconnectWallet(walletInfo, networkInfo);
+      } catch (error) {
+        console.error("Failed to reconnect:", error);
+      }
+    };
+
+    autoReconnect();
+  }, []);
+
   // Effect to monitor transaction status and update wallet text
   useEffect(() => {
     switch (transactionStatus) {
@@ -93,7 +106,7 @@ export const Wallet: FC<IWallet> = (props) => {
   };
   const disconnect = async () => {
     if (walletInfo) {
-      walletInfo.disconnect();
+      await walletInfo.disconnect();
     }
   };
 

--- a/V2/tezex/src/contexts/wallet.tsx
+++ b/V2/tezex/src/contexts/wallet.tsx
@@ -51,7 +51,7 @@ export interface WalletInfo {
   lbContractStorage: LiquidityBakingStorageXTZ | undefined;
   setAddress: React.Dispatch<React.SetStateAction<string | null>>;
   isWalletConnected: boolean;
-  disconnect: () => void;
+  disconnect: () => Promise<void>;
   initialiseTransaction: (
     component: TransactingComponent,
     sendAsset: AssetOrAssetPair,
@@ -724,7 +724,10 @@ export function WalletProvider(props: IWalletProvider) {
   }, [client]);
 
   // disconnect wallet
-  const disconnect = () => {
+  const disconnect = async () => {
+    if (client) {
+      await client.clearActiveAccount();
+    }
     setClient(null);
     setAddress(null);
   };

--- a/V2/tezex/src/functions/beacon.ts
+++ b/V2/tezex/src/functions/beacon.ts
@@ -77,3 +77,22 @@ export default async function connectWallet(
     }
   }
 }
+
+export async function reconnectWallet(
+  walletInfo: WalletInfo,
+  network: INetwork
+) {
+  const beaconWallet = new BeaconWallet({
+    name: "Tezex",
+    preferredNetwork: network.network,
+  });
+  const activeAccount = await beaconWallet.client.getActiveAccount();
+  if (activeAccount) {
+    const tezos = new TezosToolkit(network.info.tezosServer);
+    tezos.setPackerProvider(new MichelCodecPacker());
+    tezos.setWalletProvider(beaconWallet);
+    walletInfo.setAddress(activeAccount.address);
+    walletInfo.setClient(beaconWallet.client);
+    walletInfo.setToolkit(tezos);
+  }
+}


### PR DESCRIPTION
Changed wallet behavior: 
- Disconnecting the wallet now clears connection which will allow user to choose another wallet
- When refreshing the page, if user previously connected the wallet,  it will automatically reconnect. 