### PR TITLE
Add on-chain TEZEX analytics dashboard

### DIFF
--- a/V2/tezex/src/components/nav/NavApp.tsx
+++ b/V2/tezex/src/components/nav/NavApp.tsx
@@ -1,5 +1,5 @@
-import React, { FC, useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import React, { FC } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 import Tabs from "@mui/material/Tabs";
 import Tab from "@mui/material/Tab";
 
@@ -12,7 +12,6 @@ import Box from "@mui/material/Box";
 interface NavTabProps {
   label: string;
   href: string;
-  disabled?: boolean;
 }
 
 function NavTabExternal(props: NavTabProps) {
@@ -28,72 +27,23 @@ function NavTabExternal(props: NavTabProps) {
   );
 }
 
-// TODO: Fallback to old implementation when Analytics page is ready
 function NavTab(props: NavTabProps) {
   const navigate = useNavigate();
-  const { disabled, label, ...restProps } = props;
+  const { label, ...restProps } = props;
   return (
-    <Box
-      sx={{ position: "relative", display: "inline-flex", overflow: "visible" }}
-    >
+    <Box sx={{ display: "inline-flex" }}>
       <Tab
-        sx={{
-          opacity: disabled ? 0.7 : 1,
-          cursor: disabled ? "not-allowed" : "pointer",
-        }}
+        sx={{ cursor: "pointer" }}
         onClick={(event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
           event.preventDefault();
-          if (!disabled) {
-            navigate(props.href);
-          }
+          navigate(props.href);
         }}
         label={label}
-        disabled={disabled}
         {...restProps}
       />
-      {disabled && (
-        <Box
-          sx={{
-            position: "absolute",
-            bottom: "18%",
-            right: "0%",
-            background: "transparent",
-            backdropFilter: "blur(1px)",
-            WebkitBackdropFilter: "blur(1px)",
-            color: "var(--tezex-muted)",
-            fontSize: { xs: "8px", md: "9px" },
-            fontWeight: 700,
-            padding: "3px 10px",
-            textTransform: "uppercase",
-            letterSpacing: "0.4px",
-            transform: "rotate(-15deg)",
-            transformOrigin: "center",
-            pointerEvents: "none",
-            zIndex: 10,
-            borderRadius: "10px",
-            whiteSpace: "nowrap",
-          }}
-        >
-          Soon
-        </Box>
-      )}
     </Box>
   );
 }
-
-// function NavTab(props: NavTabProps) {
-//   const navigate = useNavigate();
-//   return (
-//     <Tab
-//       sx={{}}
-//       onClick={(event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
-//         event.preventDefault();
-//         navigate(props.href);
-//       }}
-//       {...props}
-//     />
-//   );
-// }
 
 interface INavApp {
   scalingKey?: string;
@@ -101,42 +51,22 @@ interface INavApp {
 
 export const NavApp: FC<INavApp> = (props) => {
   const styles = useStyles(style, props.scalingKey);
-  const [value, setValue] = useState(0);
-  const [loading, setLoading] = useState(true);
-  const navigate = useNavigate();
-  const pageId = {
-    home: 0,
-    analytics: 1,
-    about: 2,
-  };
+  const location = useLocation();
+  const value = location.pathname.startsWith("/analytics") ? 1 : 0;
 
   const aboutRedirectUrl = useSession().appConfig.aboutRedirectUrl;
-
-  useEffect(() => {
-    if (loading) {
-      navigate("home/swap");
-      setValue(0);
-      setLoading(false);
-    }
-  }, [loading, navigate]);
-
-  const handleChange = (event: React.SyntheticEvent, newValue: number) => {
-    event.preventDefault();
-    if (newValue !== pageId.about) setValue(newValue);
-  };
 
   return (
     <Tabs
       value={value}
       sx={styles.navApp}
-      onChange={handleChange}
-      aria-label="nav tabs "
+      aria-label="Primary navigation"
       TabIndicatorProps={{
         style: { display: "none" },
       }}
     >
       <NavTab label="Home" href="/home/swap" />
-      <NavTab disabled label="Analytics" href="/Analytics" />
+      <NavTab label="Analytics" href="/analytics" />
       <NavTabExternal label="About" href={aboutRedirectUrl} />
     </Tabs>
   );

--- a/V2/tezex/src/components/ui/views/sidebar/index.tsx
+++ b/V2/tezex/src/components/ui/views/sidebar/index.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useEffect } from "react";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import {
   List,
   ListItem,
@@ -35,6 +35,7 @@ export const SideBar: FC<ISideBarProps> = (props) => {
   const [liquidityOpen, setLiquidityOpen] = React.useState(false);
   const [active, setActive] = React.useState(0);
   const sessionInfo = useSession();
+  const location = useLocation();
   const styles = useStyles(style);
   const { isLandscape } = useMobileOrientation();
 
@@ -178,7 +179,12 @@ export const SideBar: FC<ISideBarProps> = (props) => {
             </Collapse>
 
             <ListItem disablePadding sx={styles.listItem}>
-              <ListItemButton disabled component={Link} to="/Analytics">
+              <ListItemButton
+                component={Link}
+                to="/analytics"
+                onClick={props.toggleMenu}
+                selected={location.pathname.startsWith("/analytics")}
+              >
                 <ListItemText primary="Analytics" sx={styles.listItemText} />
               </ListItemButton>
             </ListItem>

--- a/V2/tezex/src/index.tsx
+++ b/V2/tezex/src/index.tsx
@@ -11,6 +11,7 @@ import { createHashRouter, RouterProvider } from "react-router-dom";
 import { AppConfig } from "./types/general";
 import appConfig from "./config/app.json";
 import { Home } from "./pages/Home";
+import { Analytics } from "./pages/Analytics";
 import { ColorModeProvider } from "./contexts/color-mode";
 
 const router = createHashRouter([
@@ -32,7 +33,7 @@ const router = createHashRouter([
       },
       {
         path: "analytics",
-        element: <Home path="swap" />,
+        element: <Analytics />,
       },
     ],
   },

--- a/V2/tezex/src/pages/Analytics/api.test.ts
+++ b/V2/tezex/src/pages/Analytics/api.test.ts
@@ -1,11 +1,13 @@
 import { Token } from "../../types/general";
 import { PoolConfig, PoolType } from "../../types/pools";
 import {
+  ANALYTICS_RANGES,
   buildSwapSeries,
   calculateRemoveLiquidityValueXtz,
   calculateSwapVolumeXtz,
   convertXtz,
   formatDenominatedXtz,
+  RANGE_CONFIG,
   TzktTransaction,
 } from "./api";
 
@@ -82,6 +84,23 @@ describe("analytics calculations", () => {
     expect(series.Fees.reduce((sum, point) => sum + point.value, 0)).toBe(
       0.004
     );
+  });
+
+  it("builds every preset from the same in-memory transaction history", () => {
+    const now = new Date("2026-07-29T00:00:00Z").getTime();
+
+    ANALYTICS_RANGES.forEach((range) => {
+      const series = buildSwapSeries(
+        [],
+        [siriusPool],
+        range,
+        now,
+        new Map([[siriusPool.id, 0.001]])
+      );
+
+      expect(series.Volume).toHaveLength(RANGE_CONFIG[range].bucketCount);
+      expect(series.Fees).toHaveLength(RANGE_CONFIG[range].bucketCount);
+    });
   });
 
   it("derives removed liquidity value from the post-operation pool state", () => {

--- a/V2/tezex/src/pages/Analytics/api.test.ts
+++ b/V2/tezex/src/pages/Analytics/api.test.ts
@@ -2,7 +2,10 @@ import { Token } from "../../types/general";
 import { PoolConfig, PoolType } from "../../types/pools";
 import {
   buildSwapSeries,
+  calculateRemoveLiquidityValueXtz,
   calculateSwapVolumeXtz,
+  convertXtz,
+  formatDenominatedXtz,
   TzktTransaction,
 } from "./api";
 
@@ -79,5 +82,37 @@ describe("analytics calculations", () => {
     expect(series.Fees.reduce((sum, point) => sum + point.value, 0)).toBe(
       0.004
     );
+  });
+
+  it("derives removed liquidity value from the post-operation pool state", () => {
+    const value = calculateRemoveLiquidityValueXtz(
+      transaction({
+        parameter: {
+          entrypoint: "removeLiquidity",
+          value: { lqtBurned: "1000" },
+        },
+        storage: {
+          xtzPool: "900000000",
+          lqtTotal: "9000",
+        },
+      })
+    );
+
+    expect(value).toBe(100);
+  });
+
+  it("converts XTZ values through the same verified quote", () => {
+    const quote = {
+      btcPerXtz: 0.000003,
+      usdPerXtz: 0.2,
+      timestamp: new Date("2026-07-29T00:00:00Z").getTime(),
+    };
+
+    expect(convertXtz(1000, "XTZ", quote)).toBe(1000);
+    expect(convertXtz(1000, "BTC", quote)).toBeCloseTo(0.003);
+    expect(convertXtz(1000, "USD", quote)).toBe(200);
+    expect(formatDenominatedXtz(1000, "XTZ", quote)).toBe("1K XTZ");
+    expect(formatDenominatedXtz(1000, "BTC", quote)).toBe("0.003 BTC");
+    expect(formatDenominatedXtz(1000, "USD", quote)).toBe("$200.00");
   });
 });

--- a/V2/tezex/src/pages/Analytics/api.test.ts
+++ b/V2/tezex/src/pages/Analytics/api.test.ts
@@ -1,0 +1,83 @@
+import { Token } from "../../types/general";
+import { PoolConfig, PoolType } from "../../types/pools";
+import {
+  buildSwapSeries,
+  calculateSwapVolumeXtz,
+  TzktTransaction,
+} from "./api";
+
+const siriusPool: PoolConfig = {
+  id: "sirius",
+  name: "Sirius",
+  type: PoolType.SIRIUS,
+  address: "KT1-sirius",
+  tokenA: Token.XTZ,
+  tokenB: Token.TzBTC,
+  lpToken: Token.Sirs,
+};
+
+const transaction = (overrides: Partial<TzktTransaction>): TzktTransaction => ({
+  id: 1,
+  timestamp: "2026-07-28T12:00:00Z",
+  hash: "oo-test",
+  counter: 1,
+  sender: { address: "tz1-user" },
+  target: { address: siriusPool.address },
+  amount: 0,
+  ...overrides,
+});
+
+describe("analytics calculations", () => {
+  it("uses the transferred tez amount for XTZ-to-token swaps", () => {
+    const volume = calculateSwapVolumeXtz(
+      transaction({
+        amount: 2_500_000,
+        parameter: { entrypoint: "xtzToToken" },
+      }),
+      siriusPool
+    );
+
+    expect(volume).toBe(2.5);
+  });
+
+  it("derives XTZ volume from the post-swap pool state for token-to-XTZ swaps", () => {
+    const volume = calculateSwapVolumeXtz(
+      transaction({
+        parameter: {
+          entrypoint: "tokenToXtz",
+          value: { tokensSold: "1000000" },
+        },
+        storage: {
+          tokenPool: "11000000",
+          xtzPool: "1000000000",
+        },
+      }),
+      siriusPool
+    );
+
+    expect(volume).toBeCloseTo(99.9, 5);
+  });
+
+  it("buckets swap volume and the configured liquidity-provider fee", () => {
+    const now = new Date("2026-07-29T00:00:00Z").getTime();
+    const swaps = [
+      transaction({
+        amount: 4_000_000,
+        timestamp: "2026-07-28T23:30:00Z",
+        parameter: { entrypoint: "xtzToToken" },
+      }),
+    ];
+    const series = buildSwapSeries(
+      swaps,
+      [siriusPool],
+      "24H",
+      now,
+      new Map([[siriusPool.id, 0.001]])
+    );
+
+    expect(series.Volume.reduce((sum, point) => sum + point.value, 0)).toBe(4);
+    expect(series.Fees.reduce((sum, point) => sum + point.value, 0)).toBe(
+      0.004
+    );
+  });
+});

--- a/V2/tezex/src/pages/Analytics/api.ts
+++ b/V2/tezex/src/pages/Analytics/api.ts
@@ -4,6 +4,13 @@ import { PoolConfig, PoolType } from "../../types/pools";
 
 export type AnalyticsRange = "24H" | "7D" | "30D" | "90D";
 export type AnalyticsMetric = "Volume" | "TVL" | "Fees";
+export type AnalyticsCurrency = "XTZ" | "BTC" | "USD";
+
+export interface AnalyticsQuote {
+  btcPerXtz: number;
+  usdPerXtz: number;
+  timestamp: number;
+}
 
 export interface AnalyticsPoint {
   timestamp: number;
@@ -41,6 +48,7 @@ export interface AnalyticsActivity {
   tokenB: Asset;
   direction: string;
   value: string;
+  valueXtz: number;
   account: string;
   accountLabel?: string;
   timestamp: number;
@@ -54,6 +62,7 @@ export interface AnalyticsModel {
   activity: AnalyticsActivity[];
   blockLevel: number;
   blockTimestamp: number;
+  quote: AnalyticsQuote;
   loadedAt: number;
 }
 
@@ -87,6 +96,12 @@ interface TzktHead {
   level: number;
   timestamp: string;
   synced: boolean;
+}
+
+interface TzktQuote {
+  timestamp: string;
+  btc: number;
+  usd: number;
 }
 
 interface PoolSnapshot {
@@ -195,6 +210,18 @@ export const calculateSwapVolumeXtz = (
   // pool, the XTZ removed is postXtzPool * effectiveInput / preTokenPool.
   const effectiveInput = tokensSold * poolAmmMultiplier(pool);
   return (postXtzPool * effectiveInput) / preTokenPool / 1_000_000;
+};
+
+export const calculateRemoveLiquidityValueXtz = (
+  transaction: Pick<TzktTransaction, "parameter" | "storage">
+) => {
+  const params = getRecord(transaction.parameter?.value);
+  const storage = getRecord(transaction.storage);
+  const lqtBurned = toNumber(params.lqtBurned);
+  const postXtzPool = toNumber(storage.xtzPool);
+  const postLqtTotal = toNumber(storage.lqtTotal);
+  if (lqtBurned <= 0 || postXtzPool <= 0 || postLqtTotal <= 0) return 0;
+  return (postXtzPool * lqtBurned) / postLqtTotal / 1_000_000;
 };
 
 const percentageDelta = (current: number, previous: number) =>
@@ -344,23 +371,29 @@ const activityFromTransaction = (
   let action: AnalyticsActivity["action"];
   let direction: string;
   let value: string;
+  let valueXtz: number;
 
   if (entrypoint === "xtzToToken") {
     action = "Swap";
     direction = `${tokenA.label} → ${tokenB.label}`;
     value = formatAssetAmount(transaction.amount, tokenA);
+    valueXtz = transaction.amount / 1_000_000;
   } else if (entrypoint === "tokenToXtz") {
     action = "Swap";
     direction = `${tokenB.label} → ${tokenA.label}`;
     value = formatAssetAmount(toNumber(params.tokensSold), tokenB);
+    valueXtz = calculateSwapVolumeXtz(transaction, pool);
   } else if (entrypoint === "addLiquidity") {
     action = "Add";
     direction = `${tokenA.label} + ${tokenB.label}`;
     value = formatAssetAmount(transaction.amount, tokenA);
+    valueXtz = transaction.amount / 1_000_000;
   } else if (entrypoint === "removeLiquidity") {
     action = "Remove";
     direction = `${tokenA.label} + ${tokenB.label}`;
-    value = formatAssetAmount(toNumber(params.lqtBurned), lpToken);
+    const lqtBurned = toNumber(params.lqtBurned);
+    value = formatAssetAmount(lqtBurned, lpToken);
+    valueXtz = calculateRemoveLiquidityValueXtz(transaction);
   } else {
     return null;
   }
@@ -373,6 +406,7 @@ const activityFromTransaction = (
     tokenB,
     direction,
     value,
+    valueXtz,
     account: transaction.sender.address,
     accountLabel: transaction.sender.alias,
     timestamp: new Date(transaction.timestamp).getTime(),
@@ -393,6 +427,7 @@ export const loadAnalytics = async (
   const assets = assetMap(network.assets);
   const addresses = pools.map((pool) => pool.address);
   const headPromise = fetchJson<TzktHead>("/head", signal);
+  const quotePromise = fetchJson<TzktQuote>("/quotes/last", signal);
   const storagePromises = pools.map((pool) =>
     fetchJson<Record<string, unknown>>(
       `/contracts/${pool.address}/storage`,
@@ -409,8 +444,9 @@ export const loadAnalytics = async (
     now - 48 * HOUR
   );
 
-  const [storages, balanceHistories, swaps, recentTransactions] =
+  const [quote, storages, balanceHistories, swaps, recentTransactions] =
     await Promise.all([
+      quotePromise,
       Promise.all(storagePromises),
       Promise.all(balancePromises),
       fetchTransactions(
@@ -544,6 +580,11 @@ export const loadAnalytics = async (
     activity,
     blockLevel: preliminaryHead.level,
     blockTimestamp: now,
+    quote: {
+      btcPerXtz: quote.btc,
+      usdPerXtz: quote.usd,
+      timestamp: new Date(quote.timestamp).getTime(),
+    },
     loadedAt: Date.now(),
   };
 };
@@ -553,6 +594,44 @@ export const formatCompactXtz = (value: number) =>
     notation: value >= 1_000 ? "compact" : "standard",
     maximumFractionDigits: value >= 100 ? 1 : 2,
   }).format(value)} XTZ`;
+
+export const convertXtz = (
+  valueXtz: number,
+  currency: AnalyticsCurrency,
+  quote: AnalyticsQuote
+) => {
+  if (currency === "BTC") return valueXtz * quote.btcPerXtz;
+  if (currency === "USD") return valueXtz * quote.usdPerXtz;
+  return valueXtz;
+};
+
+export const formatDenominatedXtz = (
+  valueXtz: number,
+  currency: AnalyticsCurrency,
+  quote: AnalyticsQuote
+) => {
+  if (currency === "XTZ") return formatCompactXtz(valueXtz);
+
+  const value = convertXtz(valueXtz, currency, quote);
+  if (!Number.isFinite(value)) return "—";
+
+  if (currency === "USD") {
+    if (value > 0 && value < 0.01) return "<$0.01";
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+      notation: value >= 1_000 ? "compact" : "standard",
+      maximumFractionDigits: value >= 1_000 ? 1 : 2,
+    }).format(value);
+  }
+
+  if (value > 0 && value < 0.000001) return "<0.000001 BTC";
+  return `${new Intl.NumberFormat("en-US", {
+    notation: value >= 1_000 ? "compact" : "standard",
+    maximumFractionDigits:
+      value >= 100 ? 1 : value >= 1 ? 3 : value >= 0.01 ? 4 : 6,
+  }).format(value)} BTC`;
+};
 
 export const formatDelta = (value: number | null) =>
   value === null

--- a/V2/tezex/src/pages/Analytics/api.ts
+++ b/V2/tezex/src/pages/Analytics/api.ts
@@ -1,0 +1,570 @@
+import { NetworkInfo } from "../../contexts/network";
+import { Asset, Token } from "../../types/general";
+import { PoolConfig, PoolType } from "../../types/pools";
+
+export type AnalyticsRange = "24H" | "7D" | "30D" | "90D";
+export type AnalyticsMetric = "Volume" | "TVL" | "Fees";
+
+export interface AnalyticsPoint {
+  timestamp: number;
+  value: number;
+}
+
+export interface AnalyticsSummary {
+  tvlXtz: number;
+  tvlDelta: number | null;
+  volume24hXtz: number;
+  volumeDelta: number | null;
+  fees24hXtz: number;
+  feesDelta: number | null;
+  swaps24h: number;
+  swapsDelta: number | null;
+}
+
+export interface AnalyticsPool {
+  id: string;
+  name: string;
+  address: string;
+  tokenA: Asset;
+  tokenB: Asset;
+  tvlXtz: number;
+  volume24hXtz: number;
+  fees24hXtz: number;
+  apr: number | null;
+}
+
+export interface AnalyticsActivity {
+  id: number;
+  action: "Swap" | "Add" | "Remove";
+  poolName: string;
+  tokenA: Asset;
+  tokenB: Asset;
+  direction: string;
+  value: string;
+  account: string;
+  accountLabel?: string;
+  timestamp: number;
+  hash: string;
+}
+
+export interface AnalyticsModel {
+  summary: AnalyticsSummary;
+  chart: Record<AnalyticsMetric, AnalyticsPoint[]>;
+  pools: AnalyticsPool[];
+  activity: AnalyticsActivity[];
+  blockLevel: number;
+  blockTimestamp: number;
+  loadedAt: number;
+}
+
+interface TzktAlias {
+  alias?: string;
+  address: string;
+}
+
+export interface TzktTransaction {
+  id: number;
+  timestamp: string;
+  hash: string;
+  counter: number;
+  sender: TzktAlias;
+  target: TzktAlias;
+  amount: number;
+  parameter?: {
+    entrypoint: string;
+    value?: Record<string, unknown>;
+  };
+  storage?: Record<string, unknown>;
+}
+
+interface TzktBalancePoint {
+  level: number;
+  timestamp: string;
+  balance: number;
+}
+
+interface TzktHead {
+  level: number;
+  timestamp: string;
+  synced: boolean;
+}
+
+interface PoolSnapshot {
+  config: PoolConfig;
+  tokenA: Asset;
+  tokenB: Asset;
+  storage: Record<string, unknown>;
+  balanceHistory: TzktBalancePoint[];
+  feeRate: number;
+  currentTvlXtz: number;
+}
+
+interface RangeConfig {
+  windowMs: number;
+  bucketCount: number;
+  balanceStep: number;
+}
+
+const TZKT_API = "https://api.tzkt.io/v1";
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+const SWAP_ENTRYPOINTS = ["xtzToToken", "tokenToXtz"];
+const ACTIVITY_ENTRYPOINTS = [
+  ...SWAP_ENTRYPOINTS,
+  "addLiquidity",
+  "removeLiquidity",
+];
+
+export const RANGE_CONFIG: Record<AnalyticsRange, RangeConfig> = {
+  "24H": { windowMs: DAY, bucketCount: 24, balanceStep: 600 },
+  "7D": { windowMs: 7 * DAY, bucketCount: 7, balanceStep: 14_400 },
+  "30D": { windowMs: 30 * DAY, bucketCount: 30, balanceStep: 14_400 },
+  "90D": { windowMs: 90 * DAY, bucketCount: 30, balanceStep: 43_200 },
+};
+
+const toNumber = (value: unknown): number => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+const getRecord = (value: unknown): Record<string, unknown> =>
+  value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+
+const fetchJson = async <T>(path: string, signal?: AbortSignal): Promise<T> => {
+  const response = await fetch(`${TZKT_API}${path}`, {
+    signal,
+    headers: { Accept: "application/json" },
+  });
+
+  if (!response.ok) {
+    throw new Error(`TzKT request failed (${response.status})`);
+  }
+
+  return (await response.json()) as T;
+};
+
+const query = (values: Record<string, string | number>) => {
+  const params = new URLSearchParams();
+  Object.entries(values).forEach(([key, value]) =>
+    params.set(key, String(value))
+  );
+  return params.toString();
+};
+
+const poolFeeRate = (pool: PoolConfig, storage: Record<string, unknown>) => {
+  if (pool.type === PoolType.SIRIUS) return 0.001;
+  if (pool.type === PoolType.TEZEX) {
+    return 0.003 + toNumber(storage.protocol_fee_bp) / 10_000;
+  }
+  return 0;
+};
+
+const poolAmmMultiplier = (pool: PoolConfig) =>
+  pool.type === PoolType.SIRIUS ? 0.999 : 0.997;
+
+const currentPoolTvlXtz = (
+  pool: PoolConfig,
+  storage: Record<string, unknown>
+) => {
+  if (pool.tokenA !== Token.XTZ && pool.tokenB !== Token.XTZ) return 0;
+  return (toNumber(storage.xtzPool) * 2) / 1_000_000;
+};
+
+export const calculateSwapVolumeXtz = (
+  transaction: Pick<TzktTransaction, "amount" | "parameter" | "storage">,
+  pool: PoolConfig
+) => {
+  const entrypoint = transaction.parameter?.entrypoint;
+  if (entrypoint === "xtzToToken") {
+    return Math.max(0, transaction.amount / 1_000_000);
+  }
+
+  if (entrypoint !== "tokenToXtz") return 0;
+
+  const params = getRecord(transaction.parameter?.value);
+  const storage = getRecord(transaction.storage);
+  const tokensSold = toNumber(params.tokensSold);
+  const postTokenPool = toNumber(storage.tokenPool);
+  const postXtzPool = toNumber(storage.xtzPool);
+  const preTokenPool = postTokenPool - tokensSold;
+  if (tokensSold <= 0 || postXtzPool <= 0 || preTokenPool <= 0) return 0;
+
+  // The transaction storage is the state after the swap. For a constant-product
+  // pool, the XTZ removed is postXtzPool * effectiveInput / preTokenPool.
+  const effectiveInput = tokensSold * poolAmmMultiplier(pool);
+  return (postXtzPool * effectiveInput) / preTokenPool / 1_000_000;
+};
+
+const percentageDelta = (current: number, previous: number) =>
+  previous > 0 ? ((current - previous) / previous) * 100 : null;
+
+const dateAt = (timestamp: number) => new Date(timestamp).toISOString();
+
+const assetMap = (assets: Asset[]) =>
+  new Map<Token, Asset>(assets.map((asset) => [asset.name, asset]));
+
+const requireAsset = (assets: Map<Token, Asset>, token: Token) => {
+  const asset = assets.get(token);
+  if (!asset) throw new Error(`Missing analytics asset: ${token}`);
+  return asset;
+};
+
+const formatAssetAmount = (raw: number, asset: Asset) => {
+  const value = raw / 10 ** asset.decimals;
+  return `${new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: value >= 100 ? 1 : value >= 1 ? 3 : 6,
+  }).format(value)} ${asset.label}`;
+};
+
+const shortAddress = (address: string) =>
+  address.length > 12 ? `${address.slice(0, 6)}…${address.slice(-4)}` : address;
+
+const buildBuckets = (range: AnalyticsRange, now: number) => {
+  const config = RANGE_CONFIG[range];
+  const start = now - config.windowMs;
+  const width = config.windowMs / config.bucketCount;
+  return Array.from({ length: config.bucketCount }, (_, index) => ({
+    start: start + index * width,
+    end: start + (index + 1) * width,
+    timestamp: start + (index + 1) * width,
+  }));
+};
+
+export const buildSwapSeries = (
+  transactions: TzktTransaction[],
+  pools: PoolConfig[],
+  range: AnalyticsRange,
+  now: number,
+  feeRates: Map<string, number>
+) => {
+  const buckets = buildBuckets(range, now);
+  const poolByAddress = new Map(pools.map((pool) => [pool.address, pool]));
+  const volume = buckets.map((bucket) => ({
+    timestamp: bucket.timestamp,
+    value: 0,
+  }));
+  const fees = buckets.map((bucket) => ({
+    timestamp: bucket.timestamp,
+    value: 0,
+  }));
+
+  transactions.forEach((transaction) => {
+    const pool = poolByAddress.get(transaction.target.address);
+    if (!pool) return;
+    const timestamp = new Date(transaction.timestamp).getTime();
+    const index = buckets.findIndex(
+      (bucket) => timestamp >= bucket.start && timestamp < bucket.end
+    );
+    if (index < 0) return;
+
+    const transactionVolume = calculateSwapVolumeXtz(transaction, pool);
+    volume[index].value += transactionVolume;
+    fees[index].value += transactionVolume * (feeRates.get(pool.id) ?? 0);
+  });
+
+  return { Volume: volume, Fees: fees };
+};
+
+const valueAt = (history: TzktBalancePoint[], timestamp: number) => {
+  let selected = history[0]?.balance ?? 0;
+  for (const point of history) {
+    if (new Date(point.timestamp).getTime() > timestamp) break;
+    selected = point.balance;
+  }
+  return selected;
+};
+
+const buildTvlSeries = (
+  snapshots: PoolSnapshot[],
+  range: AnalyticsRange,
+  now: number
+) =>
+  buildBuckets(range, now).map((bucket) => ({
+    timestamp: bucket.timestamp,
+    value: snapshots.reduce((total, pool) => {
+      if (
+        pool.config.tokenA !== Token.XTZ &&
+        pool.config.tokenB !== Token.XTZ
+      ) {
+        return total;
+      }
+      return total + (valueAt(pool.balanceHistory, bucket.end) * 2) / 1_000_000;
+    }, 0),
+  }));
+
+const fetchTransactions = (
+  addresses: string[],
+  entrypoints: string[],
+  options: { since?: number; limit: number; sort: "asc" | "desc" },
+  signal?: AbortSignal
+) => {
+  const params: Record<string, string | number> = {
+    "target.in": addresses.join(","),
+    "entrypoint.in": entrypoints.join(","),
+    status: "applied",
+    limit: options.limit,
+    [`sort.${options.sort}`]: "id",
+    select: "id,timestamp,hash,counter,sender,target,amount,parameter,storage",
+  };
+  if (options.since) params["timestamp.ge"] = dateAt(options.since);
+  return fetchJson<TzktTransaction[]>(
+    `/operations/transactions?${query(params)}`,
+    signal
+  );
+};
+
+const fetchBalanceHistory = (
+  pool: PoolConfig,
+  range: AnalyticsRange,
+  signal?: AbortSignal
+) => {
+  const config = RANGE_CONFIG[range];
+  return fetchJson<TzktBalancePoint[]>(
+    `/accounts/${pool.address}/balance_history?${query({
+      step: config.balanceStep,
+      limit: config.bucketCount + 3,
+      "sort.desc": "level",
+    })}`,
+    signal
+  );
+};
+
+const activityFromTransaction = (
+  transaction: TzktTransaction,
+  pool: PoolConfig,
+  assets: Map<Token, Asset>
+): AnalyticsActivity | null => {
+  const entrypoint = transaction.parameter?.entrypoint;
+  const params = getRecord(transaction.parameter?.value);
+  const tokenA = requireAsset(assets, pool.tokenA);
+  const tokenB = requireAsset(assets, pool.tokenB);
+  const lpToken = requireAsset(assets, pool.lpToken);
+  let action: AnalyticsActivity["action"];
+  let direction: string;
+  let value: string;
+
+  if (entrypoint === "xtzToToken") {
+    action = "Swap";
+    direction = `${tokenA.label} → ${tokenB.label}`;
+    value = formatAssetAmount(transaction.amount, tokenA);
+  } else if (entrypoint === "tokenToXtz") {
+    action = "Swap";
+    direction = `${tokenB.label} → ${tokenA.label}`;
+    value = formatAssetAmount(toNumber(params.tokensSold), tokenB);
+  } else if (entrypoint === "addLiquidity") {
+    action = "Add";
+    direction = `${tokenA.label} + ${tokenB.label}`;
+    value = formatAssetAmount(transaction.amount, tokenA);
+  } else if (entrypoint === "removeLiquidity") {
+    action = "Remove";
+    direction = `${tokenA.label} + ${tokenB.label}`;
+    value = formatAssetAmount(toNumber(params.lqtBurned), lpToken);
+  } else {
+    return null;
+  }
+
+  return {
+    id: transaction.id,
+    action,
+    poolName: pool.name,
+    tokenA,
+    tokenB,
+    direction,
+    value,
+    account: transaction.sender.address,
+    accountLabel: transaction.sender.alias,
+    timestamp: new Date(transaction.timestamp).getTime(),
+    hash: transaction.hash,
+  };
+};
+
+export const loadAnalytics = async (
+  network: NetworkInfo,
+  range: AnalyticsRange,
+  signal?: AbortSignal
+): Promise<AnalyticsModel> => {
+  const pools = network.pools.filter(
+    (pool) => pool.tokenA === Token.XTZ || pool.tokenB === Token.XTZ
+  );
+  if (!pools.length) throw new Error("No XTZ pools are configured");
+
+  const assets = assetMap(network.assets);
+  const addresses = pools.map((pool) => pool.address);
+  const headPromise = fetchJson<TzktHead>("/head", signal);
+  const storagePromises = pools.map((pool) =>
+    fetchJson<Record<string, unknown>>(
+      `/contracts/${pool.address}/storage`,
+      signal
+    )
+  );
+  const balancePromises = pools.map((pool) =>
+    fetchBalanceHistory(pool, range, signal)
+  );
+  const preliminaryHead = await headPromise;
+  const now = new Date(preliminaryHead.timestamp).getTime();
+  const requestedSince = Math.min(
+    now - RANGE_CONFIG[range].windowMs,
+    now - 48 * HOUR
+  );
+
+  const [storages, balanceHistories, swaps, recentTransactions] =
+    await Promise.all([
+      Promise.all(storagePromises),
+      Promise.all(balancePromises),
+      fetchTransactions(
+        addresses,
+        SWAP_ENTRYPOINTS,
+        { since: requestedSince, limit: 10_000, sort: "asc" },
+        signal
+      ),
+      fetchTransactions(
+        addresses,
+        ACTIVITY_ENTRYPOINTS,
+        { limit: 16, sort: "desc" },
+        signal
+      ),
+    ]);
+
+  const snapshots: PoolSnapshot[] = pools.map((pool, index) => {
+    const storage = storages[index];
+    const currentBalance = toNumber(storage.xtzPool);
+    const history = [...balanceHistories[index]]
+      .sort(
+        (a, b) =>
+          new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+      )
+      .concat({
+        level: preliminaryHead.level,
+        timestamp: preliminaryHead.timestamp,
+        balance: currentBalance,
+      });
+    return {
+      config: pool,
+      tokenA: requireAsset(assets, pool.tokenA),
+      tokenB: requireAsset(assets, pool.tokenB),
+      storage,
+      balanceHistory: history,
+      feeRate: poolFeeRate(pool, storage),
+      currentTvlXtz: currentPoolTvlXtz(pool, storage),
+    };
+  });
+
+  const poolByAddress = new Map(pools.map((pool) => [pool.address, pool]));
+  const feeRates = new Map(
+    snapshots.map((snapshot) => [snapshot.config.id, snapshot.feeRate])
+  );
+  const series = buildSwapSeries(swaps, pools, range, now, feeRates);
+  const tvlSeries = buildTvlSeries(snapshots, range, now);
+  const currentStart = now - DAY;
+  const previousStart = now - 2 * DAY;
+  const currentSwaps = swaps.filter(
+    (transaction) => new Date(transaction.timestamp).getTime() >= currentStart
+  );
+  const previousSwaps = swaps.filter((transaction) => {
+    const timestamp = new Date(transaction.timestamp).getTime();
+    return timestamp >= previousStart && timestamp < currentStart;
+  });
+
+  const sumVolume = (transactions: TzktTransaction[]) =>
+    transactions.reduce((total, transaction) => {
+      const pool = poolByAddress.get(transaction.target.address);
+      return pool ? total + calculateSwapVolumeXtz(transaction, pool) : total;
+    }, 0);
+
+  const sumFees = (transactions: TzktTransaction[]) =>
+    transactions.reduce((total, transaction) => {
+      const pool = poolByAddress.get(transaction.target.address);
+      if (!pool) return total;
+      return (
+        total +
+        calculateSwapVolumeXtz(transaction, pool) * (feeRates.get(pool.id) ?? 0)
+      );
+    }, 0);
+
+  const volume24hXtz = sumVolume(currentSwaps);
+  const previousVolume = sumVolume(previousSwaps);
+  const fees24hXtz = sumFees(currentSwaps);
+  const previousFees = sumFees(previousSwaps);
+  const tvlXtz = snapshots.reduce(
+    (total, snapshot) => total + snapshot.currentTvlXtz,
+    0
+  );
+  const previousTvl = snapshots.reduce(
+    (total, snapshot) =>
+      total + (valueAt(snapshot.balanceHistory, currentStart) * 2) / 1_000_000,
+    0
+  );
+
+  const poolRows = snapshots.map((snapshot) => {
+    const poolSwaps = currentSwaps.filter(
+      (transaction) => transaction.target.address === snapshot.config.address
+    );
+    const volume = sumVolume(poolSwaps);
+    const fees = volume * snapshot.feeRate;
+    return {
+      id: snapshot.config.id,
+      name: snapshot.config.name,
+      address: snapshot.config.address,
+      tokenA: snapshot.tokenA,
+      tokenB: snapshot.tokenB,
+      tvlXtz: snapshot.currentTvlXtz,
+      volume24hXtz: volume,
+      fees24hXtz: fees,
+      apr:
+        snapshot.currentTvlXtz > 0
+          ? (fees * 365 * 100) / snapshot.currentTvlXtz
+          : null,
+    };
+  });
+
+  const activity = recentTransactions
+    .map((transaction) => {
+      const pool = poolByAddress.get(transaction.target.address);
+      return pool ? activityFromTransaction(transaction, pool, assets) : null;
+    })
+    .filter((item): item is AnalyticsActivity => item !== null)
+    .sort((a, b) => b.timestamp - a.timestamp)
+    .slice(0, 8);
+
+  return {
+    summary: {
+      tvlXtz,
+      tvlDelta: percentageDelta(tvlXtz, previousTvl),
+      volume24hXtz,
+      volumeDelta: percentageDelta(volume24hXtz, previousVolume),
+      fees24hXtz,
+      feesDelta: percentageDelta(fees24hXtz, previousFees),
+      swaps24h: currentSwaps.length,
+      swapsDelta: percentageDelta(currentSwaps.length, previousSwaps.length),
+    },
+    chart: { Volume: series.Volume, TVL: tvlSeries, Fees: series.Fees },
+    pools: poolRows,
+    activity,
+    blockLevel: preliminaryHead.level,
+    blockTimestamp: now,
+    loadedAt: Date.now(),
+  };
+};
+
+export const formatCompactXtz = (value: number) =>
+  `${new Intl.NumberFormat("en-US", {
+    notation: value >= 1_000 ? "compact" : "standard",
+    maximumFractionDigits: value >= 100 ? 1 : 2,
+  }).format(value)} XTZ`;
+
+export const formatDelta = (value: number | null) =>
+  value === null
+    ? "No prior activity"
+    : `${value >= 0 ? "+" : ""}${value.toFixed(1)}%`;
+
+export const formatAgo = (timestamp: number, now = Date.now()) => {
+  const seconds = Math.max(0, Math.floor((now - timestamp) / 1000));
+  if (seconds < 60) return `${seconds}s ago`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
+  if (seconds < 86_400) return `${Math.floor(seconds / 3600)}h ago`;
+  return `${Math.floor(seconds / 86_400)}d ago`;
+};
+
+export { shortAddress };

--- a/V2/tezex/src/pages/Analytics/api.ts
+++ b/V2/tezex/src/pages/Analytics/api.ts
@@ -2,9 +2,18 @@ import { NetworkInfo } from "../../contexts/network";
 import { Asset, Token } from "../../types/general";
 import { PoolConfig, PoolType } from "../../types/pools";
 
-export type AnalyticsRange = "24H" | "7D" | "30D" | "90D";
+export type AnalyticsRange = "24H" | "7D" | "30D" | "90D" | "6M" | "1Y";
 export type AnalyticsMetric = "Volume" | "TVL" | "Fees";
 export type AnalyticsCurrency = "XTZ" | "BTC" | "USD";
+
+export const ANALYTICS_RANGES: AnalyticsRange[] = [
+  "24H",
+  "7D",
+  "30D",
+  "90D",
+  "6M",
+  "1Y",
+];
 
 export interface AnalyticsQuote {
   btcPerXtz: number;
@@ -57,7 +66,7 @@ export interface AnalyticsActivity {
 
 export interface AnalyticsModel {
   summary: AnalyticsSummary;
-  chart: Record<AnalyticsMetric, AnalyticsPoint[]>;
+  chart: Record<AnalyticsRange, Record<AnalyticsMetric, AnalyticsPoint[]>>;
   pools: AnalyticsPool[];
   activity: AnalyticsActivity[];
   blockLevel: number;
@@ -109,7 +118,7 @@ interface PoolSnapshot {
   tokenA: Asset;
   tokenB: Asset;
   storage: Record<string, unknown>;
-  balanceHistory: TzktBalancePoint[];
+  balanceHistory: Record<AnalyticsRange, TzktBalancePoint[]>;
   feeRate: number;
   currentTvlXtz: number;
 }
@@ -135,6 +144,16 @@ export const RANGE_CONFIG: Record<AnalyticsRange, RangeConfig> = {
   "7D": { windowMs: 7 * DAY, bucketCount: 7, balanceStep: 14_400 },
   "30D": { windowMs: 30 * DAY, bucketCount: 30, balanceStep: 14_400 },
   "90D": { windowMs: 90 * DAY, bucketCount: 30, balanceStep: 43_200 },
+  "6M": { windowMs: 180 * DAY, bucketCount: 26, balanceStep: 57_600 },
+  "1Y": { windowMs: 365 * DAY, bucketCount: 52, balanceStep: 57_600 },
+};
+
+const BALANCE_HISTORY_RANGES: AnalyticsRange[] = ["24H", "30D", "1Y"];
+
+const balanceHistoryRangeFor = (range: AnalyticsRange): AnalyticsRange => {
+  if (range === "24H") return "24H";
+  if (range === "7D" || range === "30D") return "30D";
+  return "1Y";
 };
 
 const toNumber = (value: unknown): number => {
@@ -147,17 +166,43 @@ const getRecord = (value: unknown): Record<string, unknown> =>
     ? (value as Record<string, unknown>)
     : {};
 
-const fetchJson = async <T>(path: string, signal?: AbortSignal): Promise<T> => {
-  const response = await fetch(`${TZKT_API}${path}`, {
-    signal,
-    headers: { Accept: "application/json" },
+const wait = (duration: number, signal?: AbortSignal) =>
+  new Promise<void>((resolve, reject) => {
+    const timeout = window.setTimeout(resolve, duration);
+    signal?.addEventListener(
+      "abort",
+      () => {
+        window.clearTimeout(timeout);
+        reject(new DOMException("Analytics request cancelled", "AbortError"));
+      },
+      { once: true }
+    );
   });
 
-  if (!response.ok) {
+const fetchJson = async <T>(path: string, signal?: AbortSignal): Promise<T> => {
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    const response = await fetch(`${TZKT_API}${path}`, {
+      signal,
+      headers: { Accept: "application/json" },
+    });
+
+    if (response.ok) return (await response.json()) as T;
+
+    if (response.status === 429 && attempt < 3) {
+      const retryAfter = Number(response.headers.get("Retry-After"));
+      await wait(
+        Number.isFinite(retryAfter) && retryAfter > 0
+          ? retryAfter * 1_000
+          : 750 * 2 ** attempt,
+        signal
+      );
+      continue;
+    }
+
     throw new Error(`TzKT request failed (${response.status})`);
   }
 
-  return (await response.json()) as T;
+  throw new Error("TzKT request failed");
 };
 
 const query = (values: Record<string, string | number>) => {
@@ -317,14 +362,22 @@ const buildTvlSeries = (
       ) {
         return total;
       }
-      return total + (valueAt(pool.balanceHistory, bucket.end) * 2) / 1_000_000;
+      return (
+        total +
+        (valueAt(pool.balanceHistory[range], bucket.end) * 2) / 1_000_000
+      );
     }, 0),
   }));
 
 const fetchTransactions = (
   addresses: string[],
   entrypoints: string[],
-  options: { since?: number; limit: number; sort: "asc" | "desc" },
+  options: {
+    since?: number;
+    limit: number;
+    sort: "asc" | "desc";
+    select?: string;
+  },
   signal?: AbortSignal
 ) => {
   const params: Record<string, string | number> = {
@@ -333,7 +386,9 @@ const fetchTransactions = (
     status: "applied",
     limit: options.limit,
     [`sort.${options.sort}`]: "id",
-    select: "id,timestamp,hash,counter,sender,target,amount,parameter,storage",
+    select:
+      options.select ??
+      "id,timestamp,hash,counter,sender,target,amount,parameter,storage",
   };
   if (options.since) params["timestamp.ge"] = dateAt(options.since);
   return fetchJson<TzktTransaction[]>(
@@ -416,7 +471,6 @@ const activityFromTransaction = (
 
 export const loadAnalytics = async (
   network: NetworkInfo,
-  range: AnalyticsRange,
   signal?: AbortSignal
 ): Promise<AnalyticsModel> => {
   const pools = network.pools.filter(
@@ -434,25 +488,35 @@ export const loadAnalytics = async (
       signal
     )
   );
-  const balancePromises = pools.map((pool) =>
-    fetchBalanceHistory(pool, range, signal)
-  );
   const preliminaryHead = await headPromise;
   const now = new Date(preliminaryHead.timestamp).getTime();
-  const requestedSince = Math.min(
-    now - RANGE_CONFIG[range].windowMs,
-    now - 48 * HOUR
-  );
+  const requestedSince = now - RANGE_CONFIG["1Y"].windowMs;
+  const balanceHistoriesPromise = async () => {
+    const histories: TzktBalancePoint[][][] = [];
+    for (const range of BALANCE_HISTORY_RANGES) {
+      histories.push(
+        await Promise.all(
+          pools.map((pool) => fetchBalanceHistory(pool, range, signal))
+        )
+      );
+    }
+    return histories;
+  };
 
   const [quote, storages, balanceHistories, swaps, recentTransactions] =
     await Promise.all([
       quotePromise,
       Promise.all(storagePromises),
-      Promise.all(balancePromises),
+      balanceHistoriesPromise(),
       fetchTransactions(
         addresses,
         SWAP_ENTRYPOINTS,
-        { since: requestedSince, limit: 10_000, sort: "asc" },
+        {
+          since: requestedSince,
+          limit: 10_000,
+          sort: "desc",
+          select: "id,timestamp,target,amount,parameter,storage",
+        },
         signal
       ),
       fetchTransactions(
@@ -466,16 +530,25 @@ export const loadAnalytics = async (
   const snapshots: PoolSnapshot[] = pools.map((pool, index) => {
     const storage = storages[index];
     const currentBalance = toNumber(storage.xtzPool);
-    const history = [...balanceHistories[index]]
-      .sort(
-        (a, b) =>
-          new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
-      )
-      .concat({
-        level: preliminaryHead.level,
-        timestamp: preliminaryHead.timestamp,
-        balance: currentBalance,
-      });
+    const history = Object.fromEntries(
+      ANALYTICS_RANGES.map((range) => [
+        range,
+        [
+          ...balanceHistories[
+            BALANCE_HISTORY_RANGES.indexOf(balanceHistoryRangeFor(range))
+          ][index],
+        ]
+          .sort(
+            (a, b) =>
+              new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+          )
+          .concat({
+            level: preliminaryHead.level,
+            timestamp: preliminaryHead.timestamp,
+            balance: currentBalance,
+          }),
+      ])
+    ) as Record<AnalyticsRange, TzktBalancePoint[]>;
     return {
       config: pool,
       tokenA: requireAsset(assets, pool.tokenA),
@@ -491,8 +564,19 @@ export const loadAnalytics = async (
   const feeRates = new Map(
     snapshots.map((snapshot) => [snapshot.config.id, snapshot.feeRate])
   );
-  const series = buildSwapSeries(swaps, pools, range, now, feeRates);
-  const tvlSeries = buildTvlSeries(snapshots, range, now);
+  const chart = Object.fromEntries(
+    ANALYTICS_RANGES.map((range) => {
+      const series = buildSwapSeries(swaps, pools, range, now, feeRates);
+      return [
+        range,
+        {
+          Volume: series.Volume,
+          TVL: buildTvlSeries(snapshots, range, now),
+          Fees: series.Fees,
+        },
+      ];
+    })
+  ) as Record<AnalyticsRange, Record<AnalyticsMetric, AnalyticsPoint[]>>;
   const currentStart = now - DAY;
   const previousStart = now - 2 * DAY;
   const currentSwaps = swaps.filter(
@@ -529,7 +613,8 @@ export const loadAnalytics = async (
   );
   const previousTvl = snapshots.reduce(
     (total, snapshot) =>
-      total + (valueAt(snapshot.balanceHistory, currentStart) * 2) / 1_000_000,
+      total +
+      (valueAt(snapshot.balanceHistory["24H"], currentStart) * 2) / 1_000_000,
     0
   );
 
@@ -575,7 +660,7 @@ export const loadAnalytics = async (
       swaps24h: currentSwaps.length,
       swapsDelta: percentageDelta(currentSwaps.length, previousSwaps.length),
     },
-    chart: { Volume: series.Volume, TVL: tvlSeries, Fees: series.Fees },
+    chart,
     pools: poolRows,
     activity,
     blockLevel: preliminaryHead.level,

--- a/V2/tezex/src/pages/Analytics/index.tsx
+++ b/V2/tezex/src/pages/Analytics/index.tsx
@@ -1,0 +1,622 @@
+import React, {
+  FC,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { NetworkType } from "@airgap/beacon-sdk";
+import RefreshRoundedIcon from "@mui/icons-material/RefreshRounded";
+
+import { TokenPair } from "../../components/ui/elements/TokenIcon";
+import { useNetwork } from "../../hooks/network";
+import {
+  AnalyticsMetric,
+  AnalyticsModel,
+  AnalyticsPoint,
+  AnalyticsRange,
+  formatAgo,
+  formatCompactXtz,
+  formatDelta,
+  loadAnalytics,
+  shortAddress,
+} from "./api";
+import "./style.css";
+
+const METRICS: AnalyticsMetric[] = ["Volume", "TVL", "Fees"];
+const RANGES: AnalyticsRange[] = ["24H", "7D", "30D", "90D"];
+const CHART_WIDTH = 900;
+const CHART_HEIGHT = 300;
+const CHART_LEFT = 10;
+const CHART_RIGHT = 10;
+const CHART_TOP = 18;
+const CHART_BOTTOM = 34;
+
+const formatNumber = (value: number, maximumFractionDigits = 1) =>
+  new Intl.NumberFormat("en-US", { maximumFractionDigits }).format(value);
+
+const metricValue = (metric: AnalyticsMetric, value: number) => {
+  if (metric === "Fees") return formatCompactXtz(value);
+  return formatCompactXtz(value);
+};
+
+const chartDate = (timestamp: number, range: AnalyticsRange) =>
+  new Intl.DateTimeFormat(
+    "en-US",
+    range === "24H" ? { hour: "numeric" } : { month: "short", day: "numeric" }
+  ).format(timestamp);
+
+const deltaClass = (value: number | null) =>
+  value === null ? "is-neutral" : value >= 0 ? "is-positive" : "is-negative";
+
+interface StatProps {
+  label: string;
+  value: string;
+  delta: number | null;
+  deltaLabel?: string;
+}
+
+const Stat: FC<StatProps> = ({ label, value, delta, deltaLabel = "24h" }) => (
+  <div className="analytics-stat">
+    <span className="analytics-stat__label">{label}</span>
+    <strong className="analytics-stat__value">{value}</strong>
+    <span className={`analytics-stat__delta ${deltaClass(delta)}`}>
+      {formatDelta(delta)} {delta !== null && deltaLabel}
+    </span>
+  </div>
+);
+
+interface ChartProps {
+  metric: AnalyticsMetric;
+  range: AnalyticsRange;
+  points: AnalyticsPoint[];
+  loading: boolean;
+}
+
+const AnalyticsChart: FC<ChartProps> = ({ metric, range, points, loading }) => {
+  const [hoverIndex, setHoverIndex] = useState<number | null>(null);
+
+  useEffect(() => setHoverIndex(null), [metric, range]);
+
+  const geometry = useMemo(() => {
+    const values = points.map((point) => point.value);
+    const maximum = Math.max(...values, 1);
+    const minimum = metric === "TVL" ? Math.min(...values, maximum) : 0;
+    const floor = metric === "TVL" ? Math.max(0, minimum * 0.985) : 0;
+    const ceiling = Math.max(maximum * 1.025, floor + 1);
+    const chartHeight = CHART_HEIGHT - CHART_TOP - CHART_BOTTOM;
+    const width =
+      (CHART_WIDTH - CHART_LEFT - CHART_RIGHT) / Math.max(points.length, 1);
+    const y = (value: number) =>
+      CHART_TOP + (1 - (value - floor) / (ceiling - floor)) * chartHeight;
+    const line = points
+      .map(
+        (point, index) =>
+          `${index ? "L" : "M"}${(CHART_LEFT + width * (index + 0.5)).toFixed(
+            1
+          )},${y(point.value).toFixed(1)}`
+      )
+      .join(" ");
+    const area = points.length
+      ? `${line} L${(CHART_LEFT + width * (points.length - 0.5)).toFixed(1)},${
+          CHART_HEIGHT - CHART_BOTTOM
+        } L${(CHART_LEFT + width * 0.5).toFixed(1)},${
+          CHART_HEIGHT - CHART_BOTTOM
+        } Z`
+      : "";
+    return { width, y, line, area };
+  }, [metric, points]);
+
+  const activeIndex = hoverIndex ?? Math.max(0, points.length - 1);
+  const activePoint = points[activeIndex];
+
+  const indexAt = (clientX: number, element: SVGSVGElement) => {
+    const bounds = element.getBoundingClientRect();
+    const relative = ((clientX - bounds.left) / bounds.width) * CHART_WIDTH;
+    return Math.max(
+      0,
+      Math.min(
+        points.length - 1,
+        Math.floor((relative - CHART_LEFT) / geometry.width)
+      )
+    );
+  };
+
+  const labelIndexes = Array.from(
+    new Set([0, Math.floor((points.length - 1) / 2), points.length - 1])
+  ).filter((index) => index >= 0);
+
+  return (
+    <div className={`analytics-chart-shell ${loading ? "is-loading" : ""}`}>
+      <div className="analytics-chart-readout" aria-live="polite">
+        <strong>
+          {activePoint ? metricValue(metric, activePoint.value) : "—"}
+        </strong>
+        <span>
+          {activePoint
+            ? chartDate(activePoint.timestamp, range)
+            : "No activity"}
+        </span>
+      </div>
+      <div className="analytics-chart-frame">
+        <svg
+          className="analytics-chart"
+          viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}
+          width="100%"
+          role="img"
+          tabIndex={0}
+          aria-label={`${metric} over ${range}`}
+          onPointerMove={(event) =>
+            points.length &&
+            setHoverIndex(indexAt(event.clientX, event.currentTarget))
+          }
+          onPointerLeave={() => setHoverIndex(null)}
+          onBlur={() => setHoverIndex(null)}
+          onKeyDown={(event) => {
+            if (!points.length) return;
+            if (event.key === "ArrowLeft" || event.key === "ArrowRight") {
+              event.preventDefault();
+              const direction = event.key === "ArrowRight" ? 1 : -1;
+              setHoverIndex((current) =>
+                Math.max(
+                  0,
+                  Math.min(
+                    points.length - 1,
+                    (current ?? points.length - 1) + direction
+                  )
+                )
+              );
+            }
+            if (event.key === "Escape") setHoverIndex(null);
+          }}
+        >
+          {[0.25, 0.5, 0.75].map((fraction) => (
+            <line
+              key={fraction}
+              x1={CHART_LEFT}
+              y1={
+                CHART_TOP + fraction * (CHART_HEIGHT - CHART_TOP - CHART_BOTTOM)
+              }
+              x2={CHART_WIDTH - CHART_RIGHT}
+              y2={
+                CHART_TOP + fraction * (CHART_HEIGHT - CHART_TOP - CHART_BOTTOM)
+              }
+              className="analytics-chart__grid"
+            />
+          ))}
+          <line
+            x1={CHART_LEFT}
+            y1={CHART_HEIGHT - CHART_BOTTOM}
+            x2={CHART_WIDTH - CHART_RIGHT}
+            y2={CHART_HEIGHT - CHART_BOTTOM}
+            className="analytics-chart__baseline"
+          />
+
+          {metric === "TVL" ? (
+            <>
+              <path d={geometry.area} className="analytics-chart__area" />
+              <path d={geometry.line} className="analytics-chart__line" />
+            </>
+          ) : (
+            points.map((point, index) => {
+              const y = geometry.y(point.value);
+              const dense = geometry.width < 12;
+              return (
+                <rect
+                  key={point.timestamp}
+                  x={
+                    CHART_LEFT +
+                    geometry.width * index +
+                    geometry.width * (dense ? 0.12 : 0.18)
+                  }
+                  y={y}
+                  width={geometry.width * (dense ? 0.76 : 0.64)}
+                  height={Math.max(1, CHART_HEIGHT - CHART_BOTTOM - y)}
+                  rx={dense ? 1.5 : Math.min(4, geometry.width * 0.2)}
+                  className={
+                    hoverIndex === index
+                      ? "analytics-chart__bar is-active"
+                      : "analytics-chart__bar"
+                  }
+                />
+              );
+            })
+          )}
+
+          {hoverIndex !== null && points[hoverIndex] && (
+            <>
+              <line
+                x1={CHART_LEFT + geometry.width * (hoverIndex + 0.5)}
+                y1={CHART_TOP}
+                x2={CHART_LEFT + geometry.width * (hoverIndex + 0.5)}
+                y2={CHART_HEIGHT - CHART_BOTTOM}
+                className="analytics-chart__crosshair"
+              />
+              <circle
+                cx={CHART_LEFT + geometry.width * (hoverIndex + 0.5)}
+                cy={geometry.y(points[hoverIndex].value)}
+                r="5"
+                className="analytics-chart__point"
+              />
+            </>
+          )}
+
+          {labelIndexes.map((index) => (
+            <text
+              key={points[index]?.timestamp ?? index}
+              x={CHART_LEFT + geometry.width * (index + 0.5)}
+              y={CHART_HEIGHT - 10}
+              textAnchor={
+                index === 0
+                  ? "start"
+                  : index === points.length - 1
+                  ? "end"
+                  : "middle"
+              }
+              className="analytics-chart__label"
+            >
+              {points[index] ? chartDate(points[index].timestamp, range) : ""}
+            </text>
+          ))}
+        </svg>
+        {loading && (
+          <span className="analytics-chart-loading">Updating data</span>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export const Analytics: FC = () => {
+  const network = useNetwork();
+  const [metric, setMetric] = useState<AnalyticsMetric>("Volume");
+  const [range, setRange] = useState<AnalyticsRange>("7D");
+  const [model, setModel] = useState<AnalyticsModel>();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string>();
+  const [refreshKey, setRefreshKey] = useState(0);
+  const cache = useRef(new Map<string, AnalyticsModel>());
+  const refreshTarget = useRef<string>();
+
+  const isMainnet = network.network === NetworkType.MAINNET;
+  const cacheKey = `${network.info.chainId}:${range}`;
+
+  useEffect(() => {
+    if (!isMainnet) return;
+    const cached = cache.current.get(cacheKey);
+    const forceRefresh = refreshTarget.current === cacheKey;
+    if (cached && !forceRefresh) {
+      setModel(cached);
+      setError(undefined);
+      setLoading(false);
+      return;
+    }
+
+    refreshTarget.current = undefined;
+    let active = true;
+    setLoading(true);
+    setError(undefined);
+    void loadAnalytics(network.info, range)
+      .then((nextModel) => {
+        if (!active) return;
+        cache.current.set(cacheKey, nextModel);
+        setModel(nextModel);
+      })
+      .catch((reason: unknown) => {
+        if (!active) return;
+        setError(
+          reason instanceof Error
+            ? reason.message
+            : "Analytics data is temporarily unavailable"
+        );
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [cacheKey, isMainnet, network.info, range, refreshKey]);
+
+  const refresh = useCallback(() => {
+    cache.current.delete(cacheKey);
+    refreshTarget.current = cacheKey;
+    setRefreshKey((key) => key + 1);
+  }, [cacheKey]);
+
+  if (!isMainnet) {
+    return (
+      <main className="analytics-page">
+        <section className="analytics-unavailable">
+          <span className="analytics-eyebrow">ANALYTICS</span>
+          <h1>Mainnet data only</h1>
+          <p>
+            On-chain TEZEX analytics will appear here when this network has
+            active, verified pools.
+          </p>
+          <button onClick={() => network.switchNetwork(NetworkType.MAINNET)}>
+            View Mainnet analytics
+          </button>
+        </section>
+      </main>
+    );
+  }
+
+  if (!model && loading) {
+    return (
+      <main className="analytics-page" aria-busy="true">
+        <div className="analytics-intro">
+          <div>
+            <span className="analytics-eyebrow">ANALYTICS</span>
+            <h1>On-chain activity</h1>
+          </div>
+        </div>
+        <div className="analytics-skeleton" aria-label="Loading analytics">
+          <span />
+          <span />
+          <span />
+        </div>
+      </main>
+    );
+  }
+
+  if (!model) {
+    return (
+      <main className="analytics-page">
+        <section className="analytics-unavailable" role="alert">
+          <span className="analytics-eyebrow">ANALYTICS</span>
+          <h1>Data is temporarily unavailable</h1>
+          <p>{error ?? "TzKT did not return analytics data."}</p>
+          <button onClick={refresh}>Try again</button>
+        </section>
+      </main>
+    );
+  }
+
+  const { summary } = model;
+  const updated = new Intl.DateTimeFormat("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+  }).format(model.loadedAt);
+
+  return (
+    <main className="analytics-page">
+      <div className="analytics-intro">
+        <div>
+          <span className="analytics-eyebrow">ANALYTICS</span>
+          <h1>On-chain activity</h1>
+          <p>Verified activity and liquidity across TEZEX Mainnet pools.</p>
+        </div>
+        <div className="analytics-freshness">
+          <span>
+            <i /> Updated {updated}
+          </span>
+          <button
+            type="button"
+            onClick={refresh}
+            disabled={loading}
+            aria-label="Refresh analytics"
+          >
+            <RefreshRoundedIcon />
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="analytics-inline-error" role="status">
+          Showing the last successful update. {error}
+        </div>
+      )}
+
+      <section className="analytics-stats" aria-label="Market summary">
+        <Stat
+          label="Total liquidity"
+          value={formatCompactXtz(summary.tvlXtz)}
+          delta={summary.tvlDelta}
+        />
+        <Stat
+          label="Volume 24h"
+          value={formatCompactXtz(summary.volume24hXtz)}
+          delta={summary.volumeDelta}
+        />
+        <Stat
+          label="Pool fees 24h"
+          value={formatCompactXtz(summary.fees24hXtz)}
+          delta={summary.feesDelta}
+        />
+        <Stat
+          label="Swaps 24h"
+          value={formatNumber(summary.swaps24h, 0)}
+          delta={summary.swapsDelta}
+        />
+      </section>
+
+      <section
+        className="analytics-panel analytics-market"
+        aria-labelledby="market-chart-title"
+      >
+        <div className="analytics-panel__head">
+          <h2 id="market-chart-title">MARKET HISTORY</h2>
+          <div className="analytics-controls">
+            <div
+              className="analytics-segments"
+              role="group"
+              aria-label="Chart metric"
+            >
+              {METRICS.map((item) => (
+                <button
+                  key={item}
+                  type="button"
+                  className={metric === item ? "is-active" : ""}
+                  aria-pressed={metric === item}
+                  onClick={() => setMetric(item)}
+                >
+                  {item}
+                </button>
+              ))}
+            </div>
+            <div
+              className="analytics-segments"
+              role="group"
+              aria-label="Chart range"
+            >
+              {RANGES.map((item) => (
+                <button
+                  key={item}
+                  type="button"
+                  className={range === item ? "is-active" : ""}
+                  aria-pressed={range === item}
+                  onClick={() => setRange(item)}
+                >
+                  {item}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+        <AnalyticsChart
+          metric={metric}
+          range={range}
+          points={model.chart[metric]}
+          loading={loading}
+        />
+      </section>
+
+      <section className="analytics-panel" aria-labelledby="pools-title">
+        <div className="analytics-panel__head">
+          <h2 id="pools-title">POOLS</h2>
+          <span className="analytics-panel__meta">
+            Current reserves · 24h activity
+          </span>
+        </div>
+        <div className="analytics-table-wrap">
+          <table className="analytics-table analytics-pools-table">
+            <thead>
+              <tr>
+                <th>Pool</th>
+                <th>Liquidity</th>
+                <th>Volume 24h</th>
+                <th className="analytics-optional">Pool fees 24h</th>
+                <th>Est. APR</th>
+              </tr>
+            </thead>
+            <tbody>
+              {model.pools.map((pool) => (
+                <tr key={pool.id}>
+                  <td>
+                    <a
+                      className="analytics-pair"
+                      href={`https://tzkt.io/${pool.address}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      <TokenPair
+                        tokenA={pool.tokenA}
+                        tokenB={pool.tokenB}
+                        size={24}
+                        surface="var(--analytics-row-surface)"
+                      />
+                      <span>
+                        <strong>
+                          {pool.tokenA.label} / {pool.tokenB.label}
+                        </strong>
+                        <small>{pool.name}</small>
+                      </span>
+                    </a>
+                  </td>
+                  <td>{formatCompactXtz(pool.tvlXtz)}</td>
+                  <td>{formatCompactXtz(pool.volume24hXtz)}</td>
+                  <td className="analytics-optional">
+                    {formatCompactXtz(pool.fees24hXtz)}
+                  </td>
+                  <td>{pool.apr === null ? "—" : `${pool.apr.toFixed(2)}%`}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="analytics-panel" aria-labelledby="activity-title">
+        <div className="analytics-panel__head">
+          <h2 id="activity-title">RECENT ACTIVITY</h2>
+          <span className="analytics-panel__meta">Confirmed on Tezos</span>
+        </div>
+        <div className="analytics-table-wrap">
+          <table className="analytics-table analytics-activity-table">
+            <thead>
+              <tr>
+                <th>Action</th>
+                <th>Pair</th>
+                <th>Value</th>
+                <th className="analytics-optional">Account</th>
+                <th>Time</th>
+              </tr>
+            </thead>
+            <tbody>
+              {model.activity.length ? (
+                model.activity.map((activity) => (
+                  <tr key={activity.id}>
+                    <td>
+                      <span className="analytics-badge">{activity.action}</span>
+                    </td>
+                    <td>
+                      <span className="analytics-pair analytics-pair--plain">
+                        <TokenPair
+                          tokenA={activity.tokenA}
+                          tokenB={activity.tokenB}
+                          size={20}
+                          surface="var(--analytics-row-surface)"
+                        />
+                        <span>
+                          <strong>{activity.direction}</strong>
+                          <small>{activity.poolName}</small>
+                        </span>
+                      </span>
+                    </td>
+                    <td>{activity.value}</td>
+                    <td
+                      className="analytics-optional analytics-muted"
+                      title={activity.account}
+                    >
+                      {activity.accountLabel ?? shortAddress(activity.account)}
+                    </td>
+                    <td>
+                      <a
+                        className="analytics-operation"
+                        href={`https://tzkt.io/${activity.hash}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {formatAgo(activity.timestamp, model.loadedAt)}
+                      </a>
+                    </td>
+                  </tr>
+                ))
+              ) : (
+                <tr>
+                  <td colSpan={5} className="analytics-empty">
+                    No recent pool activity
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <div className="analytics-statusline">
+        <span>
+          <i /> TzKT synced
+        </span>
+        <span>Block {model.blockLevel.toLocaleString()}</span>
+        <span>Tezos Mainnet</span>
+      </div>
+    </main>
+  );
+};
+
+export default Analytics;

--- a/V2/tezex/src/pages/Analytics/index.tsx
+++ b/V2/tezex/src/pages/Analytics/index.tsx
@@ -12,12 +12,14 @@ import RefreshRoundedIcon from "@mui/icons-material/RefreshRounded";
 import { TokenPair } from "../../components/ui/elements/TokenIcon";
 import { useNetwork } from "../../hooks/network";
 import {
+  AnalyticsCurrency,
   AnalyticsMetric,
   AnalyticsModel,
   AnalyticsPoint,
+  AnalyticsQuote,
   AnalyticsRange,
   formatAgo,
-  formatCompactXtz,
+  formatDenominatedXtz,
   formatDelta,
   loadAnalytics,
   shortAddress,
@@ -26,6 +28,7 @@ import "./style.css";
 
 const METRICS: AnalyticsMetric[] = ["Volume", "TVL", "Fees"];
 const RANGES: AnalyticsRange[] = ["24H", "7D", "30D", "90D"];
+const CURRENCIES: AnalyticsCurrency[] = ["XTZ", "BTC", "USD"];
 const CHART_WIDTH = 900;
 const CHART_HEIGHT = 300;
 const CHART_LEFT = 10;
@@ -35,11 +38,6 @@ const CHART_BOTTOM = 34;
 
 const formatNumber = (value: number, maximumFractionDigits = 1) =>
   new Intl.NumberFormat("en-US", { maximumFractionDigits }).format(value);
-
-const metricValue = (metric: AnalyticsMetric, value: number) => {
-  if (metric === "Fees") return formatCompactXtz(value);
-  return formatCompactXtz(value);
-};
 
 const chartDate = (timestamp: number, range: AnalyticsRange) =>
   new Intl.DateTimeFormat(
@@ -71,10 +69,19 @@ interface ChartProps {
   metric: AnalyticsMetric;
   range: AnalyticsRange;
   points: AnalyticsPoint[];
+  currency: AnalyticsCurrency;
+  quote: AnalyticsQuote;
   loading: boolean;
 }
 
-const AnalyticsChart: FC<ChartProps> = ({ metric, range, points, loading }) => {
+const AnalyticsChart: FC<ChartProps> = ({
+  metric,
+  range,
+  points,
+  currency,
+  quote,
+  loading,
+}) => {
   const [hoverIndex, setHoverIndex] = useState<number | null>(null);
 
   useEffect(() => setHoverIndex(null), [metric, range]);
@@ -131,7 +138,9 @@ const AnalyticsChart: FC<ChartProps> = ({ metric, range, points, loading }) => {
     <div className={`analytics-chart-shell ${loading ? "is-loading" : ""}`}>
       <div className="analytics-chart-readout" aria-live="polite">
         <strong>
-          {activePoint ? metricValue(metric, activePoint.value) : "—"}
+          {activePoint
+            ? formatDenominatedXtz(activePoint.value, currency, quote)
+            : "—"}
         </strong>
         <span>
           {activePoint
@@ -272,6 +281,12 @@ export const Analytics: FC = () => {
   const network = useNetwork();
   const [metric, setMetric] = useState<AnalyticsMetric>("Volume");
   const [range, setRange] = useState<AnalyticsRange>("7D");
+  const [currency, setCurrency] = useState<AnalyticsCurrency>(() => {
+    const saved = window.localStorage.getItem("tezex-analytics-currency");
+    return CURRENCIES.includes(saved as AnalyticsCurrency)
+      ? (saved as AnalyticsCurrency)
+      : "XTZ";
+  });
   const [model, setModel] = useState<AnalyticsModel>();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string>();
@@ -281,6 +296,10 @@ export const Analytics: FC = () => {
 
   const isMainnet = network.network === NetworkType.MAINNET;
   const cacheKey = `${network.info.chainId}:${range}`;
+
+  useEffect(() => {
+    window.localStorage.setItem("tezex-analytics-currency", currency);
+  }, [currency]);
 
   useEffect(() => {
     if (!isMainnet) return;
@@ -390,18 +409,38 @@ export const Analytics: FC = () => {
           <h1>On-chain activity</h1>
           <p>Verified activity and liquidity across TEZEX Mainnet pools.</p>
         </div>
-        <div className="analytics-freshness">
-          <span>
-            <i /> Updated {updated}
-          </span>
-          <button
-            type="button"
-            onClick={refresh}
-            disabled={loading}
-            aria-label="Refresh analytics"
+        <div className="analytics-intro__tools">
+          <div
+            className={`analytics-segments analytics-denomination__segments is-${currency.toLowerCase()}`}
+            role="group"
+            aria-label="Display currency"
+            title="Conversions use the latest TzKT XTZ market quote"
           >
-            <RefreshRoundedIcon />
-          </button>
+            {CURRENCIES.map((item) => (
+              <button
+                key={item}
+                type="button"
+                className={currency === item ? "is-active" : ""}
+                aria-pressed={currency === item}
+                onClick={() => setCurrency(item)}
+              >
+                {item}
+              </button>
+            ))}
+          </div>
+          <div className="analytics-freshness">
+            <span>
+              <i /> Updated {updated}
+            </span>
+            <button
+              type="button"
+              onClick={refresh}
+              disabled={loading}
+              aria-label="Refresh analytics"
+            >
+              <RefreshRoundedIcon />
+            </button>
+          </div>
         </div>
       </div>
 
@@ -414,17 +453,25 @@ export const Analytics: FC = () => {
       <section className="analytics-stats" aria-label="Market summary">
         <Stat
           label="Total liquidity"
-          value={formatCompactXtz(summary.tvlXtz)}
+          value={formatDenominatedXtz(summary.tvlXtz, currency, model.quote)}
           delta={summary.tvlDelta}
         />
         <Stat
           label="Volume 24h"
-          value={formatCompactXtz(summary.volume24hXtz)}
+          value={formatDenominatedXtz(
+            summary.volume24hXtz,
+            currency,
+            model.quote
+          )}
           delta={summary.volumeDelta}
         />
         <Stat
           label="Pool fees 24h"
-          value={formatCompactXtz(summary.fees24hXtz)}
+          value={formatDenominatedXtz(
+            summary.fees24hXtz,
+            currency,
+            model.quote
+          )}
           delta={summary.feesDelta}
         />
         <Stat
@@ -481,6 +528,8 @@ export const Analytics: FC = () => {
           metric={metric}
           range={range}
           points={model.chart[metric]}
+          currency={currency}
+          quote={model.quote}
           loading={loading}
         />
       </section>
@@ -527,10 +576,22 @@ export const Analytics: FC = () => {
                       </span>
                     </a>
                   </td>
-                  <td>{formatCompactXtz(pool.tvlXtz)}</td>
-                  <td>{formatCompactXtz(pool.volume24hXtz)}</td>
+                  <td>
+                    {formatDenominatedXtz(pool.tvlXtz, currency, model.quote)}
+                  </td>
+                  <td>
+                    {formatDenominatedXtz(
+                      pool.volume24hXtz,
+                      currency,
+                      model.quote
+                    )}
+                  </td>
                   <td className="analytics-optional">
-                    {formatCompactXtz(pool.fees24hXtz)}
+                    {formatDenominatedXtz(
+                      pool.fees24hXtz,
+                      currency,
+                      model.quote
+                    )}
                   </td>
                   <td>{pool.apr === null ? "—" : `${pool.apr.toFixed(2)}%`}</td>
                 </tr>
@@ -558,44 +619,65 @@ export const Analytics: FC = () => {
             </thead>
             <tbody>
               {model.activity.length ? (
-                model.activity.map((activity) => (
-                  <tr key={activity.id}>
-                    <td>
-                      <span className="analytics-badge">{activity.action}</span>
-                    </td>
-                    <td>
-                      <span className="analytics-pair analytics-pair--plain">
-                        <TokenPair
-                          tokenA={activity.tokenA}
-                          tokenB={activity.tokenB}
-                          size={20}
-                          surface="var(--analytics-row-surface)"
-                        />
-                        <span>
-                          <strong>{activity.direction}</strong>
-                          <small>{activity.poolName}</small>
+                model.activity.map((activity) => {
+                  const displayValue = formatDenominatedXtz(
+                    activity.valueXtz,
+                    currency,
+                    model.quote
+                  );
+                  return (
+                    <tr key={activity.id}>
+                      <td>
+                        <span className="analytics-badge">
+                          {activity.action}
                         </span>
-                      </span>
-                    </td>
-                    <td>{activity.value}</td>
-                    <td
-                      className="analytics-optional analytics-muted"
-                      title={activity.account}
-                    >
-                      {activity.accountLabel ?? shortAddress(activity.account)}
-                    </td>
-                    <td>
-                      <a
-                        className="analytics-operation"
-                        href={`https://tzkt.io/${activity.hash}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
+                      </td>
+                      <td>
+                        <span className="analytics-pair analytics-pair--plain">
+                          <TokenPair
+                            tokenA={activity.tokenA}
+                            tokenB={activity.tokenB}
+                            size={20}
+                            surface="var(--analytics-row-surface)"
+                          />
+                          <span>
+                            <strong>{activity.direction}</strong>
+                            <small>
+                              {activity.poolName}
+                              <span className="analytics-mobile-value">
+                                {" · "}
+                                {displayValue}
+                              </span>
+                            </small>
+                          </span>
+                        </span>
+                      </td>
+                      <td>
+                        <span className="analytics-activity-value">
+                          <strong>{displayValue}</strong>
+                          <small>{activity.value}</small>
+                        </span>
+                      </td>
+                      <td
+                        className="analytics-optional analytics-muted"
+                        title={activity.account}
                       >
-                        {formatAgo(activity.timestamp, model.loadedAt)}
-                      </a>
-                    </td>
-                  </tr>
-                ))
+                        {activity.accountLabel ??
+                          shortAddress(activity.account)}
+                      </td>
+                      <td>
+                        <a
+                          className="analytics-operation"
+                          href={`https://tzkt.io/${activity.hash}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          {formatAgo(activity.timestamp, model.loadedAt)}
+                        </a>
+                      </td>
+                    </tr>
+                  );
+                })
               ) : (
                 <tr>
                   <td colSpan={5} className="analytics-empty">
@@ -613,6 +695,7 @@ export const Analytics: FC = () => {
           <i /> TzKT synced
         </span>
         <span>Block {model.blockLevel.toLocaleString()}</span>
+        <span>Rates {formatAgo(model.quote.timestamp, model.loadedAt)}</span>
         <span>Tezos Mainnet</span>
       </div>
     </main>

--- a/V2/tezex/src/pages/Analytics/index.tsx
+++ b/V2/tezex/src/pages/Analytics/index.tsx
@@ -1,4 +1,5 @@
 import React, {
+  CSSProperties,
   FC,
   useCallback,
   useEffect,
@@ -12,6 +13,7 @@ import RefreshRoundedIcon from "@mui/icons-material/RefreshRounded";
 import { TokenPair } from "../../components/ui/elements/TokenIcon";
 import { useNetwork } from "../../hooks/network";
 import {
+  ANALYTICS_RANGES,
   AnalyticsCurrency,
   AnalyticsMetric,
   AnalyticsModel,
@@ -27,7 +29,6 @@ import {
 import "./style.css";
 
 const METRICS: AnalyticsMetric[] = ["Volume", "TVL", "Fees"];
-const RANGES: AnalyticsRange[] = ["24H", "7D", "30D", "90D"];
 const CURRENCIES: AnalyticsCurrency[] = ["XTZ", "BTC", "USD"];
 const CHART_WIDTH = 900;
 const CHART_HEIGHT = 300;
@@ -43,6 +44,16 @@ const chartDate = (timestamp: number, range: AnalyticsRange) =>
   new Intl.DateTimeFormat(
     "en-US",
     range === "24H" ? { hour: "numeric" } : { month: "short", day: "numeric" }
+  ).format(timestamp);
+
+const rangeBoundaryDate = (timestamp: number, range: AnalyticsRange) =>
+  new Intl.DateTimeFormat(
+    "en-US",
+    range === "24H"
+      ? { month: "short", day: "numeric", hour: "numeric" }
+      : range === "1Y"
+      ? { month: "short", day: "numeric", year: "numeric" }
+      : { month: "short", day: "numeric" }
   ).format(timestamp);
 
 const deltaClass = (value: number | null) =>
@@ -74,6 +85,114 @@ interface ChartProps {
   loading: boolean;
 }
 
+interface RangeWindow {
+  start: number;
+  end: number;
+}
+
+interface RangeScrubberProps {
+  points: AnalyticsPoint[];
+  range: AnalyticsRange;
+  window: RangeWindow;
+  onChange: (window: RangeWindow) => void;
+}
+
+const RangeScrubber: FC<RangeScrubberProps> = ({
+  points,
+  range,
+  window,
+  onChange,
+}) => {
+  const maximumIndex = Math.max(0, points.length - 1);
+  const start = Math.min(window.start, Math.max(0, maximumIndex - 1));
+  const end = Math.max(start + 1, Math.min(window.end, maximumIndex));
+  const divisor = Math.max(1, maximumIndex);
+  const maximumValue = Math.max(...points.map((point) => point.value), 1);
+  const fullRange = start === 0 && end === maximumIndex;
+  const style = {
+    "--range-start": `${(start / divisor) * 100}%`,
+    "--range-end": `${(end / divisor) * 100}%`,
+  } as CSSProperties;
+
+  if (points.length < 2) return null;
+
+  return (
+    <div className="analytics-range-scrubber">
+      <div className="analytics-range-scrubber__meta">
+        <span>VISIBLE RANGE</span>
+        <strong>
+          {rangeBoundaryDate(points[start].timestamp, range)} —{" "}
+          {rangeBoundaryDate(points[end].timestamp, range)}
+        </strong>
+        {!fullRange && (
+          <button
+            type="button"
+            onClick={() => onChange({ start: 0, end: maximumIndex })}
+          >
+            Reset
+          </button>
+        )}
+      </div>
+      <div className="analytics-range-scrubber__track" style={style}>
+        <div className="analytics-range-scrubber__overview" aria-hidden="true">
+          {points.map((point) => (
+            <span
+              key={point.timestamp}
+              style={
+                {
+                  "--overview-height": `${Math.max(
+                    8,
+                    (point.value / maximumValue) * 100
+                  )}%`,
+                } as CSSProperties
+              }
+            />
+          ))}
+        </div>
+        <span className="analytics-range-scrubber__selection" />
+        <input
+          type="range"
+          min={0}
+          max={maximumIndex}
+          value={start}
+          aria-label="Visible range start"
+          onChange={(event) =>
+            onChange({
+              start: Math.min(Number(event.target.value), end - 1),
+              end,
+            })
+          }
+          onInput={(event) =>
+            onChange({
+              start: Math.min(Number(event.currentTarget.value), end - 1),
+              end,
+            })
+          }
+        />
+        <input
+          type="range"
+          min={0}
+          max={maximumIndex}
+          value={end}
+          aria-label="Visible range end"
+          onChange={(event) =>
+            onChange({
+              start,
+              end: Math.max(Number(event.target.value), start + 1),
+            })
+          }
+          onInput={(event) =>
+            onChange({
+              start,
+              end: Math.max(Number(event.currentTarget.value), start + 1),
+            })
+          }
+        />
+      </div>
+    </div>
+  );
+};
+
 const AnalyticsChart: FC<ChartProps> = ({
   metric,
   range,
@@ -84,7 +203,7 @@ const AnalyticsChart: FC<ChartProps> = ({
 }) => {
   const [hoverIndex, setHoverIndex] = useState<number | null>(null);
 
-  useEffect(() => setHoverIndex(null), [metric, range]);
+  useEffect(() => setHoverIndex(null), [metric, points, range]);
 
   const geometry = useMemo(() => {
     const values = points.map((point) => point.value);
@@ -281,6 +400,10 @@ export const Analytics: FC = () => {
   const network = useNetwork();
   const [metric, setMetric] = useState<AnalyticsMetric>("Volume");
   const [range, setRange] = useState<AnalyticsRange>("7D");
+  const [rangeWindow, setRangeWindow] = useState<RangeWindow>({
+    start: 0,
+    end: 6,
+  });
   const [currency, setCurrency] = useState<AnalyticsCurrency>(() => {
     const saved = window.localStorage.getItem("tezex-analytics-currency");
     return CURRENCIES.includes(saved as AnalyticsCurrency)
@@ -295,7 +418,7 @@ export const Analytics: FC = () => {
   const refreshTarget = useRef<string>();
 
   const isMainnet = network.network === NetworkType.MAINNET;
-  const cacheKey = `${network.info.chainId}:${range}`;
+  const cacheKey = network.info.chainId;
 
   useEffect(() => {
     window.localStorage.setItem("tezex-analytics-currency", currency);
@@ -316,7 +439,7 @@ export const Analytics: FC = () => {
     let active = true;
     setLoading(true);
     setError(undefined);
-    void loadAnalytics(network.info, range)
+    void loadAnalytics(network.info)
       .then((nextModel) => {
         if (!active) return;
         cache.current.set(cacheKey, nextModel);
@@ -337,13 +460,33 @@ export const Analytics: FC = () => {
     return () => {
       active = false;
     };
-  }, [cacheKey, isMainnet, network.info, range, refreshKey]);
+  }, [cacheKey, isMainnet, network.info, refreshKey]);
+
+  useEffect(() => {
+    if (!model) return;
+    setRangeWindow({
+      start: 0,
+      end: Math.max(0, model.chart[range].Volume.length - 1),
+    });
+  }, [model, range]);
 
   const refresh = useCallback(() => {
     cache.current.delete(cacheKey);
     refreshTarget.current = cacheKey;
     setRefreshKey((key) => key + 1);
   }, [cacheKey]);
+
+  const selectRange = useCallback(
+    (nextRange: AnalyticsRange) => {
+      setRange(nextRange);
+      if (!model) return;
+      setRangeWindow({
+        start: 0,
+        end: Math.max(0, model.chart[nextRange].Volume.length - 1),
+      });
+    },
+    [model]
+  );
 
   if (!isMainnet) {
     return (
@@ -395,6 +538,11 @@ export const Analytics: FC = () => {
   }
 
   const { summary } = model;
+  const selectedSeries = model.chart[range][metric];
+  const visiblePoints = selectedSeries.slice(
+    Math.min(rangeWindow.start, Math.max(0, selectedSeries.length - 1)),
+    Math.min(rangeWindow.end + 1, selectedSeries.length)
+  );
   const updated = new Intl.DateTimeFormat("en-US", {
     hour: "numeric",
     minute: "2-digit",
@@ -510,13 +658,13 @@ export const Analytics: FC = () => {
               role="group"
               aria-label="Chart range"
             >
-              {RANGES.map((item) => (
+              {ANALYTICS_RANGES.map((item) => (
                 <button
                   key={item}
                   type="button"
                   className={range === item ? "is-active" : ""}
                   aria-pressed={range === item}
-                  onClick={() => setRange(item)}
+                  onClick={() => selectRange(item)}
                 >
                   {item}
                 </button>
@@ -527,10 +675,16 @@ export const Analytics: FC = () => {
         <AnalyticsChart
           metric={metric}
           range={range}
-          points={model.chart[metric]}
+          points={visiblePoints}
           currency={currency}
           quote={model.quote}
           loading={loading}
+        />
+        <RangeScrubber
+          points={selectedSeries}
+          range={range}
+          window={rangeWindow}
+          onChange={setRangeWindow}
         />
       </section>
 

--- a/V2/tezex/src/pages/Analytics/style.css
+++ b/V2/tezex/src/pages/Analytics/style.css
@@ -1,0 +1,778 @@
+.analytics-page {
+  --analytics-row-surface: var(--tezex-panel);
+  width: 100%;
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 34px 28px 20px;
+  color: var(--tezex-text);
+  animation: analytics-enter 360ms cubic-bezier(0.22, 0.8, 0.24, 1) both;
+}
+
+.analytics-page button,
+.analytics-page a {
+  -webkit-tap-highlight-color: transparent;
+}
+
+.analytics-intro {
+  min-height: 92px;
+  margin-bottom: 24px;
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.analytics-eyebrow,
+.analytics-panel__head h2 {
+  display: block;
+  color: var(--tezex-muted);
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: 0.22em;
+}
+
+.analytics-intro h1,
+.analytics-unavailable h1 {
+  margin: 9px 0 0;
+  font-size: clamp(28px, 4vw, 42px);
+  font-weight: 650;
+  line-height: 1.02;
+  letter-spacing: -0.035em;
+}
+
+.analytics-intro p,
+.analytics-unavailable p {
+  margin: 10px 0 0;
+  color: var(--tezex-muted);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.analytics-freshness {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--tezex-muted);
+  font-family: "Red Hat Mono", monospace;
+  font-size: 11px;
+}
+
+.analytics-freshness > span,
+.analytics-statusline span:first-child {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.analytics-freshness i,
+.analytics-statusline i {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--tezex-positive);
+  box-shadow: 0 0 0 5px
+    color-mix(in srgb, var(--tezex-positive) 12%, transparent);
+  animation: analytics-live 2.4s ease-in-out infinite;
+}
+
+.analytics-freshness button {
+  width: 34px;
+  height: 34px;
+  padding: 0;
+  display: grid;
+  place-items: center;
+  color: var(--tezex-muted);
+  background: var(--tezex-panel);
+  border: 1px solid var(--tezex-line);
+  border-radius: 50%;
+  cursor: pointer;
+  transition: color 160ms ease, border-color 160ms ease, transform 160ms ease;
+}
+
+.analytics-freshness button:hover {
+  color: var(--tezex-text);
+  border-color: var(--tezex-line-strong);
+  transform: rotate(20deg);
+}
+
+.analytics-freshness button:disabled {
+  cursor: wait;
+  opacity: 0.55;
+}
+
+.analytics-freshness svg {
+  width: 17px;
+  height: 17px;
+}
+
+.analytics-inline-error {
+  margin-bottom: 16px;
+  padding: 10px 14px;
+  color: var(--tezex-text-secondary);
+  background: var(--tezex-panel-subtle);
+  border: 1px solid var(--tezex-line);
+  border-radius: 12px;
+  font-size: 12px;
+}
+
+.analytics-stats {
+  margin-bottom: 20px;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  overflow: hidden;
+  background: var(--tezex-panel);
+  border: 1px solid var(--tezex-line);
+  border-radius: 22px;
+}
+
+.analytics-stat {
+  min-width: 0;
+  padding: 20px 22px 18px;
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--tezex-line);
+}
+
+.analytics-stat:last-child {
+  border-right: 0;
+}
+
+.analytics-stat__label {
+  overflow: hidden;
+  color: var(--tezex-muted);
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1.2;
+  letter-spacing: 0.16em;
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.analytics-stat__value {
+  margin-top: 9px;
+  overflow: hidden;
+  font-family: "Red Hat Mono", monospace;
+  font-size: clamp(18px, 2.2vw, 24px);
+  font-weight: 500;
+  line-height: 1.15;
+  letter-spacing: -0.035em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.analytics-stat__delta {
+  margin-top: 6px;
+  font-family: "Red Hat Mono", monospace;
+  font-size: 10px;
+}
+
+.analytics-stat__delta.is-positive {
+  color: var(--tezex-positive);
+}
+
+.analytics-stat__delta.is-negative {
+  color: #e8786d;
+}
+
+.analytics-stat__delta.is-neutral {
+  color: var(--tezex-faint);
+}
+
+.analytics-panel {
+  --analytics-row-surface: var(--tezex-panel);
+  margin-bottom: 20px;
+  overflow: hidden;
+  background: var(--tezex-panel);
+  border: 1px solid var(--tezex-line);
+  border-radius: 22px;
+}
+
+.analytics-panel__head {
+  min-height: 58px;
+  padding: 12px 20px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  border-bottom: 1px solid var(--tezex-line);
+}
+
+.analytics-panel__head h2 {
+  margin: 0;
+  color: var(--tezex-text-secondary);
+}
+
+.analytics-panel__meta {
+  color: var(--tezex-faint);
+  font-size: 11px;
+}
+
+.analytics-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.analytics-segments {
+  padding: 3px;
+  display: inline-flex;
+  gap: 2px;
+  background: var(--tezex-panel-subtle);
+  border: 1px solid var(--tezex-line);
+  border-radius: 999px;
+}
+
+.analytics-segments button {
+  min-height: 28px;
+  padding: 0 11px;
+  color: var(--tezex-muted);
+  background: transparent;
+  border: 0;
+  border-radius: 999px;
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: 0.04em;
+  transition: color 160ms ease,
+    background-color 200ms cubic-bezier(0.22, 0.8, 0.24, 1);
+}
+
+.analytics-segments button:hover {
+  color: var(--tezex-text);
+}
+
+.analytics-segments button.is-active {
+  color: var(--tezex-action-text);
+  background: var(--tezex-action);
+}
+
+.analytics-chart-shell {
+  transition: opacity 180ms ease;
+}
+
+.analytics-chart-shell.is-loading {
+  opacity: 0.74;
+}
+
+.analytics-chart-readout {
+  min-height: 74px;
+  padding: 18px 22px 0;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.analytics-chart-readout strong {
+  font-family: "Red Hat Mono", monospace;
+  font-size: clamp(24px, 3vw, 32px);
+  font-weight: 500;
+  line-height: 1;
+  letter-spacing: -0.04em;
+}
+
+.analytics-chart-readout span {
+  margin-top: 6px;
+  color: var(--tezex-muted);
+  font-family: "Red Hat Mono", monospace;
+  font-size: 10px;
+}
+
+.analytics-chart-frame {
+  position: relative;
+  padding: 0 14px 8px;
+}
+
+.analytics-chart {
+  display: block;
+  touch-action: pan-y;
+}
+
+.analytics-chart:focus-visible,
+.analytics-segments button:focus-visible,
+.analytics-freshness button:focus-visible,
+.analytics-unavailable button:focus-visible,
+.analytics-pair:focus-visible,
+.analytics-operation:focus-visible {
+  outline: 2px solid var(--tezex-text-secondary);
+  outline-offset: 3px;
+}
+
+.analytics-chart__grid {
+  stroke: var(--tezex-line);
+  stroke-dasharray: 3 6;
+}
+
+.analytics-chart__baseline {
+  stroke: var(--tezex-line-strong);
+}
+
+.analytics-chart__area {
+  fill: color-mix(in srgb, var(--tezex-text) 7%, transparent);
+  animation: analytics-chart-in 360ms ease both;
+}
+
+.analytics-chart__line {
+  fill: none;
+  stroke: var(--tezex-text);
+  stroke-width: 2.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  animation: analytics-chart-in 360ms ease both;
+}
+
+.analytics-chart__bar {
+  fill: color-mix(in srgb, var(--tezex-text) 12%, transparent);
+  stroke: color-mix(in srgb, var(--tezex-text) 48%, transparent);
+  stroke-width: 1.4;
+  transition: fill 120ms ease, stroke 120ms ease;
+  animation: analytics-bar-in 300ms cubic-bezier(0.22, 0.8, 0.24, 1) both;
+  transform-origin: center bottom;
+}
+
+.analytics-chart__bar.is-active {
+  fill: var(--tezex-text);
+  stroke: var(--tezex-text);
+}
+
+.analytics-chart__crosshair {
+  stroke: var(--tezex-text-secondary);
+  stroke-width: 1;
+  stroke-dasharray: 3 5;
+}
+
+.analytics-chart__point {
+  fill: var(--tezex-text);
+  stroke: var(--tezex-panel);
+  stroke-width: 3;
+}
+
+.analytics-chart__label {
+  fill: var(--tezex-muted);
+  font-family: "Red Hat Mono", monospace;
+  font-size: 10px;
+}
+
+.analytics-chart-loading {
+  position: absolute;
+  right: 26px;
+  bottom: 24px;
+  padding: 5px 9px;
+  color: var(--tezex-text-secondary);
+  background: var(--tezex-panel-subtle);
+  border: 1px solid var(--tezex-line);
+  border-radius: 999px;
+  font-family: "Red Hat Mono", monospace;
+  font-size: 9px;
+}
+
+.analytics-table-wrap {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.analytics-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.analytics-table th,
+.analytics-table td {
+  padding: 13px 20px;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.analytics-table th:first-child,
+.analytics-table td:first-child {
+  text-align: left;
+}
+
+.analytics-table th {
+  color: var(--tezex-muted);
+  border-bottom: 1px solid var(--tezex-line);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.analytics-table td {
+  --analytics-row-surface: var(--tezex-panel);
+  color: var(--tezex-text-secondary);
+  border-bottom: 1px solid var(--tezex-line);
+  font-family: "Red Hat Mono", monospace;
+  font-size: 11px;
+}
+
+.analytics-table tr:last-child td {
+  border-bottom: 0;
+}
+
+.analytics-table tbody tr {
+  transition: background-color 140ms ease;
+}
+
+.analytics-table tbody tr:hover td {
+  --analytics-row-surface: var(--tezex-hover);
+  background: var(--tezex-hover);
+}
+
+.analytics-pair {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--tezex-text);
+  font-family: Inter, sans-serif;
+  text-decoration: none;
+}
+
+.analytics-pair > span:last-child {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+}
+
+.analytics-pair strong {
+  font-size: 12px;
+  font-weight: 650;
+  line-height: 1.1;
+}
+
+.analytics-pair small {
+  color: var(--tezex-muted);
+  font-size: 9px;
+  font-weight: 500;
+  line-height: 1.1;
+}
+
+.analytics-pair--plain {
+  justify-content: flex-end;
+}
+
+.analytics-badge {
+  display: inline-flex;
+  padding: 4px 9px;
+  color: var(--tezex-text-secondary);
+  border: 1px solid var(--tezex-line-strong);
+  border-radius: 999px;
+  font-family: Inter, sans-serif;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.analytics-muted {
+  color: var(--tezex-muted) !important;
+}
+
+.analytics-operation {
+  color: var(--tezex-text-secondary);
+  text-underline-offset: 3px;
+}
+
+.analytics-operation:hover {
+  color: var(--tezex-text);
+}
+
+.analytics-empty {
+  padding: 30px !important;
+  color: var(--tezex-faint) !important;
+  text-align: center !important;
+}
+
+.analytics-statusline {
+  padding: 4px 2px 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  color: var(--tezex-faint);
+  font-family: "Red Hat Mono", monospace;
+  font-size: 9px;
+}
+
+.analytics-statusline i {
+  width: 6px;
+  height: 6px;
+  box-shadow: none;
+}
+
+.analytics-unavailable {
+  max-width: 720px;
+  margin: 44px auto 0;
+  padding: 42px;
+  background: var(--tezex-panel);
+  border: 1px solid var(--tezex-line);
+  border-radius: 24px;
+}
+
+.analytics-unavailable button {
+  min-height: 42px;
+  margin-top: 24px;
+  padding: 0 20px;
+  color: var(--tezex-action-text);
+  background: var(--tezex-action);
+  border: 0;
+  border-radius: 999px;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.analytics-skeleton {
+  display: grid;
+  gap: 20px;
+}
+
+.analytics-skeleton span {
+  height: 112px;
+  overflow: hidden;
+  background: var(--tezex-panel);
+  border: 1px solid var(--tezex-line);
+  border-radius: 22px;
+  position: relative;
+}
+
+.analytics-skeleton span:nth-child(2) {
+  height: 390px;
+}
+
+.analytics-skeleton span::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    var(--tezex-hover),
+    transparent
+  );
+  transform: translateX(-100%);
+  animation: analytics-shimmer 1.4s ease-in-out infinite;
+}
+
+@media (max-width: 820px) {
+  .analytics-page {
+    padding: 28px 20px 16px;
+  }
+
+  .analytics-stats {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .analytics-stat:nth-child(2) {
+    border-right: 0;
+  }
+
+  .analytics-stat:nth-child(-n + 2) {
+    border-bottom: 1px solid var(--tezex-line);
+  }
+
+  .analytics-panel__head {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .analytics-market .analytics-panel__head {
+    padding-bottom: 14px;
+  }
+
+  .analytics-controls {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .analytics-table th,
+  .analytics-table td {
+    padding: 12px 16px;
+  }
+
+  .analytics-optional {
+    display: none;
+  }
+}
+
+@media (max-width: 560px) {
+  .analytics-page {
+    padding: 24px 16px 12px;
+  }
+
+  .analytics-intro {
+    min-height: 80px;
+    margin-bottom: 18px;
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 14px;
+  }
+
+  .analytics-intro h1 {
+    font-size: 30px;
+  }
+
+  .analytics-freshness {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .analytics-stats,
+  .analytics-panel {
+    margin-bottom: 14px;
+    border-radius: 18px;
+  }
+
+  .analytics-stat {
+    min-height: 102px;
+    padding: 16px;
+  }
+
+  .analytics-stat__value {
+    font-size: 18px;
+  }
+
+  .analytics-panel__head {
+    min-height: 52px;
+    padding: 13px 15px;
+  }
+
+  .analytics-controls {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .analytics-segments {
+    width: 100%;
+  }
+
+  .analytics-segments button {
+    flex: 1;
+    min-width: 0;
+    padding: 0 7px;
+  }
+
+  .analytics-chart-readout {
+    min-height: 66px;
+    padding: 15px 16px 0;
+  }
+
+  .analytics-chart-frame {
+    padding: 0 6px 6px;
+  }
+
+  .analytics-chart-loading {
+    right: 14px;
+    bottom: 18px;
+  }
+
+  .analytics-panel__meta {
+    display: none;
+  }
+
+  .analytics-table th,
+  .analytics-table td {
+    padding: 11px 13px;
+  }
+
+  .analytics-table th {
+    font-size: 8px;
+  }
+
+  .analytics-table td {
+    font-size: 10px;
+  }
+
+  .analytics-pair {
+    gap: 8px;
+  }
+
+  .analytics-pair strong {
+    font-size: 11px;
+  }
+
+  .analytics-activity-table th:nth-child(3),
+  .analytics-activity-table td:nth-child(3) {
+    display: none;
+  }
+
+  .analytics-pools-table th:nth-child(5),
+  .analytics-pools-table td:nth-child(5) {
+    display: none;
+  }
+
+  .analytics-statusline {
+    justify-content: flex-start;
+    flex-wrap: wrap;
+    gap: 8px 14px;
+  }
+
+  .analytics-unavailable {
+    margin-top: 26px;
+    padding: 30px 24px;
+    border-radius: 20px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .analytics-page,
+  .analytics-chart__area,
+  .analytics-chart__line,
+  .analytics-chart__bar,
+  .analytics-freshness i,
+  .analytics-statusline i,
+  .analytics-skeleton span::after {
+    animation: none;
+  }
+}
+
+@keyframes analytics-enter {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes analytics-chart-in {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes analytics-bar-in {
+  from {
+    opacity: 0;
+    transform: scaleY(0.15);
+  }
+  to {
+    opacity: 1;
+    transform: scaleY(1);
+  }
+}
+
+@keyframes analytics-live {
+  0%,
+  100% {
+    opacity: 0.7;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+@keyframes analytics-shimmer {
+  to {
+    transform: translateX(100%);
+  }
+}

--- a/V2/tezex/src/pages/Analytics/style.css
+++ b/V2/tezex/src/pages/Analytics/style.css
@@ -20,6 +20,11 @@
   align-items: flex-end;
   justify-content: space-between;
   gap: 24px;
+  text-align: left;
+}
+
+.analytics-intro > div:first-child {
+  min-width: 0;
 }
 
 .analytics-eyebrow,

--- a/V2/tezex/src/pages/Analytics/style.css
+++ b/V2/tezex/src/pages/Analytics/style.css
@@ -27,6 +27,13 @@
   min-width: 0;
 }
 
+.analytics-intro__tools {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 14px;
+}
+
 .analytics-eyebrow,
 .analytics-panel__head h2 {
   display: block;
@@ -254,6 +261,43 @@
   background: var(--tezex-action);
 }
 
+.analytics-denomination__segments {
+  position: relative;
+  width: 174px;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.analytics-denomination__segments::before {
+  content: "";
+  position: absolute;
+  top: 3px;
+  bottom: 3px;
+  left: 3px;
+  width: calc((100% - 10px) / 3);
+  background: var(--tezex-action);
+  border-radius: 999px;
+  transform: translateX(0);
+  transition: transform 220ms cubic-bezier(0.22, 0.8, 0.24, 1);
+}
+
+.analytics-denomination__segments.is-btc::before {
+  transform: translateX(calc(100% + 2px));
+}
+
+.analytics-denomination__segments.is-usd::before {
+  transform: translateX(calc(200% + 4px));
+}
+
+.analytics-denomination__segments button {
+  position: relative;
+  z-index: 1;
+}
+
+.analytics-denomination__segments button.is-active {
+  background: transparent;
+}
+
 .analytics-chart-shell {
   transition: opacity 180ms ease;
 }
@@ -458,6 +502,28 @@
   justify-content: flex-end;
 }
 
+.analytics-activity-value {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 3px;
+}
+
+.analytics-activity-value strong {
+  color: var(--tezex-text-secondary);
+  font-weight: 500;
+}
+
+.analytics-activity-value small {
+  color: var(--tezex-faint);
+  font-family: Inter, sans-serif;
+  font-size: 9px;
+}
+
+.analytics-mobile-value {
+  display: none;
+}
+
 .analytics-badge {
   display: inline-flex;
   padding: 4px 9px;
@@ -566,6 +632,17 @@
     padding: 28px 20px 16px;
   }
 
+  .analytics-intro {
+    min-height: 0;
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .analytics-intro__tools {
+    width: 100%;
+    justify-content: space-between;
+  }
+
   .analytics-stats {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -622,6 +699,16 @@
   .analytics-freshness {
     width: 100%;
     justify-content: space-between;
+  }
+
+  .analytics-intro__tools {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .analytics-denomination__segments {
+    width: 100%;
   }
 
   .analytics-stats,
@@ -703,6 +790,10 @@
     display: none;
   }
 
+  .analytics-mobile-value {
+    display: inline;
+  }
+
   .analytics-pools-table th:nth-child(5),
   .analytics-pools-table td:nth-child(5) {
     display: none;
@@ -728,8 +819,10 @@
   .analytics-chart__bar,
   .analytics-freshness i,
   .analytics-statusline i,
-  .analytics-skeleton span::after {
+  .analytics-skeleton span::after,
+  .analytics-denomination__segments::before {
     animation: none;
+    transition: none;
   }
 }
 

--- a/V2/tezex/src/pages/Analytics/style.css
+++ b/V2/tezex/src/pages/Analytics/style.css
@@ -417,6 +417,144 @@
   font-size: 9px;
 }
 
+.analytics-range-scrubber {
+  margin: 0 20px 18px;
+  padding-top: 13px;
+  border-top: 1px solid var(--tezex-line);
+}
+
+.analytics-range-scrubber__meta {
+  min-height: 24px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--tezex-muted);
+  font-family: "Red Hat Mono", monospace;
+  font-size: 9px;
+}
+
+.analytics-range-scrubber__meta > span {
+  font-family: Inter, sans-serif;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+}
+
+.analytics-range-scrubber__meta strong {
+  color: var(--tezex-text-secondary);
+  font-weight: 500;
+}
+
+.analytics-range-scrubber__meta button {
+  margin-left: auto;
+  padding: 3px 7px;
+  color: var(--tezex-muted);
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  cursor: pointer;
+  font-family: Inter, sans-serif;
+  font-size: 9px;
+  font-weight: 650;
+}
+
+.analytics-range-scrubber__meta button:hover {
+  color: var(--tezex-text);
+  background: var(--tezex-hover);
+}
+
+.analytics-range-scrubber__track {
+  height: 42px;
+  margin-top: 5px;
+  position: relative;
+}
+
+.analytics-range-scrubber__overview {
+  position: absolute;
+  inset: 6px 8px;
+  display: flex;
+  align-items: flex-end;
+  gap: 2px;
+  opacity: 0.46;
+}
+
+.analytics-range-scrubber__overview span {
+  height: var(--overview-height);
+  min-width: 1px;
+  flex: 1;
+  background: var(--tezex-muted);
+  border-radius: 1px 1px 0 0;
+}
+
+.analytics-range-scrubber__selection {
+  position: absolute;
+  top: 3px;
+  bottom: 3px;
+  left: var(--range-start);
+  right: calc(100% - var(--range-end));
+  background: color-mix(in srgb, var(--tezex-text) 5%, transparent);
+  border: 1px solid var(--tezex-line-strong);
+  border-radius: 7px;
+  pointer-events: none;
+  transition: left 140ms ease, right 140ms ease;
+}
+
+.analytics-range-scrubber__track input {
+  width: 100%;
+  height: 42px;
+  margin: 0;
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  appearance: none;
+  -webkit-appearance: none;
+  background: transparent;
+  pointer-events: none;
+}
+
+.analytics-range-scrubber__track input:last-child {
+  z-index: 3;
+}
+
+.analytics-range-scrubber__track input::-webkit-slider-runnable-track {
+  height: 42px;
+  background: transparent;
+}
+
+.analytics-range-scrubber__track input::-webkit-slider-thumb {
+  width: 13px;
+  height: 30px;
+  margin-top: 6px;
+  appearance: none;
+  -webkit-appearance: none;
+  background: var(--tezex-panel);
+  border: 2px solid var(--tezex-text-secondary);
+  border-radius: 999px;
+  box-shadow: 0 0 0 3px var(--tezex-panel);
+  cursor: ew-resize;
+  pointer-events: auto;
+}
+
+.analytics-range-scrubber__track input::-moz-range-track {
+  height: 42px;
+  background: transparent;
+}
+
+.analytics-range-scrubber__track input::-moz-range-thumb {
+  width: 11px;
+  height: 28px;
+  background: var(--tezex-panel);
+  border: 2px solid var(--tezex-text-secondary);
+  border-radius: 999px;
+  box-shadow: 0 0 0 3px var(--tezex-panel);
+  cursor: ew-resize;
+  pointer-events: auto;
+}
+
+.analytics-range-scrubber__track input:focus-visible {
+  outline: 2px solid var(--tezex-text-secondary);
+  outline-offset: 2px;
+}
+
 .analytics-table-wrap {
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
@@ -760,6 +898,20 @@
     bottom: 18px;
   }
 
+  .analytics-range-scrubber {
+    margin: 0 14px 14px;
+  }
+
+  .analytics-range-scrubber__meta {
+    align-items: flex-start;
+    flex-wrap: wrap;
+    gap: 5px 9px;
+  }
+
+  .analytics-range-scrubber__meta button {
+    margin-left: auto;
+  }
+
   .analytics-panel__meta {
     display: none;
   }
@@ -822,6 +974,10 @@
   .analytics-skeleton span::after,
   .analytics-denomination__segments::before {
     animation: none;
+    transition: none;
+  }
+
+  .analytics-range-scrubber__selection {
     transition: none;
   }
 }

--- a/V2/tezex/src/types/general.ts
+++ b/V2/tezex/src/types/general.ts
@@ -27,6 +27,7 @@ export enum Pages {
   SWAP = "/home/swap",
   ADD_LIQUIDITY = "/home/add",
   REMOVE_LIQUIDITY = "/home/remove",
+  ANALYTICS = "/analytics",
   ABOUT = "/about",
 }
 


### PR DESCRIPTION
## What changed
- adds a dedicated responsive Analytics route using the existing TEZEX header, theme, typography, and token artwork
- calculates liquidity, 24-hour volume, pool fees, swap counts, pool comparisons, and recent activity from live TzKT Mainnet data
- adds interactive Volume, TVL, and Fees charts across 24H, 7D, 30D, and 90D ranges
- enables Analytics in desktop and mobile navigation
- keeps Previewnet explicit as Mainnet-data-only until verified Previewnet pools are active

## Validation
- production dependency audit gate
- TypeScript check
- 54 frontend tests
- production build
- desktop and 390px mobile browser verification
- chart controls, range loading, navigation, and browser console checked