### PR TITLE
Add automatic RPC failover

### DIFF
--- a/V2/tezex/package-lock.json
+++ b/V2/tezex/package-lock.json
@@ -16,6 +16,8 @@
         "@mui/icons-material": "^5.11.0",
         "@mui/material": "^5.11.0",
         "@mui/system": "^5.11.4",
+        "@taquito/http-utils": "^24.3.0",
+        "@taquito/rpc": "^24.3.0",
         "@taquito/taquito": "^24.3.0",
         "async-mutex": "^0.4.0",
         "bignumber.js": "^9.1.0",

--- a/V2/tezex/package.json
+++ b/V2/tezex/package.json
@@ -12,6 +12,8 @@
     "@mui/icons-material": "^5.11.0",
     "@mui/material": "^5.11.0",
     "@mui/system": "^5.11.4",
+    "@taquito/http-utils": "^24.3.0",
+    "@taquito/rpc": "^24.3.0",
     "@taquito/taquito": "^24.3.0",
     "async-mutex": "^0.4.0",
     "bignumber.js": "^9.1.0",

--- a/V2/tezex/src/config/network/mainnet.json
+++ b/V2/tezex/src/config/network/mainnet.json
@@ -1,5 +1,7 @@
 {
   "tezosServer": "https://rpc.tzkt.io/mainnet",
+  "rpcFallbacks": ["https://tezos-mainnet.octez.io"],
+  "chainId": "NetXdQprcVkpaWU",
   "pools": [
     {
       "id": "xtz-tzbtc-sirius",

--- a/V2/tezex/src/config/network/previewnet.json
+++ b/V2/tezex/src/config/network/previewnet.json
@@ -1,5 +1,7 @@
 {
   "tezosServer": "https://michelson.previewnet.tezosx.nomadic-labs.com",
+  "rpcFallbacks": [],
+  "chainId": "NetXY2oPPzkxUW1",
   "tradingAvailability": {
     "enabled": false,
     "title": "Previewnet contracts require redeployment",

--- a/V2/tezex/src/config/network/shadownet.json
+++ b/V2/tezex/src/config/network/shadownet.json
@@ -1,5 +1,10 @@
 {
   "tezosServer": "https://rpc.shadownet.teztnets.com",
+  "rpcFallbacks": [
+    "https://tezos-shadownet.octez.io",
+    "https://rpc.tzkt.io/shadownet"
+  ],
+  "chainId": "NetXsqzbfFenSTS",
   "pools": [
     {
       "id": "xtz-tzbtc-sirius",

--- a/V2/tezex/src/contexts/network.tsx
+++ b/V2/tezex/src/contexts/network.tsx
@@ -8,6 +8,7 @@ import { MichelCodecPacker, TezosToolkit } from "@taquito/taquito";
 import { IPoolAdapter, PoolConfig } from "../types/pools";
 import { PoolRegistry } from "../adapters/poolRegistry";
 import { PoolDataCache } from "../utils/poolDataCache";
+import { createRpcToolkit } from "../functions/rpcFailover";
 import React from "react";
 export interface Address {
   name: string;
@@ -17,6 +18,8 @@ export type Assets = Asset[];
 
 export interface NetworkInfo {
   tezosServer: string;
+  rpcFallbacks: string[];
+  chainId: string;
   pools: PoolConfig[];
   assets: Assets;
   tradingAvailability?: {
@@ -72,7 +75,7 @@ export const NetworkProvider: React.FC<{ children: React.ReactNode }> = ({
     mainnet as NetworkInfo
   );
   const [toolkit, setToolkit] = useState<TezosToolkit>(
-    new TezosToolkit((mainnet as NetworkInfo).tezosServer)
+    createRpcToolkit(mainnet as NetworkInfo)
   );
   const [selectedPool, setSelectedPoolState] = useState<PoolConfig | null>(
     initialPool
@@ -99,7 +102,7 @@ export const NetworkProvider: React.FC<{ children: React.ReactNode }> = ({
     );
 
     // Create new toolkit for new network
-    const newToolkit = new TezosToolkit(newNetworkInfo.tezosServer);
+    const newToolkit = createRpcToolkit(newNetworkInfo);
     // Required, because TezLink Shadownet rpc does not support pack_data yet.
     newToolkit.setPackerProvider(new MichelCodecPacker());
 

--- a/V2/tezex/src/functions/rpcFailover.test.ts
+++ b/V2/tezex/src/functions/rpcFailover.test.ts
@@ -1,0 +1,167 @@
+import {
+  HttpRequestOptions,
+  HttpResponseError,
+  HttpTimeoutError,
+} from "@taquito/http-utils";
+import {
+  FailoverHttpBackend,
+  isRpcAvailabilityError,
+  isSafeToFailOver,
+  RpcFailoverOptions,
+} from "./rpcFailover";
+
+type RequestHandler = (
+  options: HttpRequestOptions,
+  data?: object | string
+) => Promise<unknown>;
+
+class TestFailoverBackend extends FailoverHttpBackend {
+  readonly requests: HttpRequestOptions[] = [];
+
+  constructor(
+    options: RpcFailoverOptions,
+    private readonly handler: RequestHandler
+  ) {
+    super(options);
+  }
+
+  protected requestEndpoint<T>(
+    options: HttpRequestOptions,
+    data?: object | string
+  ): Promise<T> {
+    this.requests.push(options);
+    return this.handler(options, data) as Promise<T>;
+  }
+}
+
+const primary = "https://primary.example/rpc";
+const fallback = "https://fallback.example";
+const chainId = "NetXdQprcVkpaWU";
+const readRequest: HttpRequestOptions = {
+  url: `${primary}/chains/main/blocks/head/header`,
+  method: "GET",
+};
+
+describe("RPC failover", () => {
+  it("keeps using the primary endpoint while it is healthy", async () => {
+    const backend = new TestFailoverBackend(
+      {
+        primaryUrl: primary,
+        fallbackUrls: [fallback],
+        expectedChainId: chainId,
+      },
+      async () => ({ level: 1 })
+    );
+
+    await expect(backend.createRequest(readRequest)).resolves.toEqual({
+      level: 1,
+    });
+    expect(backend.requests.map(({ url }) => url)).toEqual([readRequest.url]);
+    expect(backend.getActiveRpcUrl()).toBe(primary);
+  });
+
+  it("verifies the chain before switching and then stays on the fallback", async () => {
+    const onEndpointChange = jest.fn();
+    const backend = new TestFailoverBackend(
+      {
+        primaryUrl: primary,
+        fallbackUrls: [fallback],
+        expectedChainId: chainId,
+        onEndpointChange,
+      },
+      async ({ url }) => {
+        if (url.startsWith(primary)) throw new HttpTimeoutError(1000, url);
+        if (url.endsWith("/chains/main/chain_id")) return chainId;
+        return { level: 2 };
+      }
+    );
+
+    await expect(backend.createRequest(readRequest)).resolves.toEqual({
+      level: 2,
+    });
+    await expect(backend.createRequest(readRequest)).resolves.toEqual({
+      level: 2,
+    });
+    expect(backend.getActiveRpcUrl()).toBe(fallback);
+    expect(onEndpointChange).toHaveBeenCalledTimes(1);
+    expect(backend.requests.map(({ url }) => url)).toEqual([
+      readRequest.url,
+      `${fallback}/chains/main/chain_id`,
+      `${fallback}/chains/main/blocks/head/header`,
+      `${fallback}/chains/main/blocks/head/header`,
+    ]);
+  });
+
+  it("refuses a fallback connected to the wrong chain", async () => {
+    const backend = new TestFailoverBackend(
+      {
+        primaryUrl: primary,
+        fallbackUrls: [fallback],
+        expectedChainId: chainId,
+      },
+      async ({ url }) => {
+        if (url.startsWith(primary)) throw new HttpTimeoutError(1000, url);
+        return "NetWrongChain";
+      }
+    );
+
+    await expect(backend.createRequest(readRequest)).rejects.toBeInstanceOf(
+      HttpTimeoutError
+    );
+    expect(backend.getActiveRpcUrl()).toBe(primary);
+  });
+
+  it("does not fail over operation injection or logical RPC errors", async () => {
+    const injectionRequest: HttpRequestOptions = {
+      url: `${primary}/injection/operation`,
+      method: "POST",
+    };
+    const logicalError = new HttpResponseError(
+      "operation rejected",
+      500,
+      "Internal Server Error",
+      "contract error",
+      readRequest.url
+    );
+
+    expect(isSafeToFailOver(injectionRequest)).toBe(false);
+    expect(isRpcAvailabilityError(logicalError)).toBe(false);
+  });
+
+  it("keeps a responsive fallback active when it returns a logical error", async () => {
+    const logicalError = new HttpResponseError(
+      "operation rejected",
+      500,
+      "Internal Server Error",
+      "contract error",
+      readRequest.url
+    );
+    const backend = new TestFailoverBackend(
+      {
+        primaryUrl: primary,
+        fallbackUrls: [fallback],
+        expectedChainId: chainId,
+      },
+      async ({ url }) => {
+        if (url.startsWith(primary)) throw new HttpTimeoutError(1000, url);
+        if (url.endsWith("/chains/main/chain_id")) return chainId;
+        throw logicalError;
+      }
+    );
+
+    await expect(backend.createRequest(readRequest)).rejects.toBe(logicalError);
+    expect(backend.getActiveRpcUrl()).toBe(fallback);
+  });
+
+  it("allows failover for simulations but not arbitrary POST requests", () => {
+    expect(
+      isSafeToFailOver({
+        url: `${primary}/chains/main/blocks/head/helpers/scripts/run_operation`,
+        method: "POST",
+      })
+    ).toBe(true);
+    expect(
+      isSafeToFailOver({ url: `${primary}/admin/change`, method: "POST" })
+    ).toBe(false);
+  });
+});

--- a/V2/tezex/src/functions/rpcFailover.ts
+++ b/V2/tezex/src/functions/rpcFailover.ts
@@ -1,0 +1,199 @@
+import {
+  HttpBackend,
+  HttpRequestFailed,
+  HttpRequestOptions,
+  HttpResponseError,
+  HttpTimeoutError,
+} from "@taquito/http-utils";
+import { RpcClient } from "@taquito/rpc";
+import { MichelCodecPacker, TezosToolkit } from "@taquito/taquito";
+import type { NetworkInfo } from "../contexts/network";
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
+const DEFAULT_HEALTH_CHECK_TIMEOUT_MS = 4_000;
+const RETRIABLE_STATUS_CODES = new Set([408, 429, 502, 503, 504]);
+
+export interface RpcFailoverOptions {
+  primaryUrl: string;
+  fallbackUrls?: string[];
+  expectedChainId: string;
+  requestTimeoutMs?: number;
+  healthCheckTimeoutMs?: number;
+  onEndpointChange?: (rpcUrl: string) => void;
+}
+
+function normalizeRpcUrl(url: string): string {
+  return url.replace(/\/+$/, "");
+}
+
+export function isRpcAvailabilityError(error: unknown): boolean {
+  if (error instanceof HttpRequestFailed || error instanceof HttpTimeoutError) {
+    return true;
+  }
+
+  return (
+    error instanceof HttpResponseError &&
+    RETRIABLE_STATUS_CODES.has(Number(error.status))
+  );
+}
+
+export function isSafeToFailOver(options: HttpRequestOptions): boolean {
+  const method = options.method ?? "GET";
+  if (method === "GET") return true;
+  if (method !== "POST") return false;
+
+  let path = options.url;
+  try {
+    path = new URL(options.url).pathname;
+  } catch {
+    // The RPC client normally supplies an absolute URL. Keeping the original
+    // string still lets the suffix checks below behave safely in tests.
+  }
+
+  return [
+    "/helpers/forge/operations",
+    "/helpers/preapply/operations",
+    "/helpers/scripts/simulate_operation",
+    "/helpers/scripts/run_operation",
+    "/helpers/scripts/run_code",
+    "/helpers/scripts/run_view",
+    "/helpers/scripts/run_script_view",
+    "/helpers/scripts/pack_data",
+  ].some((suffix) => path.endsWith(suffix));
+}
+
+export class FailoverHttpBackend extends HttpBackend {
+  private readonly endpoints: string[];
+  private readonly expectedChainId: string;
+  private readonly healthCheckTimeoutMs: number;
+  private readonly onEndpointChange?: (rpcUrl: string) => void;
+  private readonly validatedEndpoints = new Set<string>();
+  private activeEndpointIndex = 0;
+
+  constructor(options: RpcFailoverOptions) {
+    super(options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS);
+    this.endpoints = Array.from(
+      new Set(
+        [options.primaryUrl, ...(options.fallbackUrls ?? [])].map(
+          normalizeRpcUrl
+        )
+      )
+    );
+    this.expectedChainId = options.expectedChainId;
+    this.healthCheckTimeoutMs =
+      options.healthCheckTimeoutMs ?? DEFAULT_HEALTH_CHECK_TIMEOUT_MS;
+    this.onEndpointChange = options.onEndpointChange;
+    this.validatedEndpoints.add(this.endpoints[0]);
+  }
+
+  getActiveRpcUrl(): string {
+    return this.endpoints[this.activeEndpointIndex];
+  }
+
+  protected requestEndpoint<T>(
+    options: HttpRequestOptions,
+    data?: object | string
+  ): Promise<T> {
+    return super.createRequest<T>(options, data);
+  }
+
+  private rewriteUrl(url: string, endpoint: string): string {
+    const primaryUrl = this.endpoints[0];
+    if (url === primaryUrl) return endpoint;
+    if (url.startsWith(`${primaryUrl}/`)) {
+      return `${endpoint}${url.slice(primaryUrl.length)}`;
+    }
+    return url;
+  }
+
+  private async endpointMatchesNetwork(endpoint: string): Promise<boolean> {
+    if (this.validatedEndpoints.has(endpoint)) return true;
+
+    try {
+      const chainId = await this.requestEndpoint<string>({
+        url: `${endpoint}/chains/main/chain_id`,
+        method: "GET",
+        timeout: this.healthCheckTimeoutMs,
+      });
+      if (chainId !== this.expectedChainId) {
+        console.error(
+          `[rpc] Refusing ${endpoint}: expected ${this.expectedChainId}, received ${chainId}`
+        );
+        return false;
+      }
+      this.validatedEndpoints.add(endpoint);
+      return true;
+    } catch (error) {
+      console.warn(`[rpc] Health check failed for ${endpoint}`, error);
+      return false;
+    }
+  }
+
+  private activateEndpoint(index: number): void {
+    if (index === this.activeEndpointIndex) return;
+    this.activeEndpointIndex = index;
+    const endpoint = this.endpoints[index];
+    this.onEndpointChange?.(endpoint);
+    console.warn(`[rpc] Switched to fallback endpoint ${endpoint}`);
+  }
+
+  async createRequest<T>(
+    options: HttpRequestOptions,
+    data?: object | string
+  ): Promise<T> {
+    const activeIndex = this.activeEndpointIndex;
+    const activeEndpoint = this.endpoints[activeIndex];
+
+    try {
+      return await this.requestEndpoint<T>(
+        { ...options, url: this.rewriteUrl(options.url, activeEndpoint) },
+        data
+      );
+    } catch (initialError) {
+      if (
+        this.endpoints.length === 1 ||
+        !isSafeToFailOver(options) ||
+        !isRpcAvailabilityError(initialError)
+      ) {
+        throw initialError;
+      }
+
+      for (let offset = 1; offset < this.endpoints.length; offset += 1) {
+        const candidateIndex = (activeIndex + offset) % this.endpoints.length;
+        const candidate = this.endpoints[candidateIndex];
+        if (!(await this.endpointMatchesNetwork(candidate))) continue;
+
+        try {
+          const result = await this.requestEndpoint<T>(
+            { ...options, url: this.rewriteUrl(options.url, candidate) },
+            data
+          );
+          this.activateEndpoint(candidateIndex);
+          return result;
+        } catch (candidateError) {
+          if (!isRpcAvailabilityError(candidateError)) {
+            // The candidate answered on the expected network. Preserve its
+            // application-level error, but keep it active so the next request
+            // does not stall on the unavailable endpoint again.
+            this.activateEndpoint(candidateIndex);
+            throw candidateError;
+          }
+        }
+      }
+
+      throw initialError;
+    }
+  }
+}
+
+export function createRpcToolkit(info: NetworkInfo): TezosToolkit {
+  const backend = new FailoverHttpBackend({
+    primaryUrl: info.tezosServer,
+    fallbackUrls: info.rpcFallbacks,
+    expectedChainId: info.chainId,
+  });
+  const rpcClient = new RpcClient(info.tezosServer, "main", backend);
+  const toolkit = new TezosToolkit(rpcClient);
+  toolkit.setPackerProvider(new MichelCodecPacker());
+  return toolkit;
+}

--- a/V2/tezex/src/functions/util.ts
+++ b/V2/tezex/src/functions/util.ts
@@ -53,11 +53,8 @@ export function makeEstimationToolkit(
   toolkit: TezosToolkit,
   userAddress: string
 ): TezosToolkit {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const rpcUrl = (toolkit.rpc as unknown as Record<string, unknown>)[
-    "url"
-  ] as string;
-  const est = new TezosToolkit(rpcUrl);
+  // Reuse the same RPC client so estimates inherit endpoint failover behavior.
+  const est = new TezosToolkit(toolkit.rpc);
   est.setPackerProvider(new MichelCodecPacker());
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   est.setProvider({ signer: new EstimationSigner(userAddress) as any });


### PR DESCRIPTION
## What changed
- Keep TzKT as the Mainnet primary and add the Octez public RPC as an independent fallback.
- Add ordered Shadownet fallbacks through Octez and TzKT.
- Verify every fallback against the expected Tezos chain ID before sending application traffic.
- Keep the selected healthy endpoint active after failover, including for fee estimation.

## Safety behavior
- Fail over only for transport failures, timeouts, rate limiting, and gateway/service availability errors.
- Preserve contract and simulation errors instead of hiding them with another request.
- Never fail over operation injection to a different provider.
- Keep Previewnet on its current single verified endpoint until another compatible public RPC is available.

## Verification
- 41 application tests passed.
- 6 dedicated RPC failover tests passed.
- TypeScript passed.
- Production build compiled.
- Production audit found no high-severity findings under the configured gate.
- Pre-commit lint and formatting checks passed.

Closes #10