### PR TITLE
Make TEZEX logo return home

### DIFF
--- a/V2/tezex/src/components/ui/views/header/index.test.tsx
+++ b/V2/tezex/src/components/ui/views/header/index.test.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { Header } from ".";
+
+jest.mock("../../../wallet/Wallet", () => ({
+  Wallet: () => <div>Wallet</div>,
+}));
+
+jest.mock("../../../nav", () => ({
+  NavApp: () => <nav>Navigation</nav>,
+}));
+
+jest.mock("../../elements/selectors/networkSelector/NetworkSelector", () => ({
+  NetworkSelector: () => <div>Network</div>,
+}));
+
+jest.mock("../../../../hooks/styles", () => () => ({
+  isMobile: false,
+  appBar: {},
+  shell: {},
+  toolbar: {},
+  container: {},
+  logoLink: {},
+  logoLarge: {},
+  networkSelector: {},
+  nav: {},
+  actions: {},
+  themeToggle: {},
+  themeIcon: {},
+  themeToggleKnob: {},
+  wallet: {},
+  menu: {},
+  menuButton: {},
+  hide: {},
+}));
+
+jest.mock("../../../../contexts/color-mode", () => ({
+  useColorMode: () => ({ mode: "light", toggleMode: jest.fn() }),
+}));
+
+const CurrentLocation = () => {
+  const location = useLocation();
+  return <div data-testid="location">{location.pathname}</div>;
+};
+
+test("the TEZEX logo navigates to the swap home route", () => {
+  render(
+    <MemoryRouter
+      initialEntries={["/home/add"]}
+      future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+    >
+      <Routes>
+        <Route
+          path="*"
+          element={
+            <>
+              <Header openMenu={false} toggleMenu={jest.fn()} />
+              <CurrentLocation />
+            </>
+          }
+        />
+      </Routes>
+    </MemoryRouter>
+  );
+
+  fireEvent.click(screen.getByRole("link", { name: "TEZEX home" }));
+
+  expect(screen.getByTestId("location")).toHaveTextContent("/home/swap");
+});

--- a/V2/tezex/src/components/ui/views/header/index.tsx
+++ b/V2/tezex/src/components/ui/views/header/index.tsx
@@ -12,6 +12,7 @@ import MenuIcon from "@mui/icons-material/Menu";
 import LightModeOutlinedIcon from "@mui/icons-material/LightModeOutlined";
 import DarkModeOutlinedIcon from "@mui/icons-material/DarkModeOutlined";
 import Container from "@mui/material/Container";
+import { Link } from "react-router-dom";
 import style from "./style";
 import useStyles from "../../../../hooks/styles";
 import { NetworkSelector } from "../../elements/selectors/networkSelector/NetworkSelector";
@@ -39,7 +40,14 @@ export const Header: FC<IHeader> = (props) => {
           sx={styles.isMobile ? styles.toolbar.mobile : styles.toolbar}
         >
           <Box sx={styles.container}>
-            <Box component="img" sx={styles.logoLarge} src={logo} alt="TEZEX" />
+            <Box
+              component={Link}
+              to="/home/swap"
+              aria-label="TEZEX home"
+              sx={styles.logoLink}
+            >
+              <Box component="img" sx={styles.logoLarge} src={logo} alt="" />
+            </Box>
 
             <Box sx={styles.networkSelector}>
               <NetworkSelector />

--- a/V2/tezex/src/components/ui/views/header/style.js
+++ b/V2/tezex/src/components/ui/views/header/style.js
@@ -46,6 +46,16 @@ const style = (theme, scale = 1) => {
       flexShrink: 0,
       "@media (min-width: 1200px)": { width: "144px" },
     },
+    logoLink: {
+      display: "flex",
+      flexShrink: 0,
+      borderRadius: "4px",
+      textDecoration: "none",
+      "&:focus-visible": {
+        outline: "2px solid var(--tezex-text-secondary)",
+        outlineOffset: "4px",
+      },
+    },
     container: {
       width: "100%",
       alignItems: "center",


### PR DESCRIPTION
## What changed

- Make the TEZEX header logo navigate to the Swap home route.
- Use React Router navigation so the app does not perform a full-page reload.
- Add accessible keyboard focus styling and a regression test.

## Why

The header rendered the logo as a static image, even though users reasonably expect the brand mark to return them to the main trading screen.

## Validation

- `npm run verify`
- Focused header navigation test
- TypeScript typecheck
- Production build
