### PR TITLE
Align mobile liquidity header labels

### DIFF
--- a/V2/tezex/src/components/addLiquidity/style.js
+++ b/V2/tezex/src/components/addLiquidity/style.js
@@ -40,6 +40,7 @@ const style = (theme, scale = 1) => {
       display: "flex",
       flexDirection: "column",
       gap: "8px",
+      textAlign: "left",
     },
     eyebrow: {
       color: "var(--tezex-muted)",

--- a/V2/tezex/src/components/removeLiquidity/style.js
+++ b/V2/tezex/src/components/removeLiquidity/style.js
@@ -40,6 +40,7 @@ const style = (theme, scale = 1) => {
       display: "flex",
       flexDirection: "column",
       gap: "8px",
+      textAlign: "left",
     },
     eyebrow: {
       color: "var(--tezex-muted)",


### PR DESCRIPTION
## What changed

- Explicitly left-align the Add Liquidity header title group.
- Apply the same rule to Remove Liquidity for consistency.

## Why

The liquidity eyebrow inherited centered text alignment on mobile, placing it differently from the Swap eyebrow and the liquidity tabs beneath it.

## Impact

The `LIQUIDITY` label now shares the card's left content edge with `Add Liquidity`, matching the Swap screen. No transaction, wallet, pool, or routing logic changed.

## Validation

- TypeScript check passed.
- 29 tests passed.
- Production build compiled successfully.
- Verified Add and Remove Liquidity at a 390 x 844 mobile viewport in light and dark themes.
