### PR TITLE
Make mobile workspace transitions continuous

### DIFF
--- a/V2/tezex/src/index.css
+++ b/V2/tezex/src/index.css
@@ -93,66 +93,6 @@ textarea {
     color 180ms ease;
 }
 
-@keyframes tezex-workspace-exit-left {
-  to {
-    transform: translateX(-104%);
-  }
-}
-
-@keyframes tezex-workspace-enter-right {
-  from {
-    transform: translateX(104%);
-  }
-}
-
-@keyframes tezex-workspace-exit-right {
-  to {
-    transform: translateX(104%);
-  }
-}
-
-@keyframes tezex-workspace-enter-left {
-  from {
-    transform: translateX(-104%);
-  }
-}
-
-html[data-mode-transition] {
-  view-transition-name: none;
-}
-
-html[data-mode-transition="forward"]::view-transition-old(
-    tezex-trading-workspace
-  ) {
-  animation: 360ms cubic-bezier(0.22, 1, 0.36, 1) both tezex-workspace-exit-left;
-}
-
-html[data-mode-transition="forward"]::view-transition-new(
-    tezex-trading-workspace
-  ) {
-  animation: 360ms cubic-bezier(0.22, 1, 0.36, 1) both
-    tezex-workspace-enter-right;
-}
-
-html[data-mode-transition="backward"]::view-transition-old(
-    tezex-trading-workspace
-  ) {
-  animation: 360ms cubic-bezier(0.22, 1, 0.36, 1) both
-    tezex-workspace-exit-right;
-}
-
-html[data-mode-transition="backward"]::view-transition-new(
-    tezex-trading-workspace
-  ) {
-  animation: 360ms cubic-bezier(0.22, 1, 0.36, 1) both
-    tezex-workspace-enter-left;
-}
-
-::view-transition-old(tezex-trading-workspace),
-::view-transition-new(tezex-trading-workspace) {
-  mix-blend-mode: normal;
-}
-
 @media (prefers-reduced-motion: reduce) {
   body,
   button,
@@ -160,11 +100,6 @@ html[data-mode-transition="backward"]::view-transition-new(
   select,
   textarea {
     transition: none;
-  }
-
-  ::view-transition-old(tezex-trading-workspace),
-  ::view-transition-new(tezex-trading-workspace) {
-    animation: none;
   }
 }
 

--- a/V2/tezex/src/pages/Home/index.test.tsx
+++ b/V2/tezex/src/pages/Home/index.test.tsx
@@ -98,22 +98,17 @@ const renderHome = () =>
     </MemoryRouter>
   );
 
-const originalStartViewTransition = document.startViewTransition;
+const originalAnimate = HTMLElement.prototype.animate;
 
 beforeEach(() => {
   window.matchMedia = jest.fn().mockReturnValue({ matches: false });
-  Object.defineProperty(document, "startViewTransition", {
-    configurable: true,
-    value: undefined,
-  });
+  delete (HTMLElement.prototype as Partial<HTMLElement>).animate;
 });
 
 afterEach(() => {
-  Object.defineProperty(document, "startViewTransition", {
-    configurable: true,
-    value: originalStartViewTransition,
-  });
+  HTMLElement.prototype.animate = originalAnimate;
   delete document.documentElement.dataset.modeTransition;
+  document.documentElement.style.overflowX = "";
 });
 
 test("changes modes immediately when browser animation is unavailable", () => {
@@ -125,32 +120,58 @@ test("changes modes immediately when browser animation is unavailable", () => {
   expect(screen.getByText("Liquidity workspace")).toBeInTheDocument();
 });
 
-test("runs a full-workspace view transition when modes change", async () => {
+test("moves outgoing and incoming workspaces on one continuous track", async () => {
   let finishTransition: () => void = () => undefined;
   const finished = new Promise<void>((resolve) => {
     finishTransition = resolve;
   });
-  const startViewTransition = jest.fn((update: () => void) => {
-    update();
-    return { finished };
-  });
-  Object.defineProperty(document, "startViewTransition", {
-    configurable: true,
-    value: startViewTransition,
-  });
+  const cancel = jest.fn();
+  const animate = jest.fn(() => ({ finished, cancel } as unknown as Animation));
+  HTMLElement.prototype.animate = animate;
 
   renderHome();
   fireEvent.click(screen.getByRole("button", { name: "Liquidity" }));
 
-  expect(startViewTransition).toHaveBeenCalledTimes(1);
-  expect(screen.getByTestId("location")).toHaveTextContent("/home/add");
+  expect(screen.getByTestId("location")).toHaveTextContent("/home/swap");
+  expect(screen.getByText("Liquidity workspace")).toBeInTheDocument();
+  expect(
+    document.querySelector('[data-workspace-snapshot="true"]')
+  ).toHaveTextContent("Swap workspace");
   expect(document.documentElement.dataset.modeTransition).toBe("forward");
   expect(screen.getByRole("button", { name: "Swap" })).toBeDisabled();
+  expect(animate).toHaveBeenNthCalledWith(
+    1,
+    [
+      { transform: "translate3d(0, 0, 0)" },
+      { transform: "translate3d(-100%, 0, 0)" },
+    ],
+    {
+      duration: 420,
+      easing: "cubic-bezier(0.65, 0, 0.35, 1)",
+      fill: "both",
+    }
+  );
+  expect(animate).toHaveBeenNthCalledWith(
+    2,
+    [
+      { transform: "translate3d(100%, 0, 0)" },
+      { transform: "translate3d(0, 0, 0)" },
+    ],
+    {
+      duration: 420,
+      easing: "cubic-bezier(0.65, 0, 0.35, 1)",
+      fill: "both",
+    }
+  );
 
   await act(async () => finishTransition());
 
   await waitFor(() =>
     expect(document.documentElement.dataset.modeTransition).toBeUndefined()
   );
+  expect(screen.getByTestId("location")).toHaveTextContent("/home/add");
+  expect(
+    document.querySelector('[data-workspace-snapshot="true"]')
+  ).not.toBeInTheDocument();
   expect(screen.getByRole("button", { name: "Swap" })).toBeEnabled();
 });

--- a/V2/tezex/src/pages/Home/index.tsx
+++ b/V2/tezex/src/pages/Home/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useState } from "react";
+import React, { FC, useCallback, useEffect, useRef, useState } from "react";
 import { flushSync } from "react-dom";
 import { useNavigate } from "react-router-dom";
 
@@ -21,10 +21,35 @@ import {
 type HomePaths = "swap" | "add" | "remove";
 type ModeTransitionDirection = "forward" | "backward";
 
+const MODE_TRANSITION_DURATION = 420;
+const MODE_TRANSITION_EASING = "cubic-bezier(0.65, 0, 0.35, 1)";
+
 const prefersReducedMotion = () =>
   window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
 
 const isLiquidityRoute = (path: HomePaths | string) => path !== "swap";
+
+const createWorkspaceSnapshot = (panel: HTMLDivElement) => {
+  const snapshot = panel.cloneNode(true) as HTMLDivElement;
+
+  snapshot.removeAttribute("data-testid");
+  snapshot.querySelectorAll<HTMLElement>("[id]").forEach((element) => {
+    element.removeAttribute("id");
+  });
+  snapshot.dataset.workspaceSnapshot = "true";
+  snapshot.setAttribute("aria-hidden", "true");
+  snapshot.inert = true;
+  Object.assign(snapshot.style, {
+    position: "absolute",
+    inset: "0 auto auto 0",
+    width: "100%",
+    pointerEvents: "none",
+    zIndex: "2",
+    willChange: "transform",
+  });
+
+  return snapshot;
+};
 
 export interface IHome {
   path: HomePaths;
@@ -34,11 +59,20 @@ export const Home: FC<IHome> = (props) => {
   const styles = useStyles(style);
   const navigate = useNavigate();
   const [isTransitioning, setIsTransitioning] = useState(false);
+  const [displayedPath, setDisplayedPath] = useState<HomePaths>(props.path);
+  const viewportRef = useRef<HTMLDivElement | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const cleanupTransitionRef = useRef<() => void>(() => undefined);
+
+  useEffect(() => () => cleanupTransitionRef.current(), []);
+  useEffect(() => {
+    if (!isTransitioning) setDisplayedPath(props.path);
+  }, [isTransitioning, props.path]);
 
   const navigateBetweenModes = useCallback(
     (href: string) => {
       const targetPath = href.split("/").pop() ?? "swap";
-      const currentIsLiquidity = isLiquidityRoute(props.path);
+      const currentIsLiquidity = isLiquidityRoute(displayedPath);
       const targetIsLiquidity = isLiquidityRoute(targetPath);
 
       if (currentIsLiquidity === targetIsLiquidity || isTransitioning) return;
@@ -47,38 +81,119 @@ export const Home: FC<IHome> = (props) => {
         ? "forward"
         : "backward";
       const completeNavigation = () => navigate(href);
-      const startViewTransition = document.startViewTransition?.bind(document);
+      const viewport = viewportRef.current;
+      const outgoingPanel = panelRef.current;
 
-      if (!startViewTransition || prefersReducedMotion()) {
+      if (!viewport || !outgoingPanel?.animate || prefersReducedMotion()) {
         completeNavigation();
         return;
       }
 
-      setIsTransitioning(true);
-      document.documentElement.dataset.modeTransition = direction;
+      const outgoingSnapshot = createWorkspaceSnapshot(outgoingPanel);
+      const outgoingHeight = outgoingPanel.getBoundingClientRect().height;
+      const previousOverflowX = document.documentElement.style.overflowX;
+      const animations: Animation[] = [];
+      let incomingPanel: HTMLDivElement | null = null;
+      let cleanedUp = false;
+      let shouldFinishNavigation = true;
 
-      try {
-        const transition = startViewTransition(() => {
-          flushSync(completeNavigation);
-        });
+      const cleanup = () => {
+        if (cleanedUp) return;
+        cleanedUp = true;
 
-        void transition.finished
-          .catch(() => undefined)
-          .then(() => {
-            delete document.documentElement.dataset.modeTransition;
-            setIsTransitioning(false);
-          });
-      } catch {
+        animations.forEach((animation) => animation.cancel());
+        outgoingSnapshot.remove();
+        viewport.style.height = "";
+        incomingPanel?.style.removeProperty("transform");
+        incomingPanel?.style.removeProperty("will-change");
+        document.documentElement.style.overflowX = previousOverflowX;
         delete document.documentElement.dataset.modeTransition;
         setIsTransitioning(false);
+        cleanupTransitionRef.current = () => undefined;
+      };
+
+      cleanupTransitionRef.current = () => {
+        shouldFinishNavigation = false;
+        cleanup();
+      };
+      document.documentElement.dataset.modeTransition = direction;
+      document.documentElement.style.overflowX = "hidden";
+      viewport.appendChild(outgoingSnapshot);
+      if (outgoingHeight > 0) viewport.style.height = `${outgoingHeight}px`;
+
+      try {
+        flushSync(() => {
+          setIsTransitioning(true);
+          setDisplayedPath(targetPath as HomePaths);
+        });
+        incomingPanel = panelRef.current;
+        if (!incomingPanel) throw new Error("Trading workspace is unavailable");
+
+        const incomingHeight = incomingPanel.getBoundingClientRect().height;
+        const incomingOffset = direction === "forward" ? "100%" : "-100%";
+        const outgoingOffset = direction === "forward" ? "-100%" : "100%";
+        const options: KeyframeAnimationOptions = {
+          duration: MODE_TRANSITION_DURATION,
+          easing: MODE_TRANSITION_EASING,
+          fill: "both",
+        };
+
+        incomingPanel.style.transform = `translate3d(${incomingOffset}, 0, 0)`;
+        incomingPanel.style.willChange = "transform";
+
+        animations.push(
+          outgoingSnapshot.animate(
+            [
+              { transform: "translate3d(0, 0, 0)" },
+              { transform: `translate3d(${outgoingOffset}, 0, 0)` },
+            ],
+            options
+          ),
+          incomingPanel.animate(
+            [
+              { transform: `translate3d(${incomingOffset}, 0, 0)` },
+              { transform: "translate3d(0, 0, 0)" },
+            ],
+            options
+          )
+        );
+
+        if (
+          outgoingHeight > 0 &&
+          incomingHeight > 0 &&
+          Math.abs(outgoingHeight - incomingHeight) > 1
+        ) {
+          animations.push(
+            viewport.animate(
+              [
+                { height: `${outgoingHeight}px` },
+                { height: `${incomingHeight}px` },
+              ],
+              options
+            )
+          );
+        }
+
+        void Promise.all(
+          animations.map((animation) =>
+            animation.finished.catch(() => undefined)
+          )
+        ).then(() => {
+          if (!shouldFinishNavigation) return;
+          flushSync(completeNavigation);
+          cleanup();
+        });
+      } catch {
+        shouldFinishNavigation = false;
         completeNavigation();
+        cleanup();
       }
     },
-    [isTransitioning, navigate, props.path]
+    [displayedPath, isTransitioning, navigate]
   );
 
   const Comp = (() => {
-    switch (props.path) {
+    switch (displayedPath) {
       case "add":
         return <AddLiquidity orientation={orientation} />;
       case "remove":
@@ -109,8 +224,14 @@ export const Home: FC<IHome> = (props) => {
           />
         </Grid2>
       </BrowserView>
-      <Grid2 sx={styles.contentViewport}>
-        <Box sx={styles.modePanel}>{Comp}</Box>
+      <Grid2 ref={viewportRef} sx={styles.contentViewport}>
+        <Box
+          ref={panelRef}
+          data-testid="trading-workspace"
+          sx={styles.modePanel}
+        >
+          {Comp}
+        </Box>
       </Grid2>
     </Grid2>
   );

--- a/V2/tezex/src/pages/Home/style.js
+++ b/V2/tezex/src/pages/Home/style.js
@@ -34,10 +34,12 @@ const style = (theme, scale = 1) => {
     contentViewport: {
       width: "100%",
       position: "relative",
+      isolation: "isolate",
     },
     modePanel: {
       width: "100%",
-      viewTransitionName: "tezex-trading-workspace",
+      position: "relative",
+      zIndex: 1,
     },
   };
 };


### PR DESCRIPTION
## What changed
- replaces the browser-native page snapshot transition with a deterministic workspace carousel
- mounts the destination workspace before motion begins so mobile never shows an empty intermediate frame
- moves outgoing and incoming workspaces together on one synchronized track in both directions
- interpolates workspace height while keeping the Swap/Liquidity control fixed
- keeps only the destination transaction controls live; the outgoing view is inert and visual-only
- preserves immediate navigation when reduced motion is enabled or animation support is unavailable

## Verification
- production dependency audit gate passes
- TypeScript type-check passes
- 33 tests pass
- optimized production build succeeds