### PR TITLE
Rebalance mobile Swap header spacing

### DIFF
--- a/V2/tezex/src/components/swap/style.js
+++ b/V2/tezex/src/components/swap/style.js
@@ -46,9 +46,11 @@ const style = (theme, scale = 1) => {
       gap: "16px",
       borderBottom: "1px solid var(--tezex-line-soft)",
       "@media (max-width: 520px)": {
+        minHeight: "auto",
         alignItems: "stretch",
         flexDirection: "column",
-        padding: "18px",
+        justifyContent: "flex-start",
+        padding: "16px 18px",
       },
     },
     cardTitleGroup: {


### PR DESCRIPTION
## What changed

- removed the obsolete fixed minimum height from the Swap header on phone widths
- tightened the mobile vertical padding while retaining the existing horizontal inset
- preserved the 82px desktop header height used to align the trading and details columns

## Why

The Swap header kept the height required by the former pool selector after that selector moved into the amount fields. With only the title group remaining, the unused height appeared as dead space above the transaction controls.

The updated mobile header follows the title's natural height and a consistent 16px vertical rhythm.

## Validation

- measured the mobile header at 390px wide: 82px reduced to approximately 72px
- measured the title-to-divider gap: approximately 25px reduced to 17px
- verified the desktop header remains 82px at 1280px wide
- reviewed the result in light and dark themes
- `npm run typecheck`
- `npm run test:ci` (51 tests)
- `npm run build`
