### PR TITLE
Add frontend release safeguards

### DIFF
--- a/.github/workflows/tezex-ui-ci.yml
+++ b/.github/workflows/tezex-ui-ci.yml
@@ -1,0 +1,51 @@
+name: TEZEX UI release gate
+
+on:
+  pull_request:
+    paths:
+      - "V2/tezex/**"
+      - ".github/workflows/tezex-ui-ci.yml"
+  push:
+    branches:
+      - trunk
+    paths:
+      - "V2/tezex/**"
+      - ".github/workflows/tezex-ui-ci.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: V2/tezex
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: V2/tezex/package-lock.json
+
+      - name: Install locked dependencies
+        run: npm ci
+        env:
+          HUSKY: 0
+
+      - name: Audit production dependencies
+        run: npm run audit:production
+
+      - name: Type-check
+        run: npm run typecheck
+
+      - name: Run tests
+        run: npm run test:ci
+
+      - name: Build release artifact
+        run: npm run build

--- a/V2/tezex/.gitignore
+++ b/V2/tezex/.gitignore
@@ -7,6 +7,8 @@
 
 # testing
 /coverage
+/.playwright-cli
+/output/playwright
 
 # production
 /build

--- a/V2/tezex/RELEASE_CHECKLIST.md
+++ b/V2/tezex/RELEASE_CHECKLIST.md
@@ -1,0 +1,68 @@
+# TEZEX UI release checklist
+
+This checklist treats the UI as a mainnet transaction client. A successful build is necessary, but the release is not complete until one deliberately small wallet transaction is confirmed on-chain.
+
+## Current rollback baseline
+
+- `origin/gh-pages`: `34995a9387d129c37e929f85e5215a59d73c9aa5`
+- Captured: 2026-07-20
+- Re-run `git fetch origin gh-pages && git rev-parse origin/gh-pages` immediately before deployment and save the fresh value if it changed.
+
+## Automated release gate
+
+From `V2/tezex`:
+
+```bash
+HUSKY=0 npm ci
+npm run verify
+```
+
+`npm run verify` must pass the production dependency audit threshold, TypeScript checks, tests, and optimized build. Do not use `npm audit fix --force`; the currently suggested forced resolution downgrades Beacon and can break wallet compatibility.
+
+## Manual preview checks
+
+- Desktop, intermediate, and mobile widths render without clipped or missing controls.
+- Swap/Liquidity, Add/Remove Liquidity, light/dark mode, pool selector, menu, and all slippage choices work.
+- Selecting Custom slippage does not change the control height.
+- Values outside 0.1%–5% are blocked; values above 1% show a warning.
+- Max Tez retains the configured fee reserve.
+- Request/Swap/Complete animation honors reduced-motion settings.
+- Browser console contains no TEZEX or Beacon integration errors.
+
+## Mainnet wallet smoke test
+
+Use a dedicated low-balance test wallet and the smallest practical trade amount.
+
+1. Confirm the header and wallet both show Mainnet.
+2. Enter a small swap and compare the pool, input, minimum received, recipient, and fees in the wallet before approving.
+3. Confirm the UI moves from Request to Swap only after wallet initiation.
+4. Record the operation hash and verify that TzKT reports `applied`.
+5. Confirm the UI reaches Complete only after on-chain confirmation and balances refresh.
+6. Test wallet rejection. The UI must show a failure explanation and return to Request.
+7. If confirmation cannot be verified, confirm the UI shows the hash, links to TzKT, and does not offer a blind retry.
+
+## Deploy
+
+Only after the automated gate and wallet smoke test pass:
+
+```bash
+git fetch origin gh-pages
+git rev-parse origin/gh-pages
+cd V2/tezex
+npm run deploy
+```
+
+The `predeploy` script runs the full verification gate again before publishing. After publishing, record the new `gh-pages` commit and verify `https://tezex.io/#/home/swap` in a fresh browser session.
+
+## Roll back without rewriting history
+
+If the production smoke check fails, revert the deployment commit on `gh-pages` instead of force-pushing:
+
+```bash
+git fetch origin gh-pages
+git switch -c hotfix/rollback-tezex-ui origin/gh-pages
+git revert <new-gh-pages-deployment-commit>
+git push origin HEAD:gh-pages
+```
+
+Then verify that `tezex.io` serves the recorded baseline and investigate on the feature branch.

--- a/V2/tezex/package.json
+++ b/V2/tezex/package.json
@@ -43,11 +43,15 @@
     "extends": null
   },
   "scripts": {
-    "predeploy": "npm run build",
+    "predeploy": "npm run verify",
     "deploy": "gh-pages -d build",
     "start": "react-app-rewired start",
     "build": "react-app-rewired build",
     "test": "react-app-rewired test",
+    "test:ci": "npm test -- --watchAll=false --runInBand",
+    "typecheck": "tsc --noEmit",
+    "audit:production": "npm audit --omit=dev --audit-level=high",
+    "verify": "npm run audit:production && npm run typecheck && npm run test:ci && npm run build",
     "eject": "react-scripts eject",
     "prepare": "cd ../.. && husky install .husky/"
   },


### PR DESCRIPTION
## Summary

- add a GitHub Actions release gate for the V2 frontend
- require the production dependency audit, type-checking, tests, and optimized build
- add a mainnet wallet smoke-test checklist and non-destructive rollback procedure
- prevent local browser-test artifacts from entering source control
- run the complete verification gate before deployment

## Impact

Frontend releases gain a repeatable automated gate and an explicit mainnet validation and rollback process.

## Validation

- TypeScript type-check passed
- 7 test suites / 28 tests passed
- optimized production build completed
- the combined branch stack matches the validated release-candidate file tree

## Review focus

Review workflow permissions and triggers, release commands, mainnet smoke checks, and rollback instructions.