### PR TITLE
Slide the full trading workspace

### DIFF
--- a/V2/tezex/src/components/ui/elements/inputs/UserAmount/index.test.tsx
+++ b/V2/tezex/src/components/ui/elements/inputs/UserAmount/index.test.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import {
+  Asset,
+  TransactingComponent,
+  TransferType,
+} from "../../../../../types/general";
+import { UserAmountField } from ".";
+
+jest.mock("./token-input", () => ({
+  TokenAmountInput: ({
+    asset,
+    loading,
+  }: {
+    asset: Asset;
+    loading?: boolean;
+  }) => (
+    <div data-testid="token-amount-input">
+      {asset.label}:{loading ? "loading" : "ready"}
+    </div>
+  ),
+}));
+
+const tez = { label: "Tez" } as Asset;
+const usdTz = { label: "USDtz" } as Asset;
+
+describe("UserAmountField", () => {
+  it("keeps the amount control mounted while a new pool initializes", () => {
+    const { rerender } = render(
+      <UserAmountField
+        component={TransactingComponent.SWAP}
+        transferType={TransferType.SEND}
+        asset={tez}
+        loading={false}
+      />
+    );
+    const amountControl = screen.getByTestId("token-amount-input");
+
+    rerender(
+      <UserAmountField
+        component={TransactingComponent.SWAP}
+        transferType={TransferType.SEND}
+        asset={usdTz}
+        loading
+      />
+    );
+
+    expect(screen.getByTestId("token-amount-input")).toBe(amountControl);
+    expect(amountControl).toHaveTextContent("USDtz:loading");
+  });
+});

--- a/V2/tezex/src/components/ui/elements/inputs/UserAmount/index.tsx
+++ b/V2/tezex/src/components/ui/elements/inputs/UserAmount/index.tsx
@@ -25,8 +25,6 @@ export interface IAmountField {
 }
 
 const AmountField: FC<IAmountField> = (props) => {
-  if (props.loading) return <div />;
-
   return (
     <TokenAmountInput
       component={props.component}

--- a/V2/tezex/src/index.css
+++ b/V2/tezex/src/index.css
@@ -93,6 +93,66 @@ textarea {
     color 180ms ease;
 }
 
+@keyframes tezex-workspace-exit-left {
+  to {
+    transform: translateX(-104%);
+  }
+}
+
+@keyframes tezex-workspace-enter-right {
+  from {
+    transform: translateX(104%);
+  }
+}
+
+@keyframes tezex-workspace-exit-right {
+  to {
+    transform: translateX(104%);
+  }
+}
+
+@keyframes tezex-workspace-enter-left {
+  from {
+    transform: translateX(-104%);
+  }
+}
+
+html[data-mode-transition] {
+  view-transition-name: none;
+}
+
+html[data-mode-transition="forward"]::view-transition-old(
+    tezex-trading-workspace
+  ) {
+  animation: 360ms cubic-bezier(0.22, 1, 0.36, 1) both tezex-workspace-exit-left;
+}
+
+html[data-mode-transition="forward"]::view-transition-new(
+    tezex-trading-workspace
+  ) {
+  animation: 360ms cubic-bezier(0.22, 1, 0.36, 1) both
+    tezex-workspace-enter-right;
+}
+
+html[data-mode-transition="backward"]::view-transition-old(
+    tezex-trading-workspace
+  ) {
+  animation: 360ms cubic-bezier(0.22, 1, 0.36, 1) both
+    tezex-workspace-exit-right;
+}
+
+html[data-mode-transition="backward"]::view-transition-new(
+    tezex-trading-workspace
+  ) {
+  animation: 360ms cubic-bezier(0.22, 1, 0.36, 1) both
+    tezex-workspace-enter-left;
+}
+
+::view-transition-old(tezex-trading-workspace),
+::view-transition-new(tezex-trading-workspace) {
+  mix-blend-mode: normal;
+}
+
 @media (prefers-reduced-motion: reduce) {
   body,
   button,
@@ -100,6 +160,11 @@ textarea {
   select,
   textarea {
     transition: none;
+  }
+
+  ::view-transition-old(tezex-trading-workspace),
+  ::view-transition-new(tezex-trading-workspace) {
+    animation: none;
   }
 }
 

--- a/V2/tezex/src/pages/Home/index.test.tsx
+++ b/V2/tezex/src/pages/Home/index.test.tsx
@@ -98,12 +98,22 @@ const renderHome = () =>
     </MemoryRouter>
   );
 
+const originalStartViewTransition = document.startViewTransition;
+
 beforeEach(() => {
   window.matchMedia = jest.fn().mockReturnValue({ matches: false });
+  Object.defineProperty(document, "startViewTransition", {
+    configurable: true,
+    value: undefined,
+  });
 });
 
 afterEach(() => {
-  delete (HTMLElement.prototype as Partial<HTMLElement>).animate;
+  Object.defineProperty(document, "startViewTransition", {
+    configurable: true,
+    value: originalStartViewTransition,
+  });
+  delete document.documentElement.dataset.modeTransition;
 });
 
 test("changes modes immediately when browser animation is unavailable", () => {
@@ -115,41 +125,32 @@ test("changes modes immediately when browser animation is unavailable", () => {
   expect(screen.getByText("Liquidity workspace")).toBeInTheDocument();
 });
 
-test("slides the current workspace out before the next workspace enters", async () => {
-  let finishExit: () => void = () => undefined;
-  const exitFinished = new Promise<void>((resolve) => {
-    finishExit = resolve;
+test("runs a full-workspace view transition when modes change", async () => {
+  let finishTransition: () => void = () => undefined;
+  const finished = new Promise<void>((resolve) => {
+    finishTransition = resolve;
   });
-  const animate = jest
-    .fn()
-    .mockReturnValueOnce({ finished: exitFinished, cancel: jest.fn() })
-    .mockReturnValue({ finished: Promise.resolve(), cancel: jest.fn() });
-  HTMLElement.prototype.animate = animate;
+  const startViewTransition = jest.fn((update: () => void) => {
+    update();
+    return { finished };
+  });
+  Object.defineProperty(document, "startViewTransition", {
+    configurable: true,
+    value: startViewTransition,
+  });
 
   renderHome();
   fireEvent.click(screen.getByRole("button", { name: "Liquidity" }));
 
-  expect(screen.getByTestId("location")).toHaveTextContent("/home/swap");
-  expect(animate).toHaveBeenNthCalledWith(
-    1,
-    [
-      { opacity: 1, transform: "translate3d(0, 0, 0)" },
-      { opacity: 0.35, transform: "translate3d(-18px, 0, 0)" },
-    ],
-    { duration: 140, easing: "cubic-bezier(.4,0,.7,.2)" }
-  );
+  expect(startViewTransition).toHaveBeenCalledTimes(1);
+  expect(screen.getByTestId("location")).toHaveTextContent("/home/add");
+  expect(document.documentElement.dataset.modeTransition).toBe("forward");
+  expect(screen.getByRole("button", { name: "Swap" })).toBeDisabled();
 
-  await act(async () => finishExit());
+  await act(async () => finishTransition());
 
   await waitFor(() =>
-    expect(screen.getByTestId("location")).toHaveTextContent("/home/add")
+    expect(document.documentElement.dataset.modeTransition).toBeUndefined()
   );
-  expect(animate).toHaveBeenNthCalledWith(
-    2,
-    [
-      { opacity: 0.35, transform: "translate3d(18px, 0, 0)" },
-      { opacity: 1, transform: "translate3d(0, 0, 0)" },
-    ],
-    { duration: 220, easing: "cubic-bezier(.22,.8,.24,1)" }
-  );
+  expect(screen.getByRole("button", { name: "Swap" })).toBeEnabled();
 });

--- a/V2/tezex/src/pages/Home/index.tsx
+++ b/V2/tezex/src/pages/Home/index.tsx
@@ -1,5 +1,6 @@
-import React, { FC, useCallback, useEffect, useRef, useState } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
+import React, { FC, useCallback, useState } from "react";
+import { flushSync } from "react-dom";
+import { useNavigate } from "react-router-dom";
 
 import { NavHome } from "../../components/nav";
 import { Swap } from "../../components/swap";
@@ -20,10 +21,6 @@ import {
 type HomePaths = "swap" | "add" | "remove";
 type ModeTransitionDirection = "forward" | "backward";
 
-interface ModeTransitionState {
-  modeTransitionDirection?: ModeTransitionDirection;
-}
-
 const prefersReducedMotion = () =>
   window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
 
@@ -36,53 +33,7 @@ export const Home: FC<IHome> = (props) => {
   const { orientation } = useMobileOrientation();
   const styles = useStyles(style);
   const navigate = useNavigate();
-  const location = useLocation();
-  const panelRef = useRef<HTMLDivElement | null>(null);
-  const exitAnimationRef = useRef<Animation | null>(null);
-  const navigationSequenceRef = useRef(0);
   const [isTransitioning, setIsTransitioning] = useState(false);
-  const transitionDirection = (location.state as ModeTransitionState | null)
-    ?.modeTransitionDirection;
-
-  useEffect(() => {
-    const panel = panelRef.current;
-
-    if (!transitionDirection || !panel?.animate || prefersReducedMotion()) {
-      setIsTransitioning(false);
-      return;
-    }
-
-    setIsTransitioning(true);
-    let isCurrentAnimation = true;
-    const offset = transitionDirection === "forward" ? "18px" : "-18px";
-    const animation = panel.animate(
-      [
-        { opacity: 0.35, transform: `translate3d(${offset}, 0, 0)` },
-        { opacity: 1, transform: "translate3d(0, 0, 0)" },
-      ],
-      {
-        duration: 220,
-        easing: "cubic-bezier(.22,.8,.24,1)",
-      }
-    );
-
-    void animation.finished
-      .catch(() => undefined)
-      .then(() => isCurrentAnimation && setIsTransitioning(false));
-
-    return () => {
-      isCurrentAnimation = false;
-      animation.cancel();
-    };
-  }, [location.key, transitionDirection]);
-
-  useEffect(
-    () => () => {
-      navigationSequenceRef.current += 1;
-      exitAnimationRef.current?.cancel();
-    },
-    []
-  );
 
   const navigateBetweenModes = useCallback(
     (href: string) => {
@@ -95,38 +46,33 @@ export const Home: FC<IHome> = (props) => {
       const direction: ModeTransitionDirection = targetIsLiquidity
         ? "forward"
         : "backward";
-      const panel = panelRef.current;
-      const completeNavigation = () =>
-        navigate(href, { state: { modeTransitionDirection: direction } });
+      const completeNavigation = () => navigate(href);
+      const startViewTransition = document.startViewTransition?.bind(document);
 
-      if (!panel?.animate || prefersReducedMotion()) {
+      if (!startViewTransition || prefersReducedMotion()) {
         completeNavigation();
         return;
       }
 
-      const sequence = navigationSequenceRef.current + 1;
-      navigationSequenceRef.current = sequence;
       setIsTransitioning(true);
+      document.documentElement.dataset.modeTransition = direction;
 
-      const offset = direction === "forward" ? "-18px" : "18px";
-      const animation = panel.animate(
-        [
-          { opacity: 1, transform: "translate3d(0, 0, 0)" },
-          { opacity: 0.35, transform: `translate3d(${offset}, 0, 0)` },
-        ],
-        {
-          duration: 140,
-          easing: "cubic-bezier(.4,0,.7,.2)",
-        }
-      );
-      exitAnimationRef.current = animation;
-
-      void animation.finished
-        .catch(() => undefined)
-        .then(() => {
-          if (navigationSequenceRef.current !== sequence) return;
-          completeNavigation();
+      try {
+        const transition = startViewTransition(() => {
+          flushSync(completeNavigation);
         });
+
+        void transition.finished
+          .catch(() => undefined)
+          .then(() => {
+            delete document.documentElement.dataset.modeTransition;
+            setIsTransitioning(false);
+          });
+      } catch {
+        delete document.documentElement.dataset.modeTransition;
+        setIsTransitioning(false);
+        completeNavigation();
+      }
     },
     [isTransitioning, navigate, props.path]
   );
@@ -164,9 +110,7 @@ export const Home: FC<IHome> = (props) => {
         </Grid2>
       </BrowserView>
       <Grid2 sx={styles.contentViewport}>
-        <Box ref={panelRef} sx={styles.modePanel}>
-          {Comp}
-        </Box>
+        <Box sx={styles.modePanel}>{Comp}</Box>
       </Grid2>
     </Grid2>
   );

--- a/V2/tezex/src/pages/Home/style.js
+++ b/V2/tezex/src/pages/Home/style.js
@@ -33,9 +33,11 @@ const style = (theme, scale = 1) => {
     },
     contentViewport: {
       width: "100%",
+      position: "relative",
     },
     modePanel: {
       width: "100%",
+      viewTransitionName: "tezex-trading-workspace",
     },
   };
 };


### PR DESCRIPTION
## What changed
- Moves the entire Swap or Liquidity workspace horizontally as one panel
- Keeps the mode control anchored while the outgoing and incoming panels cross the viewport
- Reverses the direction when returning to Swap
- Keeps amount controls mounted while changing pools so only pair-specific content updates
- Uses a reduced-motion and unsupported-browser fallback
- Keeps only the active transaction component live during the mode animation

## Validation
- Production dependency audit completed with no high-severity gate failures
- TypeScript check passed
- 33 tests passed
- Production build passed
- Mobile and desktop transitions verified in Chromium
- Mobile transition verified in WebKit with no console errors
- Pool switching verified in both Swap and Liquidity without blanking the amount controls