### PR TITLE
fix: refresh page

### DIFF
--- a/V2/tezex/src/index.tsx
+++ b/V2/tezex/src/index.tsx
@@ -6,40 +6,37 @@ import App from "./App";
 import reportWebVitals from "./reportWebVitals";
 import { SessionProvider } from "./contexts/session";
 import ReactDOM from "react-dom/client";
-import { createBrowserRouter, RouterProvider } from "react-router-dom";
+import { createHashRouter, RouterProvider } from "react-router-dom";
 import "./index.css";
 
 import { AppConfig } from "./types/general";
 import appConfig from "./config/app.json";
 import { Home } from "./pages/Home";
 
-const router = createBrowserRouter(
-  [
-    {
-      path: "/",
-      element: <App />,
-      children: [
-        {
-          path: "home/swap",
-          element: <Home path="swap" />,
-        },
-        {
-          path: "home/add",
-          element: <Home path="add" />,
-        },
-        {
-          path: "home/remove",
-          element: <Home path="remove" />,
-        },
-        {
-          path: "analytics",
-          element: <Home path="swap" />,
-        },
-      ],
-    },
-  ],
-  { basename: process.env.PUBLIC_URL }
-);
+const router = createHashRouter([
+  {
+    path: "/",
+    element: <App />,
+    children: [
+      {
+        path: "home/swap",
+        element: <Home path="swap" />,
+      },
+      {
+        path: "home/add",
+        element: <Home path="add" />,
+      },
+      {
+        path: "home/remove",
+        element: <Home path="remove" />,
+      },
+      {
+        path: "analytics",
+        element: <Home path="swap" />,
+      },
+    ],
+  },
+]);
 const root = ReactDOM.createRoot(document.getElementById("root") as Element);
 
 root.render(


### PR DESCRIPTION
Cause of a problem: As we have a single page application (GH pages), when first accessing the web-site we access "/" route which then redirects and renders the content of route "/home/swap", but this explicit route exists only on the client side not on the server, so when refreshing the page we try to access "https://tezex.io/home/swap" and it fails (404 error) as there is no route on the server.
For single page application it is recommended to use HashRouter instead of BrowserRoute which we currently use. I switched application to use HashRouter. 