### PR TITLE
Move swap token selection into amount fields

### DIFF
--- a/V2/tezex/src/components/swap/index.tsx
+++ b/V2/tezex/src/components/swap/index.tsx
@@ -30,7 +30,7 @@ import { TransactionProgress } from "./TransactionProgress";
 import useStyles from "../../hooks/styles";
 import { useTransaction } from "../../hooks/transaction";
 import { eq } from "lodash";
-import { PoolSelector } from "../ui/elements/PoolSelector";
+import { findPoolForTokenPair, getCompatibleSwapAssets } from "./tokenRouting";
 
 export interface ISwapToken {
   orientation: "portrait" | "landscape";
@@ -126,23 +126,31 @@ export const Swap: FC<ISwapToken> = () => {
     }
   }, [network.network]);
 
-  const handlePoolChange = useCallback(
-    async (newPoolId: string) => {
-      const pool = network.getAllPools().find((item) => item.id === newPoolId);
+  const handleAssetChange = useCallback(
+    async (side: typeof send | typeof receive, nextAsset: Asset) => {
+      const nextAssets: [Asset, Asset] = [...assets];
+      nextAssets[side] = nextAsset;
+
+      const pool = findPoolForTokenPair(
+        network.getAllPools(),
+        nextAssets[send].name,
+        nextAssets[receive].name
+      );
       if (!pool) return;
 
       network.setSelectedPool(pool);
-      setAssets([network.getAsset(pool.tokenA), network.getAsset(pool.tokenB)]);
+      setAssets(nextAssets);
+      setSendInputValue("0.00");
 
       wallet.clearTransaction(TransactingComponent.ADD_LIQUIDITY);
       wallet.clearTransaction(TransactingComponent.REMOVE_LIQUIDITY);
       await transactionOps.initialize(
-        [network.getAsset(pool.tokenA)],
-        [network.getAsset(pool.tokenB)],
-        newPoolId
+        [nextAssets[send]],
+        [nextAssets[receive]],
+        pool.id
       );
     },
-    [network, transactionOps, wallet]
+    [assets, network, transactionOps, wallet]
   );
 
   const transact = useCallback(async () => {
@@ -242,6 +250,16 @@ export const Swap: FC<ISwapToken> = () => {
   if (loading) return <Box sx={styles.loadingSpace} />;
 
   const transaction = transactionOps.getActiveTransaction() || active;
+  const sendAssetOptions = getCompatibleSwapAssets(
+    availablePools,
+    assets[receive].name,
+    network.getAsset
+  );
+  const receiveAssetOptions = getCompatibleSwapAssets(
+    availablePools,
+    assets[send].name,
+    network.getAsset
+  );
   const sendAmount = transaction?.sendAmount[0]?.decimal;
   const receiveAmount = transaction?.receiveAmount[0]?.decimal;
   const hasEnteredAmount = new BigNumber(sendInputValue || 0).isGreaterThan(0);
@@ -295,12 +313,6 @@ export const Swap: FC<ISwapToken> = () => {
               <Typography sx={styles.eyebrow}>SWAP</Typography>
               <Typography sx={styles.cardTitle}>Trade on Tezos</Typography>
             </Box>
-            <PoolSelector
-              onChange={handlePoolChange}
-              disabled={!canUpdate}
-              sx={styles.poolSelector}
-              variant="dark"
-            />
           </Box>
 
           <CardContent sx={styles.cardContent}>
@@ -315,6 +327,9 @@ export const Swap: FC<ISwapToken> = () => {
                 loading={!isLoaded()}
                 label="You pay"
                 visualVariant="tezex"
+                selectableAssets={sendAssetOptions}
+                onAssetChange={(asset) => handleAssetChange(send, asset)}
+                assetSelectionDisabled={!canUpdate}
               />
             </Box>
 
@@ -333,6 +348,9 @@ export const Swap: FC<ISwapToken> = () => {
                 loading={!isLoaded()}
                 label="You receive"
                 visualVariant="tezex"
+                selectableAssets={receiveAssetOptions}
+                onAssetChange={(asset) => handleAssetChange(receive, asset)}
+                assetSelectionDisabled={!canUpdate}
               />
             </Box>
 
@@ -440,8 +458,9 @@ export const Swap: FC<ISwapToken> = () => {
             </Box>
 
             <Box sx={styles.trustNote}>
-              Quotes come from the selected on-chain pool. Review every amount
-              and destination in your wallet before approving.
+              Quotes come from the on-chain pool matching the selected tokens.
+              Review every amount and destination in your wallet before
+              approving.
             </Box>
           </Box>
 

--- a/V2/tezex/src/components/swap/style.js
+++ b/V2/tezex/src/components/swap/style.js
@@ -70,15 +70,6 @@ const style = (theme, scale = 1) => {
       letterSpacing: "-0.02em",
       lineHeight: 1.2,
     },
-    poolSelector: {
-      minWidth: { xs: "150px", sm: "174px" },
-      maxWidth: "190px",
-      "@media (max-width: 520px)": {
-        width: "100%",
-        minWidth: 0,
-        maxWidth: "none",
-      },
-    },
     cardContent: {
       padding: { xs: "16px", sm: "20px" },
       "&.MuiCardContent-root:last-child": {

--- a/V2/tezex/src/components/swap/tokenRouting.test.ts
+++ b/V2/tezex/src/components/swap/tokenRouting.test.ts
@@ -1,0 +1,58 @@
+import { Token, TokenType } from "../../types/general";
+import { PoolConfig, PoolType } from "../../types/pools";
+import { findPoolForTokenPair, getCompatibleSwapAssets } from "./tokenRouting";
+
+const pools: PoolConfig[] = [
+  {
+    id: "tez-btc",
+    name: "Sirius",
+    type: PoolType.SIRIUS,
+    address: "KT1btc",
+    tokenA: Token.XTZ,
+    tokenB: Token.TzBTC,
+    lpToken: Token.Sirs,
+  },
+  {
+    id: "tez-usd",
+    name: "TEZEX",
+    type: PoolType.TEZEX,
+    address: "KT1usd",
+    tokenA: Token.XTZ,
+    tokenB: Token.USDtz,
+    lpToken: Token.LP_XTZUSDtz,
+  },
+];
+
+const getAsset = (name: Token) => ({
+  name,
+  label: name,
+  logo: `/${name}.svg`,
+  address: "",
+  decimals: 6,
+  type: TokenType.FA12,
+});
+
+describe("swap token routing", () => {
+  it("resolves the same pool regardless of trade direction", () => {
+    expect(findPoolForTokenPair(pools, Token.XTZ, Token.TzBTC)?.id).toBe(
+      "tez-btc"
+    );
+    expect(findPoolForTokenPair(pools, Token.TzBTC, Token.XTZ)?.id).toBe(
+      "tez-btc"
+    );
+  });
+
+  it("offers only assets connected to the token in the other field", () => {
+    expect(
+      getCompatibleSwapAssets(pools, Token.XTZ, getAsset).map(
+        (asset) => asset.name
+      )
+    ).toEqual([Token.TzBTC, Token.USDtz]);
+
+    expect(
+      getCompatibleSwapAssets(pools, Token.TzBTC, getAsset).map(
+        (asset) => asset.name
+      )
+    ).toEqual([Token.XTZ]);
+  });
+});

--- a/V2/tezex/src/components/swap/tokenRouting.ts
+++ b/V2/tezex/src/components/swap/tokenRouting.ts
@@ -1,0 +1,35 @@
+import { Asset, Token } from "../../types/general";
+import { PoolConfig } from "../../types/pools";
+
+export const findPoolForTokenPair = (
+  pools: PoolConfig[],
+  tokenA: Token,
+  tokenB: Token
+): PoolConfig | undefined =>
+  pools.find(
+    (pool) =>
+      (pool.tokenA === tokenA && pool.tokenB === tokenB) ||
+      (pool.tokenA === tokenB && pool.tokenB === tokenA)
+  );
+
+export const getCompatibleSwapAssets = (
+  pools: PoolConfig[],
+  counterpart: Token,
+  getAsset: (token: Token) => Asset
+): Asset[] => {
+  const compatibleTokens: Token[] = [];
+
+  pools.forEach((pool) => {
+    const token =
+      pool.tokenA === counterpart
+        ? pool.tokenB
+        : pool.tokenB === counterpart
+        ? pool.tokenA
+        : undefined;
+
+    if (token && !compatibleTokens.includes(token))
+      compatibleTokens.push(token);
+  });
+
+  return compatibleTokens.map(getAsset);
+};

--- a/V2/tezex/src/components/ui/elements/TokenSelector.test.tsx
+++ b/V2/tezex/src/components/ui/elements/TokenSelector.test.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { Asset, Token, TokenType } from "../../../types/general";
+import { TokenSelector } from "./TokenSelector";
+
+const makeAsset = (name: Token, label: string): Asset => ({
+  name,
+  label,
+  logo: `/${name}.svg`,
+  address: "",
+  decimals: 6,
+  type: TokenType.FA12,
+});
+
+const tez = makeAsset(Token.XTZ, "Tez");
+const tzbtc = makeAsset(Token.TzBTC, "tzBTC");
+const usdtz = makeAsset(Token.USDtz, "USDtz");
+
+test("selects a token from inside an amount field", () => {
+  const handleChange = jest.fn();
+
+  render(
+    <TokenSelector
+      asset={tzbtc}
+      options={[tzbtc, usdtz]}
+      onChange={handleChange}
+      ariaLabel="Select you receive"
+    />
+  );
+
+  const selector = screen.getByRole("combobox", {
+    name: "Select you receive",
+  });
+  expect(selector).toHaveTextContent("tzBTC");
+
+  fireEvent.mouseDown(selector);
+  fireEvent.click(screen.getByRole("option", { name: "USDtz" }));
+
+  expect(handleChange).toHaveBeenCalledWith(usdtz);
+});
+
+test("shows the selected token label without replacing the supplied artwork", () => {
+  render(
+    <TokenSelector
+      asset={tez}
+      options={[tez]}
+      onChange={jest.fn()}
+      ariaLabel="Select you pay"
+    />
+  );
+
+  expect(
+    screen.getByRole("combobox", { name: "Select you pay" })
+  ).toHaveTextContent("Tez");
+  expect(document.querySelector('[data-token="XTZ"]')).toBeInTheDocument();
+});

--- a/V2/tezex/src/components/ui/elements/TokenSelector.tsx
+++ b/V2/tezex/src/components/ui/elements/TokenSelector.tsx
@@ -1,0 +1,153 @@
+import React, { FC } from "react";
+
+import Box from "@mui/material/Box";
+import FormControl from "@mui/material/FormControl";
+import MenuItem from "@mui/material/MenuItem";
+import Select, { SelectChangeEvent } from "@mui/material/Select";
+import Typography from "@mui/material/Typography";
+
+import { Asset } from "../../../types/general";
+import { TokenIcon } from "./TokenIcon";
+
+export interface TokenSelectorProps {
+  asset: Asset;
+  options: Asset[];
+  onChange: (asset: Asset) => void;
+  disabled?: boolean;
+  ariaLabel: string;
+}
+
+export const TokenSelector: FC<TokenSelectorProps> = ({
+  asset,
+  options,
+  onChange,
+  disabled = false,
+  ariaLabel,
+}) => {
+  const handleChange = (event: SelectChangeEvent<string>) => {
+    const nextAsset = options.find(
+      (option) => option.name === event.target.value
+    );
+    if (nextAsset) onChange(nextAsset);
+  };
+
+  const renderAsset = (selectedName: string) => {
+    const selected =
+      options.find((option) => option.name === selectedName) ?? asset;
+
+    return (
+      <Box display="flex" alignItems="center" gap="8px">
+        <TokenIcon asset={selected} size={26} decorative />
+        <Typography
+          component="span"
+          sx={{
+            color: "var(--tezex-text)",
+            fontSize: "13px",
+            fontWeight: 700,
+            letterSpacing: "0.02em",
+          }}
+        >
+          {selected.label}
+        </Typography>
+      </Box>
+    );
+  };
+
+  return (
+    <FormControl sx={{ flexShrink: 0 }}>
+      <Select
+        value={asset.name}
+        onChange={handleChange}
+        disabled={disabled}
+        size="small"
+        inputProps={{ "aria-label": ariaLabel }}
+        renderValue={renderAsset}
+        sx={{
+          minHeight: "38px",
+          color: "var(--tezex-text)",
+          background: "var(--tezex-panel-subtle)",
+          border: "1px solid var(--tezex-line)",
+          borderRadius: "999px",
+          transition: "border-color 160ms ease, background-color 160ms ease",
+          "& .MuiSelect-select": {
+            display: "flex",
+            alignItems: "center",
+            padding: "5px 34px 5px 7px",
+          },
+          "& .MuiSelect-icon": {
+            right: "9px",
+            color: "var(--tezex-muted)",
+            fontSize: "18px",
+          },
+          "& .MuiOutlinedInput-notchedOutline": { border: "none" },
+          "&:hover": {
+            borderColor: "var(--tezex-line-strong)",
+            background: "var(--tezex-hover)",
+          },
+          "&.Mui-focused": {
+            borderColor: "var(--tezex-text-secondary)",
+            boxShadow: "0 0 0 3px var(--tezex-focus-ring)",
+          },
+          "&.Mui-disabled": {
+            opacity: 0.68,
+          },
+        }}
+        MenuProps={{
+          PaperProps: {
+            sx: {
+              marginTop: "6px",
+              minWidth: "190px !important",
+              maxHeight: "320px",
+              overflow: "auto",
+              color: "var(--tezex-text)",
+              background: "var(--tezex-panel)",
+              border: "1px solid var(--tezex-line)",
+              borderRadius: "16px",
+              boxShadow: "var(--tezex-menu-shadow)",
+              "& .MuiMenuItem-root": {
+                minHeight: "48px",
+                gap: "10px",
+                padding: "9px 12px",
+                color: "var(--tezex-text)",
+                "&:hover": { background: "var(--tezex-hover)" },
+                "&.Mui-selected": {
+                  background: "var(--tezex-line-soft)",
+                  "&:hover": { background: "var(--tezex-line)" },
+                },
+              },
+            },
+          },
+        }}
+      >
+        {options.map((option) => (
+          <MenuItem key={option.name} value={option.name}>
+            <TokenIcon asset={option} size={26} decorative />
+            <Box minWidth={0}>
+              <Typography
+                sx={{
+                  fontSize: "13px",
+                  fontWeight: 700,
+                  lineHeight: 1.2,
+                }}
+              >
+                {option.label}
+              </Typography>
+              {option.name !== option.label && (
+                <Typography
+                  sx={{
+                    marginTop: "2px",
+                    color: "var(--tezex-muted)",
+                    fontSize: "10px",
+                    lineHeight: 1.2,
+                  }}
+                >
+                  {option.name}
+                </Typography>
+              )}
+            </Box>
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  );
+};

--- a/V2/tezex/src/components/ui/elements/inputs/UserAmount/index.tsx
+++ b/V2/tezex/src/components/ui/elements/inputs/UserAmount/index.tsx
@@ -22,6 +22,9 @@ export interface IAmountField {
   loading?: boolean;
   forceZero?: boolean;
   visualVariant?: "default" | "tezex";
+  selectableAssets?: Asset[];
+  onAssetChange?: (asset: Asset) => void;
+  assetSelectionDisabled?: boolean;
 }
 
 const AmountField: FC<IAmountField> = (props) => {
@@ -40,6 +43,9 @@ const AmountField: FC<IAmountField> = (props) => {
       loading={props.loading}
       forceZero={props.forceZero}
       visualVariant={props.visualVariant}
+      selectableAssets={props.selectableAssets}
+      onAssetChange={props.onAssetChange}
+      assetSelectionDisabled={props.assetSelectionDisabled}
     />
   );
 };

--- a/V2/tezex/src/components/ui/elements/inputs/UserAmount/token-input/index.tsx
+++ b/V2/tezex/src/components/ui/elements/inputs/UserAmount/token-input/index.tsx
@@ -27,6 +27,7 @@ import {
 import { useDebounce } from "usehooks-ts";
 import { eq, toNumber } from "lodash";
 import { TokenIcon } from "../../../TokenIcon";
+import { TokenSelector } from "../../../TokenSelector";
 
 export interface IRigthInput {
   component: TransactingComponent;
@@ -42,6 +43,9 @@ export interface IRigthInput {
   loading?: boolean;
   forceZero?: boolean;
   visualVariant?: "default" | "tezex";
+  selectableAssets?: Asset[];
+  onAssetChange?: (asset: Asset) => void;
+  assetSelectionDisabled?: boolean;
 }
 
 const TokenInput: FC<IRigthInput> = (props) => {
@@ -291,12 +295,22 @@ const TokenInput: FC<IRigthInput> = (props) => {
             InputProps={{ disableUnderline: true }}
           />
 
-          <Box sx={styles.tezex.tokenPill} aria-label={props.asset.label}>
-            <TokenIcon asset={props.asset} size={26} decorative />
-            <Typography sx={styles.tezex.tokenLabel}>
-              {props.asset.label}
-            </Typography>
-          </Box>
+          {props.onAssetChange && props.selectableAssets?.length ? (
+            <TokenSelector
+              asset={props.asset}
+              options={props.selectableAssets}
+              onChange={props.onAssetChange}
+              disabled={props.assetSelectionDisabled}
+              ariaLabel={`Select ${props.label?.toLowerCase() || "token"}`}
+            />
+          ) : (
+            <Box sx={styles.tezex.tokenPill} aria-label={props.asset.label}>
+              <TokenIcon asset={props.asset} size={26} decorative />
+              <Typography sx={styles.tezex.tokenLabel}>
+                {props.asset.label}
+              </Typography>
+            </Box>
+          )}
         </Box>
       </Box>
     );

--- a/V2/tezex/src/pages/Home/index.test.tsx
+++ b/V2/tezex/src/pages/Home/index.test.tsx
@@ -117,6 +117,7 @@ const renderHome = () =>
   );
 
 const originalAnimate = HTMLElement.prototype.animate;
+const originalRequestAnimationFrame = window.requestAnimationFrame;
 
 beforeEach(() => {
   window.matchMedia = jest.fn().mockReturnValue({ matches: false });
@@ -127,6 +128,7 @@ beforeEach(() => {
 
 afterEach(() => {
   HTMLElement.prototype.animate = originalAnimate;
+  window.requestAnimationFrame = originalRequestAnimationFrame;
   delete document.documentElement.dataset.modeTransition;
   document.documentElement.style.overflowX = "";
 });
@@ -179,6 +181,11 @@ test("moves outgoing and incoming workspaces on one continuous track", async () 
   });
   const animate = jest.fn(() => ({ finished, cancel } as unknown as Animation));
   HTMLElement.prototype.animate = animate;
+  const animationFrames: FrameRequestCallback[] = [];
+  window.requestAnimationFrame = jest.fn((callback: FrameRequestCallback) => {
+    animationFrames.push(callback);
+    return animationFrames.length;
+  });
 
   renderHome();
   fireEvent.click(screen.getByRole("button", { name: "Liquidity" }));
@@ -229,5 +236,21 @@ test("moves outgoing and incoming workspaces on one continuous track", async () 
     "translate3d(0, 0, 0)",
     "translate3d(0, 0, 0)",
   ]);
+  expect(screen.getByTestId("trading-workspace")).toHaveStyle({
+    transform: "translate3d(0, 0, 0)",
+  });
+  expect(screen.getByRole("button", { name: "Swap" })).toBeDisabled();
+
+  act(() => animationFrames.shift()?.(0));
+
+  expect(screen.getByTestId("trading-workspace")).toHaveStyle({
+    transform: "translate3d(0, 0, 0)",
+  });
+
+  act(() => animationFrames.shift()?.(16));
+
+  expect(screen.getByTestId("trading-workspace")).not.toHaveStyle({
+    transform: "translate3d(0, 0, 0)",
+  });
   expect(screen.getByRole("button", { name: "Swap" })).toBeEnabled();
 });

--- a/V2/tezex/src/pages/Home/index.tsx
+++ b/V2/tezex/src/pages/Home/index.tsx
@@ -102,6 +102,7 @@ export const Home: FC<IHome> = (props) => {
       const previousOverflowX = document.documentElement.style.overflowX;
       const animations: Animation[] = [];
       let incomingPanel: HTMLDivElement | null = null;
+      let incomingHeight = outgoingHeight;
       let cleanedUp = false;
       let shouldFinishNavigation = true;
 
@@ -114,15 +115,32 @@ export const Home: FC<IHome> = (props) => {
         // first briefly restores their pre-animation styles, which can expose
         // the workspace we just slid away for a single frame.
         outgoingSnapshot.remove();
-        viewport.style.height = "";
         incomingPanel?.style.setProperty("transform", "translate3d(0, 0, 0)");
+        if (incomingHeight > 0) {
+          viewport.style.height = `${incomingHeight}px`;
+        }
         animations.forEach((animation) => animation.cancel());
-        incomingPanel?.style.removeProperty("transform");
         incomingPanel?.style.removeProperty("will-change");
         document.documentElement.style.overflowX = previousOverflowX;
         delete document.documentElement.dataset.modeTransition;
-        setIsTransitioning(false);
-        cleanupTransitionRef.current = () => undefined;
+
+        const releasePinnedStyles = () => {
+          incomingPanel?.style.removeProperty("transform");
+          viewport.style.height = "";
+          setIsTransitioning(false);
+          cleanupTransitionRef.current = () => undefined;
+        };
+
+        // Keep the incoming workspace pinned through one completed paint.
+        // Releasing the inline transform in the same frame as cancel() can
+        // expose the outgoing workspace for a frame in mobile Safari.
+        if (typeof window.requestAnimationFrame === "function") {
+          window.requestAnimationFrame(() => {
+            window.requestAnimationFrame(releasePinnedStyles);
+          });
+        } else {
+          releasePinnedStyles();
+        }
       };
 
       cleanupTransitionRef.current = () => {
@@ -142,7 +160,7 @@ export const Home: FC<IHome> = (props) => {
         incomingPanel = panelRef.current;
         if (!incomingPanel) throw new Error("Trading workspace is unavailable");
 
-        const incomingHeight = incomingPanel.getBoundingClientRect().height;
+        incomingHeight = incomingPanel.getBoundingClientRect().height;
         const incomingOffset = direction === "forward" ? "100%" : "-100%";
         const outgoingOffset = direction === "forward" ? "-100%" : "100%";
         const options: KeyframeAnimationOptions = {


### PR DESCRIPTION
## What changed

- removed the pool selector from the Swap header
- added token selectors directly to the “You pay” and “You receive” fields
- resolved the matching direct on-chain pool from the selected token pair
- limited token choices to pairs TEZEX can execute
- kept Liquidity pool selection unchanged
- added focused routing and selector interaction tests

## Why

Swap users should choose the assets they want to exchange rather than choose a pool implementation first. The selected token pair now drives the same pool adapter and transaction lifecycle.

## Validation

- npm run typecheck
- npm run test:ci (50 tests)
- npm run build
- verified token selection, pool resolution, direction reversal, desktop layout, and mobile layout