### PR TITLE
Preserve tezex.io custom domain during deployment

### DIFF
--- a/V2/tezex/package.json
+++ b/V2/tezex/package.json
@@ -46,7 +46,7 @@
   },
   "scripts": {
     "predeploy": "npm run verify",
-    "deploy": "gh-pages -d build",
+    "deploy": "gh-pages -d build --cname tezex.io",
     "start": "react-app-rewired start",
     "build": "react-app-rewired build",
     "test": "react-app-rewired test",

--- a/V2/tezex/public/CNAME
+++ b/V2/tezex/public/CNAME
@@ -1,0 +1,1 @@
+tezex.io


### PR DESCRIPTION
## What changed

- include `tezex.io` in the production build as its Pages `CNAME`
- make the deploy command explicitly preserve that custom domain

## Why

The generated Pages release removed the existing `CNAME` because the domain was not part of the source build. GitHub Pages consequently detached `tezex.io` until the domain file was restored on the deployment branch.

Keeping the domain in both the build artifact and the deploy command prevents future releases from dropping the production hostname.

## Validation

- production build completed successfully
- verified `build/CNAME` contains `tezex.io`
- verified the restored live deployment returns HTTP 200
