### PR TITLE
Smooth Swap and Liquidity transitions

### DIFF
--- a/V2/tezex/src/components/nav/NavHome.tsx
+++ b/V2/tezex/src/components/nav/NavHome.tsx
@@ -13,9 +13,10 @@ import useStyles from "../../hooks/styles";
 interface NavTabProps extends Omit<TabProps, "onClick"> {
   href: string;
   scalingKey?: string;
+  onNavigate?: (href: string) => void;
 }
 
-function NavTab({ href, scalingKey, ...tabProps }: NavTabProps) {
+function NavTab({ href, scalingKey, onNavigate, ...tabProps }: NavTabProps) {
   const navigate = useNavigate();
   const styles = useStyles(style, scalingKey);
   return (
@@ -25,7 +26,8 @@ function NavTab({ href, scalingKey, ...tabProps }: NavTabProps) {
       sx={styles.navHome.tab}
       onClick={(event) => {
         event.preventDefault();
-        navigate(href);
+        if (onNavigate) onNavigate(href);
+        else navigate(href);
       }}
     />
   );
@@ -33,6 +35,8 @@ function NavTab({ href, scalingKey, ...tabProps }: NavTabProps) {
 
 export interface INavHome {
   scalingKey?: string;
+  onNavigate?: (href: string) => void;
+  isTransitioning?: boolean;
 }
 export const NavHome: FC<INavHome> = (props) => {
   const styles = useStyles(style, props.scalingKey);
@@ -68,12 +72,21 @@ export const NavHome: FC<INavHome> = (props) => {
       sx={styles.navHome.root}
       onChange={handleChange}
       aria-label="nav-home-tabs"
+      aria-busy={props.isTransitioning}
     >
-      <NavTab label="Swap" href="/home/swap" scalingKey={props.scalingKey} />
+      <NavTab
+        label="Swap"
+        href="/home/swap"
+        scalingKey={props.scalingKey}
+        onNavigate={props.onNavigate}
+        disabled={props.isTransitioning}
+      />
       <NavTab
         label="Liquidity"
         href={liquidityHref()}
         scalingKey={props.scalingKey}
+        onNavigate={props.onNavigate}
+        disabled={props.isTransitioning}
       />
     </Tabs>
   );

--- a/V2/tezex/src/components/nav/style.js
+++ b/V2/tezex/src/components/nav/style.js
@@ -145,6 +145,13 @@ const style = (theme, scale = 1) => {
           "&.Mui-selected": {
             color: "var(--tezex-action-text)",
           },
+          "&.Mui-disabled": {
+            opacity: 1,
+            color: "var(--tezex-muted)",
+          },
+          "&.Mui-selected.Mui-disabled": {
+            color: "var(--tezex-action-text)",
+          },
           "&.Mui-selected.Mui-focusVisible": {
             outlineColor: "var(--tezex-panel)",
           },

--- a/V2/tezex/src/pages/Home/index.test.tsx
+++ b/V2/tezex/src/pages/Home/index.test.tsx
@@ -1,0 +1,155 @@
+import React from "react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import {
+  MemoryRouter,
+  Route,
+  Routes,
+  useLocation,
+  useParams,
+} from "react-router-dom";
+import { Home } from ".";
+
+jest.mock("../../components/nav", () => ({
+  NavHome: ({
+    onNavigate,
+    isTransitioning,
+  }: {
+    onNavigate: (href: string) => void;
+    isTransitioning: boolean;
+  }) => (
+    <nav>
+      <button
+        type="button"
+        onClick={() => onNavigate("/home/swap")}
+        disabled={isTransitioning}
+      >
+        Swap
+      </button>
+      <button
+        type="button"
+        onClick={() => onNavigate("/home/add")}
+        disabled={isTransitioning}
+      >
+        Liquidity
+      </button>
+    </nav>
+  ),
+}));
+
+jest.mock("../../components/swap", () => ({
+  Swap: () => <div>Swap workspace</div>,
+}));
+
+jest.mock("../../components/addLiquidity", () => ({
+  AddLiquidity: () => <div>Liquidity workspace</div>,
+}));
+
+jest.mock("../../components/removeLiquidity", () => ({
+  RemoveLiquidity: () => <div>Remove liquidity workspace</div>,
+}));
+
+jest.mock("../../hooks/styles", () => () => ({
+  homeContainer: {},
+  nav: { mobile: {} },
+  contentViewport: {},
+  modePanel: {},
+}));
+
+jest.mock("react-device-detect", () => ({
+  BrowserView: ({ children }: { children: React.ReactNode }) => children,
+  MobileView: () => null,
+  useMobileOrientation: () => ({ orientation: "portrait" }),
+}));
+
+const RoutedHome = () => {
+  const { mode = "swap" } = useParams();
+  const path = mode === "remove" ? "remove" : mode === "add" ? "add" : "swap";
+  return <Home path={path} />;
+};
+
+const Location = () => {
+  const location = useLocation();
+  return <div data-testid="location">{location.pathname}</div>;
+};
+
+const renderHome = () =>
+  render(
+    <MemoryRouter
+      initialEntries={["/home/swap"]}
+      future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+    >
+      <Routes>
+        <Route
+          path="/home/:mode"
+          element={
+            <>
+              <RoutedHome />
+              <Location />
+            </>
+          }
+        />
+      </Routes>
+    </MemoryRouter>
+  );
+
+beforeEach(() => {
+  window.matchMedia = jest.fn().mockReturnValue({ matches: false });
+});
+
+afterEach(() => {
+  delete (HTMLElement.prototype as Partial<HTMLElement>).animate;
+});
+
+test("changes modes immediately when browser animation is unavailable", () => {
+  renderHome();
+
+  fireEvent.click(screen.getByRole("button", { name: "Liquidity" }));
+
+  expect(screen.getByTestId("location")).toHaveTextContent("/home/add");
+  expect(screen.getByText("Liquidity workspace")).toBeInTheDocument();
+});
+
+test("slides the current workspace out before the next workspace enters", async () => {
+  let finishExit: () => void = () => undefined;
+  const exitFinished = new Promise<void>((resolve) => {
+    finishExit = resolve;
+  });
+  const animate = jest
+    .fn()
+    .mockReturnValueOnce({ finished: exitFinished, cancel: jest.fn() })
+    .mockReturnValue({ finished: Promise.resolve(), cancel: jest.fn() });
+  HTMLElement.prototype.animate = animate;
+
+  renderHome();
+  fireEvent.click(screen.getByRole("button", { name: "Liquidity" }));
+
+  expect(screen.getByTestId("location")).toHaveTextContent("/home/swap");
+  expect(animate).toHaveBeenNthCalledWith(
+    1,
+    [
+      { opacity: 1, transform: "translate3d(0, 0, 0)" },
+      { opacity: 0.35, transform: "translate3d(-18px, 0, 0)" },
+    ],
+    { duration: 140, easing: "cubic-bezier(.4,0,.7,.2)" }
+  );
+
+  await act(async () => finishExit());
+
+  await waitFor(() =>
+    expect(screen.getByTestId("location")).toHaveTextContent("/home/add")
+  );
+  expect(animate).toHaveBeenNthCalledWith(
+    2,
+    [
+      { opacity: 0.35, transform: "translate3d(18px, 0, 0)" },
+      { opacity: 1, transform: "translate3d(0, 0, 0)" },
+    ],
+    { duration: 220, easing: "cubic-bezier(.22,.8,.24,1)" }
+  );
+});

--- a/V2/tezex/src/pages/Home/index.tsx
+++ b/V2/tezex/src/pages/Home/index.tsx
@@ -1,4 +1,5 @@
-import React, { FC } from "react";
+import React, { FC, useCallback, useEffect, useRef, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 
 import { NavHome } from "../../components/nav";
 import { Swap } from "../../components/swap";
@@ -6,6 +7,7 @@ import { AddLiquidity } from "../../components/addLiquidity";
 import { RemoveLiquidity } from "../../components/removeLiquidity";
 
 import Grid2 from "@mui/material/Unstable_Grid2"; // Grid version 2
+import Box from "@mui/material/Box";
 
 import style from "./style";
 import useStyles from "../../hooks/styles";
@@ -16,6 +18,16 @@ import {
 } from "react-device-detect";
 
 type HomePaths = "swap" | "add" | "remove";
+type ModeTransitionDirection = "forward" | "backward";
+
+interface ModeTransitionState {
+  modeTransitionDirection?: ModeTransitionDirection;
+}
+
+const prefersReducedMotion = () =>
+  window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+
+const isLiquidityRoute = (path: HomePaths | string) => path !== "swap";
 
 export interface IHome {
   path: HomePaths;
@@ -23,6 +35,102 @@ export interface IHome {
 export const Home: FC<IHome> = (props) => {
   const { orientation } = useMobileOrientation();
   const styles = useStyles(style);
+  const navigate = useNavigate();
+  const location = useLocation();
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const exitAnimationRef = useRef<Animation | null>(null);
+  const navigationSequenceRef = useRef(0);
+  const [isTransitioning, setIsTransitioning] = useState(false);
+  const transitionDirection = (location.state as ModeTransitionState | null)
+    ?.modeTransitionDirection;
+
+  useEffect(() => {
+    const panel = panelRef.current;
+
+    if (!transitionDirection || !panel?.animate || prefersReducedMotion()) {
+      setIsTransitioning(false);
+      return;
+    }
+
+    setIsTransitioning(true);
+    let isCurrentAnimation = true;
+    const offset = transitionDirection === "forward" ? "18px" : "-18px";
+    const animation = panel.animate(
+      [
+        { opacity: 0.35, transform: `translate3d(${offset}, 0, 0)` },
+        { opacity: 1, transform: "translate3d(0, 0, 0)" },
+      ],
+      {
+        duration: 220,
+        easing: "cubic-bezier(.22,.8,.24,1)",
+      }
+    );
+
+    void animation.finished
+      .catch(() => undefined)
+      .then(() => isCurrentAnimation && setIsTransitioning(false));
+
+    return () => {
+      isCurrentAnimation = false;
+      animation.cancel();
+    };
+  }, [location.key, transitionDirection]);
+
+  useEffect(
+    () => () => {
+      navigationSequenceRef.current += 1;
+      exitAnimationRef.current?.cancel();
+    },
+    []
+  );
+
+  const navigateBetweenModes = useCallback(
+    (href: string) => {
+      const targetPath = href.split("/").pop() ?? "swap";
+      const currentIsLiquidity = isLiquidityRoute(props.path);
+      const targetIsLiquidity = isLiquidityRoute(targetPath);
+
+      if (currentIsLiquidity === targetIsLiquidity || isTransitioning) return;
+
+      const direction: ModeTransitionDirection = targetIsLiquidity
+        ? "forward"
+        : "backward";
+      const panel = panelRef.current;
+      const completeNavigation = () =>
+        navigate(href, { state: { modeTransitionDirection: direction } });
+
+      if (!panel?.animate || prefersReducedMotion()) {
+        completeNavigation();
+        return;
+      }
+
+      const sequence = navigationSequenceRef.current + 1;
+      navigationSequenceRef.current = sequence;
+      setIsTransitioning(true);
+
+      const offset = direction === "forward" ? "-18px" : "18px";
+      const animation = panel.animate(
+        [
+          { opacity: 1, transform: "translate3d(0, 0, 0)" },
+          { opacity: 0.35, transform: `translate3d(${offset}, 0, 0)` },
+        ],
+        {
+          duration: 140,
+          easing: "cubic-bezier(.4,0,.7,.2)",
+        }
+      );
+      exitAnimationRef.current = animation;
+
+      void animation.finished
+        .catch(() => undefined)
+        .then(() => {
+          if (navigationSequenceRef.current !== sequence) return;
+          completeNavigation();
+        });
+    },
+    [isTransitioning, navigate, props.path]
+  );
+
   const Comp = (() => {
     switch (props.path) {
       case "add":
@@ -38,16 +146,28 @@ export const Home: FC<IHome> = (props) => {
     <Grid2 sx={styles.homeContainer} container>
       <MobileView>
         <Grid2 sx={styles.nav.mobile}>
-          <NavHome scalingKey="navHome" />
+          <NavHome
+            scalingKey="navHome"
+            onNavigate={navigateBetweenModes}
+            isTransitioning={isTransitioning}
+          />
         </Grid2>
       </MobileView>
 
       <BrowserView>
         <Grid2 sx={styles.nav}>
-          <NavHome scalingKey="navHome" />
+          <NavHome
+            scalingKey="navHome"
+            onNavigate={navigateBetweenModes}
+            isTransitioning={isTransitioning}
+          />
         </Grid2>
       </BrowserView>
-      <Grid2>{Comp}</Grid2>
+      <Grid2 sx={styles.contentViewport}>
+        <Box ref={panelRef} sx={styles.modePanel}>
+          {Comp}
+        </Box>
+      </Grid2>
     </Grid2>
   );
 };

--- a/V2/tezex/src/pages/Home/style.js
+++ b/V2/tezex/src/pages/Home/style.js
@@ -31,6 +31,12 @@ const style = (theme, scale = 1) => {
       width: "100%",
       padding: { xs: "0 16px", md: "0 28px" },
     },
+    contentViewport: {
+      width: "100%",
+    },
+    modePanel: {
+      width: "100%",
+    },
   };
 };
 


### PR DESCRIPTION
## What changed

- Animate the Swap workspace out to the left before Liquidity enters from the right.
- Reverse the motion when returning from Liquidity to Swap.
- Keep the segmented control anchored and temporarily lock repeated navigation while the transition is running.
- Respect the operating system's reduced-motion preference and fall back safely when browser animation support is unavailable.
- Add regression coverage for both animated and non-animated navigation.

## Why

Swap and Liquidity are two modes of the same trading workspace. Their content previously changed abruptly, making the interaction feel like a page refresh even though the selected tab used a sliding indicator.

## Validation

- `npm run verify`
- 32 automated tests passed
- TypeScript typecheck passed
- Production build passed
- Real-browser forward and reverse transitions verified at desktop and iPhone viewport widths
- Browser console: zero errors and zero warnings
