### PR TITLE
Harden modified DEX initialization and fee accounting

### DIFF
--- a/dex/README.md
+++ b/dex/README.md
@@ -36,7 +36,8 @@ Decentralized Exchange (DEX) implementation for Tezos blockchain based on Dexter
 - **Views**: On-chain views for quotes and pool state
   - `get_reserves`: Get current pool reserves
   - `get_lqt_total`: Get total liquidity tokens
-  - `get_fee_bp`: Get fee in basis points (30 = 0.3%)
+  - `get_fee_bp`: Get the immutable LP, protocol, and total fees in basis points
+    `(25, 5, 30)`
   - `is_active`: Check whether a modified pool has completed verified initialization
   - `quote_tez_to_token`: Calculate XTZ → Token swap output
   - `quote_token_to_tez`: Calculate Token → XTZ swap output
@@ -112,7 +113,7 @@ math using the following formula, rounded down:
 ```
 lqt = sqrt(xtz_seed * token_seed)
 ``` 
-This amount will be minted to **MANAGER** address (see .env.example)
+This amount will be minted to the final **MANAGER** address (see .env.example).
 Consider burning some initial liquidity (sending to a null address) to ensure the pool is never fully depleted.
 
 
@@ -121,13 +122,17 @@ This will:
 2. Deploy DEX contract
 3. Deploy LQT contract (with DEX as admin)
 4. In one atomic operation group, link the LQT address, fund both reserves,
-   synchronize the token pool, and activate a modified pool
+   synchronize the token pool, activate a modified pool, and transfer DEX
+   management from the deployment signer to `MANAGER`
 5. Verify the resulting on-chain addresses, reserves, balances, LQT supply, and
    activation state
 6. Save the exact integer configuration and initialization operation hash to
    `deployments/testnet-latest.json`
 
-`MANAGER` must match the account identified by the deployment private key.
+For modified pools, the total swap fee is immutable: 25 bp remains with LPs and
+5 bp is accumulated for the protocol fee recipient. `MANAGER` is used as the
+initial recipient. It may be an originated multisig contract; the private-key
+signer only manages the inactive initialization window.
 
 ### 3. Deploy to Mainnet
 

--- a/dex/README.md
+++ b/dex/README.md
@@ -44,9 +44,11 @@ Decentralized Exchange (DEX) implementation for Tezos blockchain based on Dexter
 
 Modified pools originate inactive. Their manager must seed both reserves, link
 the LQT contract, synchronize the token balance, and call `activate` with the
-expected XTZ, token, and LQT totals. Activation also verifies the actual LQT
-total supply. Swap and liquidity entrypoints remain unavailable until all
-checks pass.
+expected XTZ and LQT totals and the minimum configured token seed. Tokens sent
+directly to the inactive pool before initialization are treated as an LP
+donation and cannot block activation. Activation also verifies the actual LQT
+total supply. Swap and liquidity entrypoints remain unavailable until all checks
+pass.
 
 ### Liquidity Token (lqt_fa12.mligo)
 - FA1.2 compliant token
@@ -133,6 +135,10 @@ For modified pools, the total swap fee is immutable: 25 bp remains with LPs and
 5 bp is accumulated for the protocol fee recipient. `MANAGER` is used as the
 initial recipient. It may be an originated multisig contract; the private-key
 signer only manages the inactive initialization window.
+
+The configured token seed is a minimum for modified-pool activation. Any tokens
+transferred directly to the pool before its initialization batch are included
+in `tokenPool` and benefit LPs rather than forcing the deployment to restart.
 
 ### 3. Deploy to Mainnet
 

--- a/dex/README.md
+++ b/dex/README.md
@@ -37,8 +37,15 @@ Decentralized Exchange (DEX) implementation for Tezos blockchain based on Dexter
   - `get_reserves`: Get current pool reserves
   - `get_lqt_total`: Get total liquidity tokens
   - `get_fee_bp`: Get fee in basis points (30 = 0.3%)
+  - `is_active`: Check whether a modified pool has completed verified initialization
   - `quote_tez_to_token`: Calculate XTZ → Token swap output
   - `quote_token_to_tez`: Calculate Token → XTZ swap output
+
+Modified pools originate inactive. Their manager must seed both reserves, link
+the LQT contract, synchronize the token balance, and call `activate` with the
+expected XTZ, token, and LQT totals. Activation also verifies the actual LQT
+total supply. Swap and liquidity entrypoints remain unavailable until all
+checks pass.
 
 ### Liquidity Token (lqt_fa12.mligo)
 - FA1.2 compliant token
@@ -85,6 +92,10 @@ ligo compile contract ./contracts/dexter.mligo -o ./compiled_contracts/pool.tz -
 # Compile DEX contract with underlying FA2
 ligo compile contract contracts/dexter.mligo -o ./compiled_contracts/pool_fa2.tz -D DEPLOY,FA2 --no-warn
 
+# Compile modified DEX contracts
+ligo compile contract ./contracts/dexter_mod.mligo -o ./compiled_contracts/pool_mod.tz -D DEPLOY --no-warn
+ligo compile contract ./contracts/dexter_mod.mligo -o ./compiled_contracts/pool_fa2_mod.tz -D DEPLOY,FA2 --no-warn
+
 # Compile LQT contract
 ligo compile contract ./contracts/lqt_fa12.mligo -o ./compiled_contracts/lqt.tz --no-warn
 ```
@@ -95,7 +106,8 @@ ligo compile contract ./contracts/lqt_fa12.mligo -o ./compiled_contracts/lqt.tz 
 npm run deploy:testnet
 ```
 
-**NOTE:** initial LQT amount will be calculated using the next formula:
+**NOTE:** the initial LQT amount is calculated with arbitrary-precision integer
+math using the following formula, rounded down:
 
 ```
 lqt = sqrt(xtz_seed * token_seed)
@@ -108,10 +120,14 @@ This will:
 1. Check deployer's XTZ and token balance
 2. Deploy DEX contract
 3. Deploy LQT contract (with DEX as admin)
-4. Link LQT address to DEX
-5. Update DEX contract XTZ pool
-6. Update DEX contract Token pool
-7. Save deployment info to `deployments/testnet-latest.json`
+4. In one atomic operation group, link the LQT address, fund both reserves,
+   synchronize the token pool, and activate a modified pool
+5. Verify the resulting on-chain addresses, reserves, balances, LQT supply, and
+   activation state
+6. Save the exact integer configuration and initialization operation hash to
+   `deployments/testnet-latest.json`
+
+`MANAGER` must match the account identified by the deployment private key.
 
 ### 3. Deploy to Mainnet
 

--- a/dex/compiled_contracts/pool_fa2_mod.tz
+++ b/dex/compiled_contracts/pool_fa2_mod.tz
@@ -2,32 +2,31 @@
     (or (unit %claimProtocolFeeToken)
         (or (unit %claimProtocolFeeXtz)
             (or (address %setProtocolFeeRecipient)
-                (or (nat %setProtocolFee)
-                    (or (nat %activateInternal)
-                        (or (pair %activate
-                               (mutez %expectedXtzPool)
-                               (pair (nat %expectedTokenPool) (nat %expectedLqtTotal)))
-                            (or (pair %tokenToToken
-                                   (address %outputDexterContract)
-                                   (pair (nat %minTokensBought)
-                                         (pair (address %to) (pair (nat %tokensSold) (timestamp %deadline)))))
-                                (or (list %updateTokenPoolInternal (pair (pair address nat) nat))
-                                    (or (unit %updateTokenPool)
-                                        (or (address %setLqtAddress)
-                                            (or (address %setManager)
-                                                (or (pair %setBaker (option %baker key_hash) (bool %freezeBaker))
-                                                    (or (unit %default)
-                                                        (or (pair %tokenToXtz
-                                                               (address %to)
-                                                               (pair (nat %tokensSold) (pair (mutez %minXtzBought) (timestamp %deadline))))
-                                                            (or (pair %xtzToToken (address %to) (pair (nat %minTokensBought) (timestamp %deadline)))
-                                                                (or (pair %removeLiquidity
-                                                                       (address %to)
-                                                                       (pair (nat %lqtBurned)
-                                                                             (pair (mutez %minXtzWithdrawn) (pair (nat %minTokensWithdrawn) (timestamp %deadline)))))
-                                                                    (pair %addLiquidity
-                                                                       (address %owner)
-                                                                       (pair (nat %minLqtMinted) (pair (nat %maxTokensDeposited) (timestamp %deadline)))))))))))))))))))) ;
+                (or (nat %activateInternal)
+                    (or (pair %activate
+                           (mutez %expectedXtzPool)
+                           (pair (nat %expectedTokenPool) (nat %expectedLqtTotal)))
+                        (or (pair %tokenToToken
+                               (address %outputDexterContract)
+                               (pair (nat %minTokensBought)
+                                     (pair (address %to) (pair (nat %tokensSold) (timestamp %deadline)))))
+                            (or (list %updateTokenPoolInternal (pair (pair address nat) nat))
+                                (or (unit %updateTokenPool)
+                                    (or (address %setLqtAddress)
+                                        (or (address %setManager)
+                                            (or (pair %setBaker (option %baker key_hash) (bool %freezeBaker))
+                                                (or (unit %default)
+                                                    (or (pair %tokenToXtz
+                                                           (address %to)
+                                                           (pair (nat %tokensSold) (pair (mutez %minXtzBought) (timestamp %deadline))))
+                                                        (or (pair %xtzToToken (address %to) (pair (nat %minTokensBought) (timestamp %deadline)))
+                                                            (or (pair %removeLiquidity
+                                                                   (address %to)
+                                                                   (pair (nat %lqtBurned)
+                                                                         (pair (mutez %minXtzWithdrawn) (pair (nat %minTokensWithdrawn) (timestamp %deadline)))))
+                                                                (pair %addLiquidity
+                                                                   (address %owner)
+                                                                   (pair (nat %minLqtMinted) (pair (nat %maxTokensDeposited) (timestamp %deadline))))))))))))))))))) ;
   storage
     (pair (nat %tokenPool)
           (pair (mutez %xtzPool)
@@ -40,9 +39,8 @@
                                                     (pair (address %tokenAddress)
                                                           (pair (nat %tokenId)
                                                                 (pair (address %lqtAddress)
-                                                                      (pair (nat %protocol_fee_bp)
-                                                                            (pair (address %protocol_fee_recipient)
-                                                                                  (pair (mutez %accumulated_protocol_fee_xtz) (nat %accumulated_protocol_fee_token))))))))))))))) ;
+                                                                      (pair (address %protocol_fee_recipient)
+                                                                            (pair (mutez %accumulated_protocol_fee_xtz) (nat %accumulated_protocol_fee_token)))))))))))))) ;
   code { UNPAIR ;
          IF_LEFT
            { DROP ;
@@ -55,24 +53,24 @@
                   GT ;
                   IF { PUSH nat 10 ; FAILWITH }
                      { DUP ;
-                       GET 25 ;
+                       GET 23 ;
                        SENDER ;
                        COMPARE ;
                        NEQ ;
                        IF { PUSH nat 39 ; FAILWITH }
                           { PUSH nat 0 ;
                             DUP 2 ;
-                            GET 28 ;
+                            GET 26 ;
                             COMPARE ;
                             EQ ;
                             IF { PUSH nat 40 ; FAILWITH }
                                { DUP ;
                                  PUSH nat 0 ;
-                                 UPDATE 28 ;
+                                 UPDATE 26 ;
                                  SWAP ;
-                                 GET 28 ;
+                                 GET 26 ;
                                  DUP 2 ;
-                                 GET 25 ;
+                                 GET 23 ;
                                  SELF_ADDRESS ;
                                  DUP 4 ;
                                  DUP ;
@@ -109,26 +107,26 @@
                       GT ;
                       IF { PUSH nat 10 ; FAILWITH }
                          { DUP ;
-                           GET 25 ;
+                           GET 23 ;
                            SENDER ;
                            COMPARE ;
                            NEQ ;
                            IF { PUSH nat 39 ; FAILWITH }
                               { PUSH mutez 0 ;
                                 DUP 2 ;
-                                GET 27 ;
+                                GET 25 ;
                                 COMPARE ;
                                 EQ ;
                                 IF { PUSH nat 40 ; FAILWITH }
                                    { DUP ;
                                      PUSH mutez 0 ;
-                                     UPDATE 27 ;
+                                     UPDATE 25 ;
                                      DUP ;
-                                     GET 25 ;
+                                     GET 23 ;
                                      CONTRACT unit ;
                                      IF_NONE { PUSH nat 9 ; FAILWITH } {} ;
                                      DIG 2 ;
-                                     GET 27 ;
+                                     GET 25 ;
                                      UNIT ;
                                      TRANSFER_TOKENS ;
                                      SWAP ;
@@ -150,397 +148,397 @@
                                SENDER ;
                                COMPARE ;
                                NEQ ;
-                               IF { PUSH nat 41 ; FAILWITH } { UPDATE 25 ; NIL operation ; PAIR } } } }
+                               IF { PUSH nat 41 ; FAILWITH } { UPDATE 23 ; NIL operation ; PAIR } } } }
                    { IF_LEFT
                        { DUP 2 ;
-                         GET 11 ;
-                         IF { PUSH nat 2 ; FAILWITH }
+                         GET 21 ;
+                         SENDER ;
+                         COMPARE ;
+                         NEQ ;
+                         DUP 3 ;
+                         GET 9 ;
+                         NOT ;
+                         OR ;
+                         IF { PUSH nat 49 ; FAILWITH }
                             { PUSH mutez 0 ;
                               AMOUNT ;
                               COMPARE ;
                               GT ;
                               IF { PUSH nat 10 ; FAILWITH }
                                  { DUP 2 ;
-                                   GET 15 ;
-                                   SENDER ;
+                                   GET 5 ;
                                    COMPARE ;
                                    NEQ ;
-                                   IF { PUSH nat 37 ; FAILWITH }
-                                      { PUSH nat 1000 ;
+                                   IF { PUSH nat 50 ; FAILWITH }
+                                      { PUSH nat 0 ;
                                         DUP 2 ;
+                                        GET 5 ;
                                         COMPARE ;
-                                        GT ;
-                                        IF { PUSH nat 38 ; FAILWITH } { UPDATE 23 ; NIL operation ; PAIR } } } } }
+                                        EQ ;
+                                        PUSH nat 0 ;
+                                        DUP 3 ;
+                                        CAR ;
+                                        COMPARE ;
+                                        EQ ;
+                                        PUSH mutez 0 ;
+                                        DUP 4 ;
+                                        GET 3 ;
+                                        COMPARE ;
+                                        EQ ;
+                                        OR ;
+                                        OR ;
+                                        IF { PUSH nat 47 ; FAILWITH }
+                                           { PUSH bool True ;
+                                             UPDATE 7 ;
+                                             PUSH bool False ;
+                                             UPDATE 9 ;
+                                             NIL operation ;
+                                             PAIR } } } } }
                        { IF_LEFT
                            { DUP 2 ;
-                             GET 21 ;
-                             SENDER ;
-                             COMPARE ;
-                             NEQ ;
-                             DUP 3 ;
-                             GET 9 ;
-                             NOT ;
-                             OR ;
-                             IF { PUSH nat 49 ; FAILWITH }
+                             GET 11 ;
+                             IF { PUSH nat 2 ; FAILWITH }
                                 { PUSH mutez 0 ;
                                   AMOUNT ;
                                   COMPARE ;
                                   GT ;
                                   IF { PUSH nat 10 ; FAILWITH }
                                      { DUP 2 ;
-                                       GET 5 ;
+                                       GET 15 ;
+                                       SENDER ;
                                        COMPARE ;
                                        NEQ ;
-                                       IF { PUSH nat 50 ; FAILWITH }
-                                          { PUSH nat 0 ;
-                                            DUP 2 ;
-                                            GET 5 ;
-                                            COMPARE ;
-                                            EQ ;
-                                            PUSH nat 0 ;
+                                       IF { PUSH nat 45 ; FAILWITH }
+                                          { DUP 2 ;
+                                            GET 9 ;
                                             DUP 3 ;
-                                            CAR ;
-                                            COMPARE ;
-                                            EQ ;
-                                            PUSH mutez 0 ;
-                                            DUP 4 ;
-                                            GET 3 ;
-                                            COMPARE ;
-                                            EQ ;
+                                            GET 7 ;
                                             OR ;
-                                            OR ;
-                                            IF { PUSH nat 47 ; FAILWITH }
-                                               { PUSH bool True ;
-                                                 UPDATE 7 ;
-                                                 PUSH bool False ;
-                                                 UPDATE 9 ;
-                                                 NIL operation ;
-                                                 PAIR } } } } }
+                                            IF { PUSH nat 44 ; FAILWITH }
+                                               { PUSH address "tz1Ke2h7sDdakHJQh8WX4Z372du1KChsksyU" ;
+                                                 DUP 3 ;
+                                                 GET 21 ;
+                                                 COMPARE ;
+                                                 EQ ;
+                                                 IF { PUSH nat 46 ; FAILWITH }
+                                                    { DUP ;
+                                                      CAR ;
+                                                      BALANCE ;
+                                                      COMPARE ;
+                                                      NEQ ;
+                                                      DUP 2 ;
+                                                      GET 4 ;
+                                                      DUP 4 ;
+                                                      GET 5 ;
+                                                      COMPARE ;
+                                                      NEQ ;
+                                                      DUP 3 ;
+                                                      GET 3 ;
+                                                      DUP 5 ;
+                                                      CAR ;
+                                                      COMPARE ;
+                                                      NEQ ;
+                                                      DUP 4 ;
+                                                      CAR ;
+                                                      DUP 6 ;
+                                                      GET 3 ;
+                                                      COMPARE ;
+                                                      NEQ ;
+                                                      PUSH nat 0 ;
+                                                      DUP 6 ;
+                                                      GET 4 ;
+                                                      COMPARE ;
+                                                      EQ ;
+                                                      PUSH nat 0 ;
+                                                      DUP 7 ;
+                                                      GET 3 ;
+                                                      COMPARE ;
+                                                      EQ ;
+                                                      PUSH mutez 0 ;
+                                                      DIG 7 ;
+                                                      CAR ;
+                                                      COMPARE ;
+                                                      EQ ;
+                                                      OR ;
+                                                      OR ;
+                                                      OR ;
+                                                      OR ;
+                                                      OR ;
+                                                      OR ;
+                                                      IF { PUSH nat 47 ; FAILWITH }
+                                                         { SELF_ADDRESS ;
+                                                           CONTRACT %activateInternal nat ;
+                                                           IF_NONE
+                                                             { PUSH string "Cannot get activateInternal entrypoint" ; FAILWITH }
+                                                             {} ;
+                                                           DUP 2 ;
+                                                           GET 21 ;
+                                                           CONTRACT %getTotalSupply (pair (unit %request) (contract %callback nat)) ;
+                                                           IF_NONE { PUSH nat 48 ; FAILWITH } {} ;
+                                                           PUSH mutez 0 ;
+                                                           DIG 2 ;
+                                                           UNIT ;
+                                                           PAIR ;
+                                                           TRANSFER_TOKENS ;
+                                                           SWAP ;
+                                                           PUSH bool True ;
+                                                           UPDATE 9 ;
+                                                           NIL operation ;
+                                                           DIG 2 ;
+                                                           CONS ;
+                                                           PAIR } } } } } } }
                            { IF_LEFT
-                               { DUP 2 ;
+                               { UNPAIR 5 ;
+                                 CONTRACT %xtzToToken
+                                   (pair (address %to) (pair (nat %minTokensBought) (timestamp %deadline))) ;
+                                 IF_NONE { PUSH nat 31 ; FAILWITH } {} ;
+                                 DUP 6 ;
                                  GET 11 ;
                                  IF { PUSH nat 2 ; FAILWITH }
-                                    { PUSH mutez 0 ;
-                                      AMOUNT ;
+                                    { PUSH nat 0 ;
+                                      DUP 7 ;
+                                      GET 5 ;
                                       COMPARE ;
                                       GT ;
-                                      IF { PUSH nat 10 ; FAILWITH }
-                                         { DUP 2 ;
-                                           GET 15 ;
-                                           SENDER ;
+                                      PUSH nat 0 ;
+                                      DUP 8 ;
+                                      CAR ;
+                                      COMPARE ;
+                                      GT ;
+                                      PUSH mutez 0 ;
+                                      DUP 9 ;
+                                      GET 3 ;
+                                      COMPARE ;
+                                      GT ;
+                                      DUP 9 ;
+                                      GET 7 ;
+                                      AND ;
+                                      AND ;
+                                      AND ;
+                                      IF { PUSH mutez 0 ;
+                                           AMOUNT ;
                                            COMPARE ;
-                                           NEQ ;
-                                           IF { PUSH nat 45 ; FAILWITH }
-                                              { DUP 2 ;
-                                                GET 9 ;
-                                                DUP 3 ;
-                                                GET 7 ;
-                                                OR ;
-                                                IF { PUSH nat 44 ; FAILWITH }
-                                                   { PUSH address "tz1Ke2h7sDdakHJQh8WX4Z372du1KChsksyU" ;
-                                                     DUP 3 ;
-                                                     GET 21 ;
-                                                     COMPARE ;
-                                                     EQ ;
-                                                     IF { PUSH nat 46 ; FAILWITH }
-                                                        { DUP ;
-                                                          CAR ;
-                                                          BALANCE ;
-                                                          COMPARE ;
-                                                          NEQ ;
-                                                          DUP 2 ;
-                                                          GET 4 ;
-                                                          DUP 4 ;
-                                                          GET 5 ;
-                                                          COMPARE ;
-                                                          NEQ ;
-                                                          DUP 3 ;
-                                                          GET 3 ;
-                                                          DUP 5 ;
-                                                          CAR ;
-                                                          COMPARE ;
-                                                          NEQ ;
-                                                          DUP 4 ;
-                                                          CAR ;
-                                                          DUP 6 ;
-                                                          GET 3 ;
-                                                          COMPARE ;
-                                                          NEQ ;
-                                                          PUSH nat 0 ;
-                                                          DUP 6 ;
-                                                          GET 4 ;
-                                                          COMPARE ;
-                                                          EQ ;
-                                                          PUSH nat 0 ;
-                                                          DUP 7 ;
-                                                          GET 3 ;
-                                                          COMPARE ;
-                                                          EQ ;
-                                                          PUSH mutez 0 ;
-                                                          DIG 7 ;
-                                                          CAR ;
-                                                          COMPARE ;
-                                                          EQ ;
-                                                          OR ;
-                                                          OR ;
-                                                          OR ;
-                                                          OR ;
-                                                          OR ;
-                                                          OR ;
-                                                          IF { PUSH nat 47 ; FAILWITH }
-                                                             { SELF_ADDRESS ;
-                                                               CONTRACT %activateInternal nat ;
-                                                               IF_NONE
-                                                                 { PUSH string "Cannot get activateInternal entrypoint" ; FAILWITH }
-                                                                 {} ;
-                                                               DUP 2 ;
-                                                               GET 21 ;
-                                                               CONTRACT %getTotalSupply (pair (unit %request) (contract %callback nat)) ;
-                                                               IF_NONE { PUSH nat 48 ; FAILWITH } {} ;
-                                                               PUSH mutez 0 ;
-                                                               DIG 2 ;
-                                                               UNIT ;
-                                                               PAIR ;
-                                                               TRANSFER_TOKENS ;
-                                                               SWAP ;
-                                                               PUSH bool True ;
-                                                               UPDATE 9 ;
-                                                               NIL operation ;
-                                                               DIG 2 ;
-                                                               CONS ;
-                                                               PAIR } } } } } } }
+                                           GT ;
+                                           IF { PUSH nat 10 ; FAILWITH }
+                                              { DUP 5 ;
+                                                NOW ;
+                                                COMPARE ;
+                                                GE ;
+                                                IF { PUSH nat 3 ; FAILWITH }
+                                                   { PUSH nat 10000 ;
+                                                     PUSH nat 5 ;
+                                                     DUP 6 ;
+                                                     MUL ;
+                                                     EDIV ;
+                                                     IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                     DUP ;
+                                                     DUP 6 ;
+                                                     SUB ;
+                                                     ISNAT ;
+                                                     IF_NONE { PUSH nat 34 ; FAILWITH } {} ;
+                                                     PUSH nat 997 ;
+                                                     DUP 7 ;
+                                                     MUL ;
+                                                     PUSH nat 1000 ;
+                                                     DUP 10 ;
+                                                     CAR ;
+                                                     MUL ;
+                                                     ADD ;
+                                                     PUSH mutez 1 ;
+                                                     DUP 10 ;
+                                                     GET 3 ;
+                                                     EDIV ;
+                                                     IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                     PUSH nat 997 ;
+                                                     DUP 9 ;
+                                                     MUL ;
+                                                     MUL ;
+                                                     EDIV ;
+                                                     IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                     PUSH mutez 1 ;
+                                                     DUP 10 ;
+                                                     GET 3 ;
+                                                     EDIV ;
+                                                     IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                     DUP 2 ;
+                                                     SWAP ;
+                                                     SUB ;
+                                                     ISNAT ;
+                                                     IF_NONE { PUSH nat 36 ; FAILWITH } {} ;
+                                                     PUSH mutez 1 ;
+                                                     SWAP ;
+                                                     MUL ;
+                                                     PUSH mutez 1 ;
+                                                     DIG 2 ;
+                                                     MUL ;
+                                                     DUP 10 ;
+                                                     DIG 3 ;
+                                                     DUP 11 ;
+                                                     CAR ;
+                                                     ADD ;
+                                                     UPDATE 1 ;
+                                                     DIG 2 ;
+                                                     UPDATE 3 ;
+                                                     DIG 2 ;
+                                                     DIG 8 ;
+                                                     GET 26 ;
+                                                     ADD ;
+                                                     UPDATE 26 ;
+                                                     DIG 5 ;
+                                                     SELF_ADDRESS ;
+                                                     SENDER ;
+                                                     DUP 4 ;
+                                                     DUP ;
+                                                     GET 17 ;
+                                                     CONTRACT %transfer (list (pair address (list (pair address (pair nat nat))))) ;
+                                                     IF_NONE { PUSH nat 0 ; FAILWITH } {} ;
+                                                     PUSH mutez 0 ;
+                                                     NIL (pair address (list (pair address (pair nat nat)))) ;
+                                                     NIL (pair address (pair nat nat)) ;
+                                                     DIG 7 ;
+                                                     DIG 5 ;
+                                                     GET 19 ;
+                                                     PAIR ;
+                                                     DIG 6 ;
+                                                     PAIR ;
+                                                     CONS ;
+                                                     DIG 4 ;
+                                                     PAIR ;
+                                                     CONS ;
+                                                     TRANSFER_TOKENS ;
+                                                     DIG 3 ;
+                                                     DIG 3 ;
+                                                     DIG 6 ;
+                                                     DIG 5 ;
+                                                     DIG 6 ;
+                                                     PAIR 3 ;
+                                                     TRANSFER_TOKENS ;
+                                                     DIG 2 ;
+                                                     NIL operation ;
+                                                     DIG 2 ;
+                                                     CONS ;
+                                                     DIG 2 ;
+                                                     CONS ;
+                                                     PAIR } } }
+                                         { PUSH nat 43 ; FAILWITH } } }
                                { IF_LEFT
-                                   { UNPAIR 5 ;
-                                     CONTRACT %xtzToToken
-                                       (pair (address %to) (pair (nat %minTokensBought) (timestamp %deadline))) ;
-                                     IF_NONE { PUSH nat 31 ; FAILWITH } {} ;
-                                     DUP 6 ;
+                                   { DUP 2 ;
+                                     GET 17 ;
+                                     SENDER ;
+                                     COMPARE ;
+                                     NEQ ;
+                                     DUP 3 ;
                                      GET 11 ;
-                                     IF { PUSH nat 2 ; FAILWITH }
-                                        { PUSH nat 0 ;
-                                          DUP 7 ;
-                                          GET 5 ;
+                                     NOT ;
+                                     OR ;
+                                     IF { PUSH nat 29 ; FAILWITH }
+                                        { PUSH mutez 0 ;
+                                          AMOUNT ;
                                           COMPARE ;
                                           GT ;
-                                          PUSH nat 0 ;
-                                          DUP 8 ;
-                                          CAR ;
-                                          COMPARE ;
-                                          GT ;
-                                          PUSH mutez 0 ;
-                                          DUP 9 ;
-                                          GET 3 ;
-                                          COMPARE ;
-                                          GT ;
-                                          DUP 9 ;
-                                          GET 7 ;
-                                          AND ;
-                                          AND ;
-                                          AND ;
-                                          IF { PUSH mutez 0 ;
-                                               AMOUNT ;
-                                               COMPARE ;
-                                               GT ;
-                                               IF { PUSH nat 10 ; FAILWITH }
-                                                  { DUP 5 ;
-                                                    NOW ;
-                                                    COMPARE ;
-                                                    GE ;
-                                                    IF { PUSH nat 3 ; FAILWITH }
-                                                       { PUSH nat 10000 ;
-                                                         DUP 7 ;
-                                                         GET 23 ;
-                                                         DUP 6 ;
-                                                         MUL ;
-                                                         EDIV ;
-                                                         IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                         DUP ;
-                                                         DUP 6 ;
-                                                         SUB ;
-                                                         ISNAT ;
-                                                         IF_NONE { PUSH nat 34 ; FAILWITH } {} ;
-                                                         PUSH nat 997 ;
-                                                         DUP 2 ;
-                                                         MUL ;
-                                                         PUSH nat 1000 ;
-                                                         DUP 10 ;
-                                                         CAR ;
-                                                         MUL ;
-                                                         ADD ;
-                                                         PUSH mutez 1 ;
-                                                         DUP 10 ;
-                                                         GET 3 ;
-                                                         EDIV ;
-                                                         IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                         PUSH nat 997 ;
-                                                         DUP 4 ;
-                                                         MUL ;
-                                                         MUL ;
-                                                         EDIV ;
-                                                         IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                         PUSH mutez 1 ;
-                                                         DUP 10 ;
-                                                         GET 3 ;
-                                                         EDIV ;
-                                                         IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                         DUP 2 ;
-                                                         SWAP ;
-                                                         SUB ;
-                                                         ISNAT ;
-                                                         IF_NONE { PUSH nat 36 ; FAILWITH } {} ;
-                                                         PUSH mutez 1 ;
-                                                         SWAP ;
-                                                         MUL ;
-                                                         PUSH mutez 1 ;
-                                                         DIG 2 ;
-                                                         MUL ;
-                                                         DUP 10 ;
-                                                         DIG 3 ;
-                                                         DUP 11 ;
-                                                         CAR ;
-                                                         ADD ;
-                                                         UPDATE 1 ;
-                                                         DIG 2 ;
-                                                         UPDATE 3 ;
-                                                         DIG 2 ;
-                                                         DIG 8 ;
-                                                         GET 28 ;
-                                                         ADD ;
-                                                         UPDATE 28 ;
-                                                         DIG 5 ;
-                                                         SELF_ADDRESS ;
-                                                         SENDER ;
-                                                         DUP 4 ;
-                                                         DUP ;
-                                                         GET 17 ;
-                                                         CONTRACT %transfer (list (pair address (list (pair address (pair nat nat))))) ;
-                                                         IF_NONE { PUSH nat 0 ; FAILWITH } {} ;
-                                                         PUSH mutez 0 ;
-                                                         NIL (pair address (list (pair address (pair nat nat)))) ;
-                                                         NIL (pair address (pair nat nat)) ;
-                                                         DIG 7 ;
-                                                         DIG 5 ;
-                                                         GET 19 ;
-                                                         PAIR ;
-                                                         DIG 6 ;
-                                                         PAIR ;
-                                                         CONS ;
-                                                         DIG 4 ;
-                                                         PAIR ;
-                                                         CONS ;
-                                                         TRANSFER_TOKENS ;
-                                                         DIG 3 ;
-                                                         DIG 3 ;
-                                                         DIG 6 ;
-                                                         DIG 5 ;
-                                                         DIG 6 ;
-                                                         PAIR 3 ;
-                                                         TRANSFER_TOKENS ;
-                                                         DIG 2 ;
-                                                         NIL operation ;
-                                                         DIG 2 ;
-                                                         CONS ;
-                                                         DIG 2 ;
-                                                         CONS ;
-                                                         PAIR } } }
-                                             { PUSH nat 43 ; FAILWITH } } }
+                                          IF { PUSH nat 10 ; FAILWITH }
+                                             { IF_CONS
+                                                 { UNPAIR ;
+                                                   UNPAIR ;
+                                                   DIG 3 ;
+                                                   IF_CONS
+                                                     { PUSH nat 32 ; FAILWITH }
+                                                     { DUP 4 ;
+                                                       GET 19 ;
+                                                       DIG 2 ;
+                                                       COMPARE ;
+                                                       EQ ;
+                                                       SELF_ADDRESS ;
+                                                       DIG 2 ;
+                                                       COMPARE ;
+                                                       EQ ;
+                                                       AND ;
+                                                       IF {} { PUSH nat 32 ; FAILWITH } } }
+                                                 { PUSH nat 32 ; FAILWITH } ;
+                                               DUP 2 ;
+                                               GET 26 ;
+                                               SWAP ;
+                                               SUB ;
+                                               ISNAT ;
+                                               IF_NONE { PUSH nat 42 ; FAILWITH } {} ;
+                                               UPDATE 1 ;
+                                               PUSH bool False ;
+                                               UPDATE 11 ;
+                                               NIL operation ;
+                                               PAIR } } }
                                    { IF_LEFT
-                                       { DUP 2 ;
-                                         GET 17 ;
+                                       { DROP ;
+                                         SOURCE ;
                                          SENDER ;
                                          COMPARE ;
                                          NEQ ;
-                                         DUP 3 ;
-                                         GET 11 ;
-                                         NOT ;
-                                         OR ;
-                                         IF { PUSH nat 29 ; FAILWITH }
+                                         IF { PUSH nat 25 ; FAILWITH }
                                             { PUSH mutez 0 ;
                                               AMOUNT ;
                                               COMPARE ;
                                               GT ;
                                               IF { PUSH nat 10 ; FAILWITH }
-                                                 { IF_CONS
-                                                     { UNPAIR ;
-                                                       UNPAIR ;
-                                                       DIG 3 ;
-                                                       IF_CONS
-                                                         { PUSH nat 32 ; FAILWITH }
-                                                         { DUP 4 ;
-                                                           GET 19 ;
-                                                           DIG 2 ;
-                                                           COMPARE ;
-                                                           EQ ;
-                                                           SELF_ADDRESS ;
-                                                           DIG 2 ;
-                                                           COMPARE ;
-                                                           EQ ;
-                                                           AND ;
-                                                           IF {} { PUSH nat 32 ; FAILWITH } } }
-                                                     { PUSH nat 32 ; FAILWITH } ;
-                                                   DUP 2 ;
-                                                   GET 28 ;
-                                                   SWAP ;
-                                                   SUB ;
-                                                   ISNAT ;
-                                                   IF_NONE { PUSH nat 42 ; FAILWITH } {} ;
-                                                   UPDATE 1 ;
-                                                   PUSH bool False ;
-                                                   UPDATE 11 ;
-                                                   NIL operation ;
-                                                   PAIR } } }
+                                                 { DUP ;
+                                                   GET 11 ;
+                                                   IF { PUSH nat 33 ; FAILWITH }
+                                                      { DUP ;
+                                                        GET 15 ;
+                                                        SENDER ;
+                                                        COMPARE ;
+                                                        NEQ ;
+                                                        DUP 2 ;
+                                                        GET 7 ;
+                                                        NOT ;
+                                                        AND ;
+                                                        IF { PUSH nat 45 ; FAILWITH }
+                                                           { SELF_ADDRESS ;
+                                                             CONTRACT %updateTokenPoolInternal (list (pair (pair address nat) nat)) ;
+                                                             IF_NONE
+                                                               { PUSH string "Cannot get updateTokenPoolInternal entrypoint" ; FAILWITH }
+                                                               {} ;
+                                                             DUP 2 ;
+                                                             GET 17 ;
+                                                             CONTRACT %balance_of
+                                                               (pair (list (pair address nat)) (contract (list (pair (pair address nat) nat)))) ;
+                                                             IF_NONE { PUSH nat 28 ; FAILWITH } {} ;
+                                                             PUSH mutez 0 ;
+                                                             DIG 2 ;
+                                                             NIL (pair address nat) ;
+                                                             DUP 5 ;
+                                                             GET 19 ;
+                                                             SELF_ADDRESS ;
+                                                             PAIR ;
+                                                             CONS ;
+                                                             PAIR ;
+                                                             TRANSFER_TOKENS ;
+                                                             SWAP ;
+                                                             PUSH bool True ;
+                                                             UPDATE 11 ;
+                                                             NIL operation ;
+                                                             DIG 2 ;
+                                                             CONS ;
+                                                             PAIR } } } } }
                                        { IF_LEFT
-                                           { DROP ;
-                                             SOURCE ;
-                                             SENDER ;
-                                             COMPARE ;
-                                             NEQ ;
-                                             IF { PUSH nat 25 ; FAILWITH }
+                                           { DUP 2 ;
+                                             GET 11 ;
+                                             IF { PUSH nat 2 ; FAILWITH }
                                                 { PUSH mutez 0 ;
                                                   AMOUNT ;
                                                   COMPARE ;
                                                   GT ;
                                                   IF { PUSH nat 10 ; FAILWITH }
-                                                     { DUP ;
-                                                       GET 11 ;
-                                                       IF { PUSH nat 33 ; FAILWITH }
-                                                          { DUP ;
-                                                            GET 15 ;
-                                                            SENDER ;
+                                                     { DUP 2 ;
+                                                       GET 15 ;
+                                                       SENDER ;
+                                                       COMPARE ;
+                                                       NEQ ;
+                                                       IF { PUSH nat 23 ; FAILWITH }
+                                                          { PUSH address "tz1Ke2h7sDdakHJQh8WX4Z372du1KChsksyU" ;
+                                                            DUP 3 ;
+                                                            GET 21 ;
                                                             COMPARE ;
                                                             NEQ ;
-                                                            DUP 2 ;
-                                                            GET 7 ;
-                                                            NOT ;
-                                                            AND ;
-                                                            IF { PUSH nat 45 ; FAILWITH }
-                                                               { SELF_ADDRESS ;
-                                                                 CONTRACT %updateTokenPoolInternal (list (pair (pair address nat) nat)) ;
-                                                                 IF_NONE
-                                                                   { PUSH string "Cannot get updateTokenPoolInternal entrypoint" ; FAILWITH }
-                                                                   {} ;
-                                                                 DUP 2 ;
-                                                                 GET 17 ;
-                                                                 CONTRACT %balance_of
-                                                                   (pair (list (pair address nat)) (contract (list (pair (pair address nat) nat)))) ;
-                                                                 IF_NONE { PUSH nat 28 ; FAILWITH } {} ;
-                                                                 PUSH mutez 0 ;
-                                                                 DIG 2 ;
-                                                                 NIL (pair address nat) ;
-                                                                 DUP 5 ;
-                                                                 GET 19 ;
-                                                                 SELF_ADDRESS ;
-                                                                 PAIR ;
-                                                                 CONS ;
-                                                                 PAIR ;
-                                                                 TRANSFER_TOKENS ;
-                                                                 SWAP ;
-                                                                 PUSH bool True ;
-                                                                 UPDATE 11 ;
-                                                                 NIL operation ;
-                                                                 DIG 2 ;
-                                                                 CONS ;
-                                                                 PAIR } } } } }
+                                                            IF { PUSH nat 24 ; FAILWITH } { UPDATE 21 ; NIL operation ; PAIR } } } } }
                                            { IF_LEFT
                                                { DUP 2 ;
                                                  GET 11 ;
@@ -555,15 +553,10 @@
                                                            SENDER ;
                                                            COMPARE ;
                                                            NEQ ;
-                                                           IF { PUSH nat 23 ; FAILWITH }
-                                                              { PUSH address "tz1Ke2h7sDdakHJQh8WX4Z372du1KChsksyU" ;
-                                                                DUP 3 ;
-                                                                GET 21 ;
-                                                                COMPARE ;
-                                                                NEQ ;
-                                                                IF { PUSH nat 24 ; FAILWITH } { UPDATE 21 ; NIL operation ; PAIR } } } } }
+                                                           IF { PUSH nat 21 ; FAILWITH } { UPDATE 15 ; NIL operation ; PAIR } } } }
                                                { IF_LEFT
-                                                   { DUP 2 ;
+                                                   { UNPAIR ;
+                                                     DUP 3 ;
                                                      GET 11 ;
                                                      IF { PUSH nat 2 ; FAILWITH }
                                                         { PUSH mutez 0 ;
@@ -571,218 +564,475 @@
                                                           COMPARE ;
                                                           GT ;
                                                           IF { PUSH nat 10 ; FAILWITH }
-                                                             { DUP 2 ;
+                                                             { DUP 3 ;
                                                                GET 15 ;
                                                                SENDER ;
                                                                COMPARE ;
                                                                NEQ ;
-                                                               IF { PUSH nat 21 ; FAILWITH } { UPDATE 15 ; NIL operation ; PAIR } } } }
+                                                               IF { PUSH nat 20 ; FAILWITH }
+                                                                  { DUP 3 ;
+                                                                    GET 13 ;
+                                                                    IF { PUSH nat 22 ; FAILWITH }
+                                                                       { DUG 2 ; UPDATE 13 ; NIL operation ; DIG 2 ; SET_DELEGATE ; CONS ; PAIR } } } } }
                                                    { IF_LEFT
-                                                       { UNPAIR ;
-                                                         DUP 3 ;
+                                                       { DROP ;
+                                                         DUP ;
                                                          GET 11 ;
                                                          IF { PUSH nat 2 ; FAILWITH }
-                                                            { PUSH mutez 0 ;
-                                                              AMOUNT ;
+                                                            { DUP ;
+                                                              GET 15 ;
+                                                              SENDER ;
                                                               COMPARE ;
-                                                              GT ;
-                                                              IF { PUSH nat 10 ; FAILWITH }
-                                                                 { DUP 3 ;
-                                                                   GET 15 ;
-                                                                   SENDER ;
-                                                                   COMPARE ;
-                                                                   NEQ ;
-                                                                   IF { PUSH nat 20 ; FAILWITH }
-                                                                      { DUP 3 ;
-                                                                        GET 13 ;
-                                                                        IF { PUSH nat 22 ; FAILWITH }
-                                                                           { DUG 2 ; UPDATE 13 ; NIL operation ; DIG 2 ; SET_DELEGATE ; CONS ; PAIR } } } } }
+                                                              NEQ ;
+                                                              DUP 2 ;
+                                                              GET 7 ;
+                                                              NOT ;
+                                                              AND ;
+                                                              IF { PUSH nat 45 ; FAILWITH }
+                                                                 { DUP ; AMOUNT ; DIG 2 ; GET 3 ; ADD ; UPDATE 3 ; NIL operation ; PAIR } } }
                                                        { IF_LEFT
-                                                           { DROP ;
-                                                             DUP ;
+                                                           { UNPAIR 4 ;
+                                                             DUP 5 ;
                                                              GET 11 ;
                                                              IF { PUSH nat 2 ; FAILWITH }
-                                                                { DUP ;
-                                                                  GET 15 ;
-                                                                  SENDER ;
+                                                                { PUSH nat 0 ;
+                                                                  DUP 6 ;
+                                                                  GET 5 ;
                                                                   COMPARE ;
-                                                                  NEQ ;
-                                                                  DUP 2 ;
+                                                                  GT ;
+                                                                  PUSH nat 0 ;
+                                                                  DUP 7 ;
+                                                                  CAR ;
+                                                                  COMPARE ;
+                                                                  GT ;
+                                                                  PUSH mutez 0 ;
+                                                                  DUP 8 ;
+                                                                  GET 3 ;
+                                                                  COMPARE ;
+                                                                  GT ;
+                                                                  DUP 8 ;
                                                                   GET 7 ;
-                                                                  NOT ;
                                                                   AND ;
-                                                                  IF { PUSH nat 45 ; FAILWITH }
-                                                                     { DUP ; AMOUNT ; DIG 2 ; GET 3 ; ADD ; UPDATE 3 ; NIL operation ; PAIR } } }
+                                                                  AND ;
+                                                                  AND ;
+                                                                  IF { DIG 3 ;
+                                                                       NOW ;
+                                                                       COMPARE ;
+                                                                       GE ;
+                                                                       IF { PUSH nat 3 ; FAILWITH }
+                                                                          { PUSH mutez 0 ;
+                                                                            AMOUNT ;
+                                                                            COMPARE ;
+                                                                            GT ;
+                                                                            IF { PUSH nat 10 ; FAILWITH }
+                                                                               { PUSH nat 10000 ;
+                                                                                 PUSH nat 5 ;
+                                                                                 DUP 4 ;
+                                                                                 MUL ;
+                                                                                 EDIV ;
+                                                                                 IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                 DUP ;
+                                                                                 DUP 4 ;
+                                                                                 SUB ;
+                                                                                 ISNAT ;
+                                                                                 IF_NONE { PUSH nat 34 ; FAILWITH } {} ;
+                                                                                 PUSH nat 997 ;
+                                                                                 DUP 5 ;
+                                                                                 MUL ;
+                                                                                 PUSH nat 1000 ;
+                                                                                 DUP 8 ;
+                                                                                 CAR ;
+                                                                                 MUL ;
+                                                                                 ADD ;
+                                                                                 PUSH mutez 1 ;
+                                                                                 DUP 8 ;
+                                                                                 GET 3 ;
+                                                                                 EDIV ;
+                                                                                 IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                 PUSH nat 997 ;
+                                                                                 DUP 7 ;
+                                                                                 MUL ;
+                                                                                 MUL ;
+                                                                                 EDIV ;
+                                                                                 IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                 PUSH mutez 1 ;
+                                                                                 SWAP ;
+                                                                                 MUL ;
+                                                                                 DIG 5 ;
+                                                                                 DUP 2 ;
+                                                                                 COMPARE ;
+                                                                                 LT ;
+                                                                                 IF { PUSH nat 8 ; FAILWITH } {} ;
+                                                                                 PUSH mutez 1 ;
+                                                                                 DUP 7 ;
+                                                                                 GET 3 ;
+                                                                                 EDIV ;
+                                                                                 IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                 PUSH mutez 1 ;
+                                                                                 DUP 3 ;
+                                                                                 EDIV ;
+                                                                                 IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                 SWAP ;
+                                                                                 SUB ;
+                                                                                 ISNAT ;
+                                                                                 IF_NONE { PUSH nat 36 ; FAILWITH } {} ;
+                                                                                 PUSH mutez 1 ;
+                                                                                 SWAP ;
+                                                                                 MUL ;
+                                                                                 DIG 5 ;
+                                                                                 SELF_ADDRESS ;
+                                                                                 SENDER ;
+                                                                                 DUP 9 ;
+                                                                                 DUP ;
+                                                                                 GET 17 ;
+                                                                                 CONTRACT %transfer (list (pair address (list (pair address (pair nat nat))))) ;
+                                                                                 IF_NONE { PUSH nat 0 ; FAILWITH } {} ;
+                                                                                 PUSH mutez 0 ;
+                                                                                 NIL (pair address (list (pair address (pair nat nat)))) ;
+                                                                                 NIL (pair address (pair nat nat)) ;
+                                                                                 DIG 7 ;
+                                                                                 DIG 5 ;
+                                                                                 GET 19 ;
+                                                                                 PAIR ;
+                                                                                 DIG 6 ;
+                                                                                 PAIR ;
+                                                                                 CONS ;
+                                                                                 DIG 4 ;
+                                                                                 PAIR ;
+                                                                                 CONS ;
+                                                                                 TRANSFER_TOKENS ;
+                                                                                 DIG 5 ;
+                                                                                 CONTRACT unit ;
+                                                                                 IF_NONE { PUSH nat 9 ; FAILWITH } {} ;
+                                                                                 DIG 3 ;
+                                                                                 UNIT ;
+                                                                                 TRANSFER_TOKENS ;
+                                                                                 DUP 6 ;
+                                                                                 DIG 4 ;
+                                                                                 DUP 7 ;
+                                                                                 CAR ;
+                                                                                 ADD ;
+                                                                                 UPDATE 1 ;
+                                                                                 DIG 3 ;
+                                                                                 UPDATE 3 ;
+                                                                                 DIG 3 ;
+                                                                                 DIG 4 ;
+                                                                                 GET 26 ;
+                                                                                 ADD ;
+                                                                                 UPDATE 26 ;
+                                                                                 NIL operation ;
+                                                                                 DIG 2 ;
+                                                                                 CONS ;
+                                                                                 DIG 2 ;
+                                                                                 CONS ;
+                                                                                 PAIR } } }
+                                                                     { PUSH nat 43 ; FAILWITH } } }
                                                            { IF_LEFT
-                                                               { UNPAIR 4 ;
-                                                                 DUP 5 ;
+                                                               { UNPAIR 3 ;
+                                                                 DUP 4 ;
                                                                  GET 11 ;
                                                                  IF { PUSH nat 2 ; FAILWITH }
                                                                     { PUSH nat 0 ;
-                                                                      DUP 6 ;
+                                                                      DUP 5 ;
                                                                       GET 5 ;
                                                                       COMPARE ;
                                                                       GT ;
                                                                       PUSH nat 0 ;
-                                                                      DUP 7 ;
+                                                                      DUP 6 ;
                                                                       CAR ;
                                                                       COMPARE ;
                                                                       GT ;
                                                                       PUSH mutez 0 ;
-                                                                      DUP 8 ;
+                                                                      DUP 7 ;
                                                                       GET 3 ;
                                                                       COMPARE ;
                                                                       GT ;
-                                                                      DUP 8 ;
+                                                                      DUP 7 ;
                                                                       GET 7 ;
                                                                       AND ;
                                                                       AND ;
                                                                       AND ;
-                                                                      IF { DIG 3 ;
+                                                                      IF { DIG 2 ;
                                                                            NOW ;
                                                                            COMPARE ;
                                                                            GE ;
                                                                            IF { PUSH nat 3 ; FAILWITH }
-                                                                              { PUSH mutez 0 ;
+                                                                              { PUSH mutez 1 ;
+                                                                                DUP 4 ;
+                                                                                GET 3 ;
+                                                                                EDIV ;
+                                                                                IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                PUSH mutez 1 ;
                                                                                 AMOUNT ;
+                                                                                EDIV ;
+                                                                                IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                PUSH nat 10000 ;
+                                                                                PUSH nat 5 ;
+                                                                                DUP 3 ;
+                                                                                MUL ;
+                                                                                EDIV ;
+                                                                                IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                DUP ;
+                                                                                DUP 3 ;
+                                                                                SUB ;
+                                                                                ISNAT ;
+                                                                                IF_NONE { PUSH nat 34 ; FAILWITH } {} ;
+                                                                                PUSH nat 997 ;
+                                                                                DUP 4 ;
+                                                                                MUL ;
+                                                                                PUSH nat 1000 ;
+                                                                                DIG 5 ;
+                                                                                MUL ;
+                                                                                ADD ;
+                                                                                DUP 7 ;
+                                                                                CAR ;
+                                                                                PUSH nat 997 ;
+                                                                                DIG 5 ;
+                                                                                MUL ;
+                                                                                MUL ;
+                                                                                EDIV ;
+                                                                                IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                DIG 4 ;
+                                                                                DUP 2 ;
                                                                                 COMPARE ;
-                                                                                GT ;
-                                                                                IF { PUSH nat 10 ; FAILWITH }
-                                                                                   { PUSH nat 10000 ;
-                                                                                     DUP 5 ;
-                                                                                     GET 23 ;
-                                                                                     DUP 4 ;
-                                                                                     MUL ;
-                                                                                     EDIV ;
-                                                                                     IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                                     DUP ;
-                                                                                     DUP 4 ;
-                                                                                     SUB ;
-                                                                                     ISNAT ;
-                                                                                     IF_NONE { PUSH nat 34 ; FAILWITH } {} ;
-                                                                                     PUSH nat 997 ;
-                                                                                     DUP 2 ;
-                                                                                     MUL ;
-                                                                                     PUSH nat 1000 ;
-                                                                                     DUP 8 ;
-                                                                                     CAR ;
-                                                                                     MUL ;
-                                                                                     ADD ;
-                                                                                     PUSH mutez 1 ;
-                                                                                     DUP 8 ;
-                                                                                     GET 3 ;
-                                                                                     EDIV ;
-                                                                                     IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                                     PUSH nat 997 ;
-                                                                                     DUP 4 ;
-                                                                                     MUL ;
-                                                                                     MUL ;
-                                                                                     EDIV ;
-                                                                                     IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                                     PUSH mutez 1 ;
-                                                                                     SWAP ;
-                                                                                     MUL ;
-                                                                                     DIG 5 ;
-                                                                                     DUP 2 ;
-                                                                                     COMPARE ;
-                                                                                     LT ;
-                                                                                     IF { PUSH nat 8 ; FAILWITH } {} ;
-                                                                                     PUSH mutez 1 ;
-                                                                                     DUP 7 ;
-                                                                                     GET 3 ;
-                                                                                     EDIV ;
-                                                                                     IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                                     PUSH mutez 1 ;
-                                                                                     DUP 3 ;
-                                                                                     EDIV ;
-                                                                                     IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                                     SWAP ;
-                                                                                     SUB ;
-                                                                                     ISNAT ;
-                                                                                     IF_NONE { PUSH nat 36 ; FAILWITH } {} ;
-                                                                                     PUSH mutez 1 ;
-                                                                                     SWAP ;
-                                                                                     MUL ;
-                                                                                     DIG 5 ;
-                                                                                     SELF_ADDRESS ;
-                                                                                     SENDER ;
-                                                                                     DUP 9 ;
-                                                                                     DUP ;
-                                                                                     GET 17 ;
-                                                                                     CONTRACT %transfer (list (pair address (list (pair address (pair nat nat))))) ;
-                                                                                     IF_NONE { PUSH nat 0 ; FAILWITH } {} ;
-                                                                                     PUSH mutez 0 ;
-                                                                                     NIL (pair address (list (pair address (pair nat nat)))) ;
-                                                                                     NIL (pair address (pair nat nat)) ;
-                                                                                     DIG 7 ;
-                                                                                     DIG 5 ;
-                                                                                     GET 19 ;
-                                                                                     PAIR ;
-                                                                                     DIG 6 ;
-                                                                                     PAIR ;
-                                                                                     CONS ;
-                                                                                     DIG 4 ;
-                                                                                     PAIR ;
-                                                                                     CONS ;
-                                                                                     TRANSFER_TOKENS ;
-                                                                                     DIG 5 ;
-                                                                                     CONTRACT unit ;
-                                                                                     IF_NONE { PUSH nat 9 ; FAILWITH } {} ;
-                                                                                     DIG 3 ;
-                                                                                     UNIT ;
-                                                                                     TRANSFER_TOKENS ;
-                                                                                     DUP 6 ;
-                                                                                     DIG 4 ;
-                                                                                     DUP 7 ;
-                                                                                     CAR ;
-                                                                                     ADD ;
-                                                                                     UPDATE 1 ;
-                                                                                     DIG 3 ;
-                                                                                     UPDATE 3 ;
-                                                                                     DIG 3 ;
-                                                                                     DIG 4 ;
-                                                                                     GET 28 ;
-                                                                                     ADD ;
-                                                                                     UPDATE 28 ;
-                                                                                     NIL operation ;
-                                                                                     DIG 2 ;
-                                                                                     CONS ;
-                                                                                     DIG 2 ;
-                                                                                     CONS ;
-                                                                                     PAIR } } }
+                                                                                LT ;
+                                                                                IF { PUSH nat 18 ; FAILWITH } {} ;
+                                                                                DUP ;
+                                                                                DUP 6 ;
+                                                                                CAR ;
+                                                                                SUB ;
+                                                                                ISNAT ;
+                                                                                IF_NONE { PUSH nat 19 ; FAILWITH } {} ;
+                                                                                PUSH mutez 1 ;
+                                                                                DIG 4 ;
+                                                                                MUL ;
+                                                                                PUSH mutez 1 ;
+                                                                                DIG 4 ;
+                                                                                MUL ;
+                                                                                DUP 6 ;
+                                                                                SWAP ;
+                                                                                DUP 7 ;
+                                                                                GET 3 ;
+                                                                                ADD ;
+                                                                                UPDATE 3 ;
+                                                                                DIG 2 ;
+                                                                                UPDATE 1 ;
+                                                                                SWAP ;
+                                                                                DIG 4 ;
+                                                                                GET 25 ;
+                                                                                ADD ;
+                                                                                UPDATE 25 ;
+                                                                                SWAP ;
+                                                                                DIG 2 ;
+                                                                                SELF_ADDRESS ;
+                                                                                DUP 4 ;
+                                                                                DUP ;
+                                                                                GET 17 ;
+                                                                                CONTRACT %transfer (list (pair address (list (pair address (pair nat nat))))) ;
+                                                                                IF_NONE { PUSH nat 0 ; FAILWITH } {} ;
+                                                                                PUSH mutez 0 ;
+                                                                                NIL (pair address (list (pair address (pair nat nat)))) ;
+                                                                                NIL (pair address (pair nat nat)) ;
+                                                                                DIG 7 ;
+                                                                                DIG 5 ;
+                                                                                GET 19 ;
+                                                                                PAIR ;
+                                                                                DIG 6 ;
+                                                                                PAIR ;
+                                                                                CONS ;
+                                                                                DIG 4 ;
+                                                                                PAIR ;
+                                                                                CONS ;
+                                                                                TRANSFER_TOKENS ;
+                                                                                SWAP ;
+                                                                                NIL operation ;
+                                                                                DIG 2 ;
+                                                                                CONS ;
+                                                                                PAIR } }
                                                                          { PUSH nat 43 ; FAILWITH } } }
                                                                { IF_LEFT
-                                                                   { UNPAIR 3 ;
-                                                                     DUP 4 ;
+                                                                   { UNPAIR 5 ;
+                                                                     DUP 6 ;
                                                                      GET 11 ;
                                                                      IF { PUSH nat 2 ; FAILWITH }
                                                                         { PUSH nat 0 ;
-                                                                          DUP 5 ;
+                                                                          DUP 7 ;
                                                                           GET 5 ;
                                                                           COMPARE ;
                                                                           GT ;
                                                                           PUSH nat 0 ;
-                                                                          DUP 6 ;
+                                                                          DUP 8 ;
                                                                           CAR ;
                                                                           COMPARE ;
                                                                           GT ;
                                                                           PUSH mutez 0 ;
-                                                                          DUP 7 ;
+                                                                          DUP 9 ;
                                                                           GET 3 ;
                                                                           COMPARE ;
                                                                           GT ;
-                                                                          DUP 7 ;
+                                                                          DUP 9 ;
                                                                           GET 7 ;
                                                                           AND ;
                                                                           AND ;
                                                                           AND ;
-                                                                          IF { DIG 2 ;
+                                                                          IF { DIG 4 ;
+                                                                               NOW ;
+                                                                               COMPARE ;
+                                                                               GE ;
+                                                                               IF { PUSH nat 3 ; FAILWITH }
+                                                                                  { PUSH mutez 0 ;
+                                                                                    AMOUNT ;
+                                                                                    COMPARE ;
+                                                                                    GT ;
+                                                                                    IF { PUSH nat 10 ; FAILWITH }
+                                                                                       { DUP 5 ;
+                                                                                         GET 5 ;
+                                                                                         PUSH mutez 1 ;
+                                                                                         DUP 7 ;
+                                                                                         GET 3 ;
+                                                                                         EDIV ;
+                                                                                         IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                         DUP 4 ;
+                                                                                         MUL ;
+                                                                                         EDIV ;
+                                                                                         IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                         PUSH mutez 1 ;
+                                                                                         SWAP ;
+                                                                                         MUL ;
+                                                                                         DUP 6 ;
+                                                                                         GET 5 ;
+                                                                                         DUP 7 ;
+                                                                                         CAR ;
+                                                                                         DUP 5 ;
+                                                                                         MUL ;
+                                                                                         EDIV ;
+                                                                                         IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                         DIG 4 ;
+                                                                                         DUP 3 ;
+                                                                                         COMPARE ;
+                                                                                         LT ;
+                                                                                         IF { PUSH nat 11 ; FAILWITH }
+                                                                                            { DIG 4 ;
+                                                                                              DUP 2 ;
+                                                                                              COMPARE ;
+                                                                                              LT ;
+                                                                                              IF { PUSH nat 13 ; FAILWITH }
+                                                                                                 { DUP 4 ;
+                                                                                                   DUP 6 ;
+                                                                                                   GET 5 ;
+                                                                                                   SUB ;
+                                                                                                   ISNAT ;
+                                                                                                   IF_NONE { PUSH nat 14 ; FAILWITH } {} ;
+                                                                                                   DUP 2 ;
+                                                                                                   DUP 7 ;
+                                                                                                   CAR ;
+                                                                                                   SUB ;
+                                                                                                   ISNAT ;
+                                                                                                   IF_NONE { PUSH nat 15 ; FAILWITH } {} ;
+                                                                                                   PUSH mutez 1 ;
+                                                                                                   DUP 8 ;
+                                                                                                   GET 3 ;
+                                                                                                   EDIV ;
+                                                                                                   IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                                   PUSH mutez 1 ;
+                                                                                                   DUP 6 ;
+                                                                                                   EDIV ;
+                                                                                                   IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                                   SWAP ;
+                                                                                                   SUB ;
+                                                                                                   ISNAT ;
+                                                                                                   IF_NONE { PUSH nat 36 ; FAILWITH } {} ;
+                                                                                                   PUSH mutez 1 ;
+                                                                                                   SWAP ;
+                                                                                                   MUL ;
+                                                                                                   DIG 6 ;
+                                                                                                   PUSH int 0 ;
+                                                                                                   SUB ;
+                                                                                                   SENDER ;
+                                                                                                   DUP 9 ;
+                                                                                                   GET 21 ;
+                                                                                                   CONTRACT %mintOrBurn (pair (int %quantity) (address %target)) ;
+                                                                                                   IF_NONE { PUSH nat 12 ; FAILWITH } {} ;
+                                                                                                   PUSH mutez 0 ;
+                                                                                                   DIG 2 ;
+                                                                                                   DIG 3 ;
+                                                                                                   PAIR ;
+                                                                                                   TRANSFER_TOKENS ;
+                                                                                                   DIG 4 ;
+                                                                                                   DUP 7 ;
+                                                                                                   SELF_ADDRESS ;
+                                                                                                   DUP 10 ;
+                                                                                                   DUP ;
+                                                                                                   GET 17 ;
+                                                                                                   CONTRACT %transfer (list (pair address (list (pair address (pair nat nat))))) ;
+                                                                                                   IF_NONE { PUSH nat 0 ; FAILWITH } {} ;
+                                                                                                   PUSH mutez 0 ;
+                                                                                                   NIL (pair address (list (pair address (pair nat nat)))) ;
+                                                                                                   NIL (pair address (pair nat nat)) ;
+                                                                                                   DIG 7 ;
+                                                                                                   DIG 5 ;
+                                                                                                   GET 19 ;
+                                                                                                   PAIR ;
+                                                                                                   DIG 6 ;
+                                                                                                   PAIR ;
+                                                                                                   CONS ;
+                                                                                                   DIG 4 ;
+                                                                                                   PAIR ;
+                                                                                                   CONS ;
+                                                                                                   TRANSFER_TOKENS ;
+                                                                                                   DIG 6 ;
+                                                                                                   CONTRACT unit ;
+                                                                                                   IF_NONE { PUSH nat 9 ; FAILWITH } {} ;
+                                                                                                   DIG 6 ;
+                                                                                                   UNIT ;
+                                                                                                   TRANSFER_TOKENS ;
+                                                                                                   DIG 6 ;
+                                                                                                   DIG 4 ;
+                                                                                                   UPDATE 3 ;
+                                                                                                   DIG 5 ;
+                                                                                                   UPDATE 5 ;
+                                                                                                   DIG 4 ;
+                                                                                                   UPDATE 1 ;
+                                                                                                   NIL operation ;
+                                                                                                   DIG 2 ;
+                                                                                                   CONS ;
+                                                                                                   DIG 2 ;
+                                                                                                   CONS ;
+                                                                                                   DIG 2 ;
+                                                                                                   CONS ;
+                                                                                                   PAIR } } } } }
+                                                                             { PUSH nat 43 ; FAILWITH } } }
+                                                                   { UNPAIR 4 ;
+                                                                     DUP 5 ;
+                                                                     GET 11 ;
+                                                                     IF { PUSH nat 2 ; FAILWITH }
+                                                                        { PUSH nat 0 ;
+                                                                          DUP 6 ;
+                                                                          GET 5 ;
+                                                                          COMPARE ;
+                                                                          GT ;
+                                                                          PUSH nat 0 ;
+                                                                          DUP 7 ;
+                                                                          CAR ;
+                                                                          COMPARE ;
+                                                                          GT ;
+                                                                          PUSH mutez 0 ;
+                                                                          DUP 8 ;
+                                                                          GET 3 ;
+                                                                          COMPARE ;
+                                                                          GT ;
+                                                                          DUP 8 ;
+                                                                          GET 7 ;
+                                                                          AND ;
+                                                                          AND ;
+                                                                          AND ;
+                                                                          IF { DIG 3 ;
                                                                                NOW ;
                                                                                COMPARE ;
                                                                                GE ;
                                                                                IF { PUSH nat 3 ; FAILWITH }
                                                                                   { PUSH mutez 1 ;
-                                                                                    DUP 4 ;
+                                                                                    DUP 5 ;
                                                                                     GET 3 ;
                                                                                     EDIV ;
                                                                                     IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
@@ -790,365 +1040,90 @@
                                                                                     AMOUNT ;
                                                                                     EDIV ;
                                                                                     IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                                    PUSH nat 10000 ;
-                                                                                    DUP 6 ;
-                                                                                    GET 23 ;
+                                                                                    DUP 2 ;
+                                                                                    DUP 7 ;
+                                                                                    GET 5 ;
                                                                                     DUP 3 ;
                                                                                     MUL ;
                                                                                     EDIV ;
                                                                                     IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                                    DUP ;
                                                                                     DIG 2 ;
-                                                                                    SUB ;
-                                                                                    ISNAT ;
-                                                                                    IF_NONE { PUSH nat 34 ; FAILWITH } {} ;
-                                                                                    PUSH nat 997 ;
-                                                                                    DUP 2 ;
-                                                                                    MUL ;
-                                                                                    PUSH nat 1000 ;
-                                                                                    DIG 4 ;
-                                                                                    MUL ;
-                                                                                    ADD ;
-                                                                                    DUP 6 ;
+                                                                                    DUP 7 ;
                                                                                     CAR ;
-                                                                                    PUSH nat 997 ;
-                                                                                    DUP 4 ;
-                                                                                    MUL ;
+                                                                                    DIG 3 ;
                                                                                     MUL ;
                                                                                     EDIV ;
-                                                                                    IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                    IF_NONE
+                                                                                      { PUSH string "DIV by 0" ; FAILWITH }
+                                                                                      { UNPAIR ; SWAP ; INT ; EQ ; IF {} { PUSH nat 1 ; ADD } } ;
                                                                                     DIG 4 ;
                                                                                     DUP 2 ;
                                                                                     COMPARE ;
-                                                                                    LT ;
-                                                                                    IF { PUSH nat 18 ; FAILWITH } {} ;
-                                                                                    DUP ;
-                                                                                    DUP 6 ;
-                                                                                    CAR ;
-                                                                                    SUB ;
-                                                                                    ISNAT ;
-                                                                                    IF_NONE { PUSH nat 19 ; FAILWITH } {} ;
-                                                                                    PUSH mutez 1 ;
-                                                                                    DIG 4 ;
-                                                                                    MUL ;
-                                                                                    PUSH mutez 1 ;
-                                                                                    DIG 4 ;
-                                                                                    MUL ;
-                                                                                    DUP 6 ;
-                                                                                    SWAP ;
-                                                                                    DUP 7 ;
-                                                                                    GET 3 ;
-                                                                                    ADD ;
-                                                                                    UPDATE 3 ;
-                                                                                    DIG 2 ;
-                                                                                    UPDATE 1 ;
-                                                                                    SWAP ;
-                                                                                    DIG 4 ;
-                                                                                    GET 27 ;
-                                                                                    ADD ;
-                                                                                    UPDATE 27 ;
-                                                                                    SWAP ;
-                                                                                    DIG 2 ;
-                                                                                    SELF_ADDRESS ;
-                                                                                    DUP 4 ;
-                                                                                    DUP ;
-                                                                                    GET 17 ;
-                                                                                    CONTRACT %transfer (list (pair address (list (pair address (pair nat nat))))) ;
-                                                                                    IF_NONE { PUSH nat 0 ; FAILWITH } {} ;
-                                                                                    PUSH mutez 0 ;
-                                                                                    NIL (pair address (list (pair address (pair nat nat)))) ;
-                                                                                    NIL (pair address (pair nat nat)) ;
-                                                                                    DIG 7 ;
-                                                                                    DIG 5 ;
-                                                                                    GET 19 ;
-                                                                                    PAIR ;
-                                                                                    DIG 6 ;
-                                                                                    PAIR ;
-                                                                                    CONS ;
-                                                                                    DIG 4 ;
-                                                                                    PAIR ;
-                                                                                    CONS ;
-                                                                                    TRANSFER_TOKENS ;
-                                                                                    SWAP ;
-                                                                                    NIL operation ;
-                                                                                    DIG 2 ;
-                                                                                    CONS ;
-                                                                                    PAIR } }
-                                                                             { PUSH nat 43 ; FAILWITH } } }
-                                                                   { IF_LEFT
-                                                                       { UNPAIR 5 ;
-                                                                         DUP 6 ;
-                                                                         GET 11 ;
-                                                                         IF { PUSH nat 2 ; FAILWITH }
-                                                                            { PUSH nat 0 ;
-                                                                              DUP 7 ;
-                                                                              GET 5 ;
-                                                                              COMPARE ;
-                                                                              GT ;
-                                                                              PUSH nat 0 ;
-                                                                              DUP 8 ;
-                                                                              CAR ;
-                                                                              COMPARE ;
-                                                                              GT ;
-                                                                              PUSH mutez 0 ;
-                                                                              DUP 9 ;
-                                                                              GET 3 ;
-                                                                              COMPARE ;
-                                                                              GT ;
-                                                                              DUP 9 ;
-                                                                              GET 7 ;
-                                                                              AND ;
-                                                                              AND ;
-                                                                              AND ;
-                                                                              IF { DIG 4 ;
-                                                                                   NOW ;
-                                                                                   COMPARE ;
-                                                                                   GE ;
-                                                                                   IF { PUSH nat 3 ; FAILWITH }
-                                                                                      { PUSH mutez 0 ;
-                                                                                        AMOUNT ;
-                                                                                        COMPARE ;
-                                                                                        GT ;
-                                                                                        IF { PUSH nat 10 ; FAILWITH }
-                                                                                           { DUP 5 ;
-                                                                                             GET 5 ;
-                                                                                             PUSH mutez 1 ;
-                                                                                             DUP 7 ;
-                                                                                             GET 3 ;
-                                                                                             EDIV ;
-                                                                                             IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                                             DUP 4 ;
-                                                                                             MUL ;
-                                                                                             EDIV ;
-                                                                                             IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                                             PUSH mutez 1 ;
-                                                                                             SWAP ;
-                                                                                             MUL ;
-                                                                                             DUP 6 ;
-                                                                                             GET 5 ;
-                                                                                             DUP 7 ;
-                                                                                             CAR ;
-                                                                                             DUP 5 ;
-                                                                                             MUL ;
-                                                                                             EDIV ;
-                                                                                             IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                                             DIG 4 ;
-                                                                                             DUP 3 ;
-                                                                                             COMPARE ;
-                                                                                             LT ;
-                                                                                             IF { PUSH nat 11 ; FAILWITH }
-                                                                                                { DIG 4 ;
-                                                                                                  DUP 2 ;
-                                                                                                  COMPARE ;
-                                                                                                  LT ;
-                                                                                                  IF { PUSH nat 13 ; FAILWITH }
-                                                                                                     { DUP 4 ;
-                                                                                                       DUP 6 ;
-                                                                                                       GET 5 ;
-                                                                                                       SUB ;
-                                                                                                       ISNAT ;
-                                                                                                       IF_NONE { PUSH nat 14 ; FAILWITH } {} ;
-                                                                                                       DUP 2 ;
-                                                                                                       DUP 7 ;
-                                                                                                       CAR ;
-                                                                                                       SUB ;
-                                                                                                       ISNAT ;
-                                                                                                       IF_NONE { PUSH nat 15 ; FAILWITH } {} ;
-                                                                                                       PUSH mutez 1 ;
-                                                                                                       DUP 8 ;
-                                                                                                       GET 3 ;
-                                                                                                       EDIV ;
-                                                                                                       IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                                                       PUSH mutez 1 ;
-                                                                                                       DUP 6 ;
-                                                                                                       EDIV ;
-                                                                                                       IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                                                       SWAP ;
-                                                                                                       SUB ;
-                                                                                                       ISNAT ;
-                                                                                                       IF_NONE { PUSH nat 36 ; FAILWITH } {} ;
-                                                                                                       PUSH mutez 1 ;
-                                                                                                       SWAP ;
-                                                                                                       MUL ;
-                                                                                                       DIG 6 ;
-                                                                                                       PUSH int 0 ;
-                                                                                                       SUB ;
-                                                                                                       SENDER ;
-                                                                                                       DUP 9 ;
-                                                                                                       GET 21 ;
-                                                                                                       CONTRACT %mintOrBurn (pair (int %quantity) (address %target)) ;
-                                                                                                       IF_NONE { PUSH nat 12 ; FAILWITH } {} ;
-                                                                                                       PUSH mutez 0 ;
-                                                                                                       DIG 2 ;
-                                                                                                       DIG 3 ;
-                                                                                                       PAIR ;
-                                                                                                       TRANSFER_TOKENS ;
-                                                                                                       DIG 4 ;
-                                                                                                       DUP 7 ;
-                                                                                                       SELF_ADDRESS ;
-                                                                                                       DUP 10 ;
-                                                                                                       DUP ;
-                                                                                                       GET 17 ;
-                                                                                                       CONTRACT %transfer (list (pair address (list (pair address (pair nat nat))))) ;
-                                                                                                       IF_NONE { PUSH nat 0 ; FAILWITH } {} ;
-                                                                                                       PUSH mutez 0 ;
-                                                                                                       NIL (pair address (list (pair address (pair nat nat)))) ;
-                                                                                                       NIL (pair address (pair nat nat)) ;
-                                                                                                       DIG 7 ;
-                                                                                                       DIG 5 ;
-                                                                                                       GET 19 ;
-                                                                                                       PAIR ;
-                                                                                                       DIG 6 ;
-                                                                                                       PAIR ;
-                                                                                                       CONS ;
-                                                                                                       DIG 4 ;
-                                                                                                       PAIR ;
-                                                                                                       CONS ;
-                                                                                                       TRANSFER_TOKENS ;
-                                                                                                       DIG 6 ;
-                                                                                                       CONTRACT unit ;
-                                                                                                       IF_NONE { PUSH nat 9 ; FAILWITH } {} ;
-                                                                                                       DIG 6 ;
-                                                                                                       UNIT ;
-                                                                                                       TRANSFER_TOKENS ;
-                                                                                                       DIG 6 ;
-                                                                                                       DIG 4 ;
-                                                                                                       UPDATE 3 ;
-                                                                                                       DIG 5 ;
-                                                                                                       UPDATE 5 ;
-                                                                                                       DIG 4 ;
-                                                                                                       UPDATE 1 ;
-                                                                                                       NIL operation ;
-                                                                                                       DIG 2 ;
-                                                                                                       CONS ;
-                                                                                                       DIG 2 ;
-                                                                                                       CONS ;
-                                                                                                       DIG 2 ;
-                                                                                                       CONS ;
-                                                                                                       PAIR } } } } }
-                                                                                 { PUSH nat 43 ; FAILWITH } } }
-                                                                       { UNPAIR 4 ;
-                                                                         DUP 5 ;
-                                                                         GET 11 ;
-                                                                         IF { PUSH nat 2 ; FAILWITH }
-                                                                            { PUSH nat 0 ;
-                                                                              DUP 6 ;
-                                                                              GET 5 ;
-                                                                              COMPARE ;
-                                                                              GT ;
-                                                                              PUSH nat 0 ;
-                                                                              DUP 7 ;
-                                                                              CAR ;
-                                                                              COMPARE ;
-                                                                              GT ;
-                                                                              PUSH mutez 0 ;
-                                                                              DUP 8 ;
-                                                                              GET 3 ;
-                                                                              COMPARE ;
-                                                                              GT ;
-                                                                              DUP 8 ;
-                                                                              GET 7 ;
-                                                                              AND ;
-                                                                              AND ;
-                                                                              AND ;
-                                                                              IF { DIG 3 ;
-                                                                                   NOW ;
-                                                                                   COMPARE ;
-                                                                                   GE ;
-                                                                                   IF { PUSH nat 3 ; FAILWITH }
-                                                                                      { PUSH mutez 1 ;
-                                                                                        DUP 5 ;
-                                                                                        GET 3 ;
-                                                                                        EDIV ;
-                                                                                        IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                                        PUSH mutez 1 ;
-                                                                                        AMOUNT ;
-                                                                                        EDIV ;
-                                                                                        IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                                        DUP 2 ;
-                                                                                        DUP 7 ;
-                                                                                        GET 5 ;
-                                                                                        DUP 3 ;
-                                                                                        MUL ;
-                                                                                        EDIV ;
-                                                                                        IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                                        DIG 2 ;
-                                                                                        DUP 7 ;
-                                                                                        CAR ;
-                                                                                        DIG 3 ;
-                                                                                        MUL ;
-                                                                                        EDIV ;
-                                                                                        IF_NONE
-                                                                                          { PUSH string "DIV by 0" ; FAILWITH }
-                                                                                          { UNPAIR ; SWAP ; INT ; EQ ; IF {} { PUSH nat 1 ; ADD } } ;
-                                                                                        DIG 4 ;
-                                                                                        DUP 2 ;
-                                                                                        COMPARE ;
-                                                                                        GT ;
-                                                                                        IF { PUSH nat 4 ; FAILWITH }
-                                                                                           { DIG 3 ;
-                                                                                             DUP 3 ;
-                                                                                             COMPARE ;
-                                                                                             LT ;
-                                                                                             IF { PUSH nat 5 ; FAILWITH }
-                                                                                                { DUP 4 ;
-                                                                                                  DUP 3 ;
-                                                                                                  DUP 6 ;
-                                                                                                  GET 5 ;
-                                                                                                  ADD ;
-                                                                                                  UPDATE 5 ;
-                                                                                                  DUP 2 ;
-                                                                                                  DUP 6 ;
-                                                                                                  CAR ;
-                                                                                                  ADD ;
-                                                                                                  UPDATE 1 ;
-                                                                                                  AMOUNT ;
-                                                                                                  DIG 5 ;
-                                                                                                  GET 3 ;
-                                                                                                  ADD ;
-                                                                                                  UPDATE 3 ;
-                                                                                                  SWAP ;
-                                                                                                  SELF_ADDRESS ;
-                                                                                                  SENDER ;
-                                                                                                  DUP 4 ;
-                                                                                                  DUP ;
-                                                                                                  GET 17 ;
-                                                                                                  CONTRACT %transfer (list (pair address (list (pair address (pair nat nat))))) ;
-                                                                                                  IF_NONE { PUSH nat 0 ; FAILWITH } {} ;
-                                                                                                  PUSH mutez 0 ;
-                                                                                                  NIL (pair address (list (pair address (pair nat nat)))) ;
-                                                                                                  NIL (pair address (pair nat nat)) ;
-                                                                                                  DIG 7 ;
-                                                                                                  DIG 5 ;
-                                                                                                  GET 19 ;
-                                                                                                  PAIR ;
-                                                                                                  DIG 6 ;
-                                                                                                  PAIR ;
-                                                                                                  CONS ;
-                                                                                                  DIG 4 ;
-                                                                                                  PAIR ;
-                                                                                                  CONS ;
-                                                                                                  TRANSFER_TOKENS ;
-                                                                                                  DIG 2 ;
-                                                                                                  INT ;
-                                                                                                  DIG 3 ;
-                                                                                                  DUP 4 ;
-                                                                                                  GET 21 ;
-                                                                                                  CONTRACT %mintOrBurn (pair (int %quantity) (address %target)) ;
-                                                                                                  IF_NONE { PUSH nat 12 ; FAILWITH } {} ;
-                                                                                                  PUSH mutez 0 ;
-                                                                                                  DIG 2 ;
-                                                                                                  DIG 3 ;
-                                                                                                  PAIR ;
-                                                                                                  TRANSFER_TOKENS ;
-                                                                                                  DIG 2 ;
-                                                                                                  NIL operation ;
-                                                                                                  DIG 2 ;
-                                                                                                  CONS ;
-                                                                                                  DIG 2 ;
-                                                                                                  CONS ;
-                                                                                                  PAIR } } } }
-                                                                                 { PUSH nat 43 ; FAILWITH } } } } } } } } } } } } } } } } } } } ;
+                                                                                    GT ;
+                                                                                    IF { PUSH nat 4 ; FAILWITH }
+                                                                                       { DIG 3 ;
+                                                                                         DUP 3 ;
+                                                                                         COMPARE ;
+                                                                                         LT ;
+                                                                                         IF { PUSH nat 5 ; FAILWITH }
+                                                                                            { DUP 4 ;
+                                                                                              DUP 3 ;
+                                                                                              DUP 6 ;
+                                                                                              GET 5 ;
+                                                                                              ADD ;
+                                                                                              UPDATE 5 ;
+                                                                                              DUP 2 ;
+                                                                                              DUP 6 ;
+                                                                                              CAR ;
+                                                                                              ADD ;
+                                                                                              UPDATE 1 ;
+                                                                                              AMOUNT ;
+                                                                                              DIG 5 ;
+                                                                                              GET 3 ;
+                                                                                              ADD ;
+                                                                                              UPDATE 3 ;
+                                                                                              SWAP ;
+                                                                                              SELF_ADDRESS ;
+                                                                                              SENDER ;
+                                                                                              DUP 4 ;
+                                                                                              DUP ;
+                                                                                              GET 17 ;
+                                                                                              CONTRACT %transfer (list (pair address (list (pair address (pair nat nat))))) ;
+                                                                                              IF_NONE { PUSH nat 0 ; FAILWITH } {} ;
+                                                                                              PUSH mutez 0 ;
+                                                                                              NIL (pair address (list (pair address (pair nat nat)))) ;
+                                                                                              NIL (pair address (pair nat nat)) ;
+                                                                                              DIG 7 ;
+                                                                                              DIG 5 ;
+                                                                                              GET 19 ;
+                                                                                              PAIR ;
+                                                                                              DIG 6 ;
+                                                                                              PAIR ;
+                                                                                              CONS ;
+                                                                                              DIG 4 ;
+                                                                                              PAIR ;
+                                                                                              CONS ;
+                                                                                              TRANSFER_TOKENS ;
+                                                                                              DIG 2 ;
+                                                                                              INT ;
+                                                                                              DIG 3 ;
+                                                                                              DUP 4 ;
+                                                                                              GET 21 ;
+                                                                                              CONTRACT %mintOrBurn (pair (int %quantity) (address %target)) ;
+                                                                                              IF_NONE { PUSH nat 12 ; FAILWITH } {} ;
+                                                                                              PUSH mutez 0 ;
+                                                                                              DIG 2 ;
+                                                                                              DIG 3 ;
+                                                                                              PAIR ;
+                                                                                              TRANSFER_TOKENS ;
+                                                                                              DIG 2 ;
+                                                                                              NIL operation ;
+                                                                                              DIG 2 ;
+                                                                                              CONS ;
+                                                                                              DIG 2 ;
+                                                                                              CONS ;
+                                                                                              PAIR } } } }
+                                                                             { PUSH nat 43 ; FAILWITH } } } } } } } } } } } } } } } } } } ;
   view "get_reserves"
        unit
        (pair nat nat)
@@ -1190,15 +1165,7 @@
   view "get_fee_bp"
        unit
        (pair nat (pair nat nat))
-       { CDR ;
-         DUP ;
-         GET 23 ;
-         PUSH nat 30 ;
-         ADD ;
-         SWAP ;
-         GET 23 ;
-         PUSH nat 30 ;
-         PAIR 3 } ;
+       { DROP ; PUSH nat 30 ; PUSH nat 5 ; PUSH nat 25 ; PAIR 3 } ;
   view "quote_tez_to_token"
        nat
        nat
@@ -1219,32 +1186,21 @@
          DUP 5 ;
          INT ;
          EQ ;
-         DUP 7 ;
+         DIG 6 ;
          GET 7 ;
          NOT ;
          OR ;
          OR ;
          OR ;
-         IF { DROP 4 ; PUSH nat 0 }
-            { PUSH nat 10000 ;
-              DIG 4 ;
-              GET 23 ;
-              DUP 5 ;
-              MUL ;
-              EDIV ;
-              IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-              DIG 3 ;
-              SUB ;
-              ISNAT ;
-              IF_NONE { PUSH nat 0 } {} ;
-              PUSH nat 997 ;
-              DUP 2 ;
+         IF { DROP 3 ; PUSH nat 0 }
+            { PUSH nat 997 ;
+              DUP 4 ;
               MUL ;
               PUSH nat 1000 ;
-              DIG 4 ;
+              DIG 3 ;
               MUL ;
               ADD ;
-              DIG 2 ;
+              SWAP ;
               PUSH nat 997 ;
               DIG 3 ;
               MUL ;
@@ -1271,32 +1227,21 @@
          DUP 5 ;
          INT ;
          EQ ;
-         DUP 7 ;
+         DIG 6 ;
          GET 7 ;
          NOT ;
          OR ;
          OR ;
          OR ;
-         IF { DROP 4 ; PUSH nat 0 }
-            { PUSH nat 10000 ;
-              DIG 4 ;
-              GET 23 ;
-              DUP 5 ;
-              MUL ;
-              EDIV ;
-              IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-              DIG 3 ;
-              SUB ;
-              ISNAT ;
-              IF_NONE { PUSH nat 0 } {} ;
-              PUSH nat 997 ;
-              DUP 2 ;
+         IF { DROP 3 ; PUSH nat 0 }
+            { PUSH nat 997 ;
+              DUP 4 ;
               MUL ;
               PUSH nat 1000 ;
-              DIG 3 ;
+              DIG 2 ;
               MUL ;
               ADD ;
-              DIG 2 ;
+              SWAP ;
               PUSH nat 997 ;
               DIG 3 ;
               MUL ;

--- a/dex/compiled_contracts/pool_fa2_mod.tz
+++ b/dex/compiled_contracts/pool_fa2_mod.tz
@@ -237,7 +237,7 @@
                                                       DUP 5 ;
                                                       CAR ;
                                                       COMPARE ;
-                                                      NEQ ;
+                                                      LT ;
                                                       DUP 4 ;
                                                       CAR ;
                                                       DUP 6 ;

--- a/dex/compiled_contracts/pool_fa2_mod.tz
+++ b/dex/compiled_contracts/pool_fa2_mod.tz
@@ -3,45 +3,51 @@
         (or (unit %claimProtocolFeeXtz)
             (or (address %setProtocolFeeRecipient)
                 (or (nat %setProtocolFee)
-                    (or (pair %tokenToToken
-                           (address %outputDexterContract)
-                           (pair (nat %minTokensBought)
-                                 (pair (address %to) (pair (nat %tokensSold) (timestamp %deadline)))))
-                        (or (list %updateTokenPoolInternal (pair (pair address nat) nat))
-                            (or (unit %updateTokenPool)
-                                (or (address %setLqtAddress)
-                                    (or (address %setManager)
-                                        (or (pair %setBaker (option %baker key_hash) (bool %freezeBaker))
-                                            (or (unit %default)
-                                                (or (pair %tokenToXtz
-                                                       (address %to)
-                                                       (pair (nat %tokensSold) (pair (mutez %minXtzBought) (timestamp %deadline))))
-                                                    (or (pair %xtzToToken (address %to) (pair (nat %minTokensBought) (timestamp %deadline)))
-                                                        (or (pair %removeLiquidity
+                    (or (nat %activateInternal)
+                        (or (pair %activate
+                               (mutez %expectedXtzPool)
+                               (pair (nat %expectedTokenPool) (nat %expectedLqtTotal)))
+                            (or (pair %tokenToToken
+                                   (address %outputDexterContract)
+                                   (pair (nat %minTokensBought)
+                                         (pair (address %to) (pair (nat %tokensSold) (timestamp %deadline)))))
+                                (or (list %updateTokenPoolInternal (pair (pair address nat) nat))
+                                    (or (unit %updateTokenPool)
+                                        (or (address %setLqtAddress)
+                                            (or (address %setManager)
+                                                (or (pair %setBaker (option %baker key_hash) (bool %freezeBaker))
+                                                    (or (unit %default)
+                                                        (or (pair %tokenToXtz
                                                                (address %to)
-                                                               (pair (nat %lqtBurned)
-                                                                     (pair (mutez %minXtzWithdrawn) (pair (nat %minTokensWithdrawn) (timestamp %deadline)))))
-                                                            (pair %addLiquidity
-                                                               (address %owner)
-                                                               (pair (nat %minLqtMinted) (pair (nat %maxTokensDeposited) (timestamp %deadline)))))))))))))))))) ;
+                                                               (pair (nat %tokensSold) (pair (mutez %minXtzBought) (timestamp %deadline))))
+                                                            (or (pair %xtzToToken (address %to) (pair (nat %minTokensBought) (timestamp %deadline)))
+                                                                (or (pair %removeLiquidity
+                                                                       (address %to)
+                                                                       (pair (nat %lqtBurned)
+                                                                             (pair (mutez %minXtzWithdrawn) (pair (nat %minTokensWithdrawn) (timestamp %deadline)))))
+                                                                    (pair %addLiquidity
+                                                                       (address %owner)
+                                                                       (pair (nat %minLqtMinted) (pair (nat %maxTokensDeposited) (timestamp %deadline)))))))))))))))))))) ;
   storage
     (pair (nat %tokenPool)
           (pair (mutez %xtzPool)
                 (pair (nat %lqtTotal)
-                      (pair (bool %selfIsUpdatingTokenPool)
-                            (pair (bool %freezeBaker)
-                                  (pair (address %manager)
-                                        (pair (address %tokenAddress)
-                                              (pair (nat %tokenId)
-                                                    (pair (address %lqtAddress)
-                                                          (pair (nat %protocol_fee_bp)
-                                                                (pair (address %protocol_fee_recipient)
-                                                                      (pair (mutez %accumulated_protocol_fee_xtz) (nat %accumulated_protocol_fee_token))))))))))))) ;
+                      (pair (bool %active)
+                            (pair (bool %activationPending)
+                                  (pair (bool %selfIsUpdatingTokenPool)
+                                        (pair (bool %freezeBaker)
+                                              (pair (address %manager)
+                                                    (pair (address %tokenAddress)
+                                                          (pair (nat %tokenId)
+                                                                (pair (address %lqtAddress)
+                                                                      (pair (nat %protocol_fee_bp)
+                                                                            (pair (address %protocol_fee_recipient)
+                                                                                  (pair (mutez %accumulated_protocol_fee_xtz) (nat %accumulated_protocol_fee_token))))))))))))))) ;
   code { UNPAIR ;
          IF_LEFT
            { DROP ;
              DUP ;
-             GET 7 ;
+             GET 11 ;
              IF { PUSH nat 2 ; FAILWITH }
                 { PUSH mutez 0 ;
                   AMOUNT ;
@@ -49,28 +55,28 @@
                   GT ;
                   IF { PUSH nat 10 ; FAILWITH }
                      { DUP ;
-                       GET 21 ;
+                       GET 25 ;
                        SENDER ;
                        COMPARE ;
                        NEQ ;
                        IF { PUSH nat 39 ; FAILWITH }
                           { PUSH nat 0 ;
                             DUP 2 ;
-                            GET 24 ;
+                            GET 28 ;
                             COMPARE ;
                             EQ ;
                             IF { PUSH nat 40 ; FAILWITH }
                                { DUP ;
                                  PUSH nat 0 ;
-                                 UPDATE 24 ;
+                                 UPDATE 28 ;
                                  SWAP ;
-                                 GET 24 ;
+                                 GET 28 ;
                                  DUP 2 ;
-                                 GET 21 ;
+                                 GET 25 ;
                                  SELF_ADDRESS ;
                                  DUP 4 ;
                                  DUP ;
-                                 GET 13 ;
+                                 GET 17 ;
                                  CONTRACT %transfer (list (pair address (list (pair address (pair nat nat))))) ;
                                  IF_NONE { PUSH nat 0 ; FAILWITH } {} ;
                                  PUSH mutez 0 ;
@@ -78,7 +84,7 @@
                                  NIL (pair address (pair nat nat)) ;
                                  DIG 7 ;
                                  DIG 5 ;
-                                 GET 15 ;
+                                 GET 19 ;
                                  PAIR ;
                                  DIG 6 ;
                                  PAIR ;
@@ -95,7 +101,7 @@
            { IF_LEFT
                { DROP ;
                  DUP ;
-                 GET 7 ;
+                 GET 11 ;
                  IF { PUSH nat 2 ; FAILWITH }
                     { PUSH mutez 0 ;
                       AMOUNT ;
@@ -103,26 +109,26 @@
                       GT ;
                       IF { PUSH nat 10 ; FAILWITH }
                          { DUP ;
-                           GET 21 ;
+                           GET 25 ;
                            SENDER ;
                            COMPARE ;
                            NEQ ;
                            IF { PUSH nat 39 ; FAILWITH }
                               { PUSH mutez 0 ;
                                 DUP 2 ;
-                                GET 23 ;
+                                GET 27 ;
                                 COMPARE ;
                                 EQ ;
                                 IF { PUSH nat 40 ; FAILWITH }
                                    { DUP ;
                                      PUSH mutez 0 ;
-                                     UPDATE 23 ;
+                                     UPDATE 27 ;
                                      DUP ;
-                                     GET 21 ;
+                                     GET 25 ;
                                      CONTRACT unit ;
                                      IF_NONE { PUSH nat 9 ; FAILWITH } {} ;
                                      DIG 2 ;
-                                     GET 23 ;
+                                     GET 27 ;
                                      UNIT ;
                                      TRANSFER_TOKENS ;
                                      SWAP ;
@@ -132,7 +138,7 @@
                                      PAIR } } } } }
                { IF_LEFT
                    { DUP 2 ;
-                     GET 7 ;
+                     GET 11 ;
                      IF { PUSH nat 2 ; FAILWITH }
                         { PUSH mutez 0 ;
                           AMOUNT ;
@@ -140,14 +146,14 @@
                           GT ;
                           IF { PUSH nat 10 ; FAILWITH }
                              { DUP 2 ;
-                               GET 11 ;
+                               GET 15 ;
                                SENDER ;
                                COMPARE ;
                                NEQ ;
-                               IF { PUSH nat 41 ; FAILWITH } { UPDATE 21 ; NIL operation ; PAIR } } } }
+                               IF { PUSH nat 41 ; FAILWITH } { UPDATE 25 ; NIL operation ; PAIR } } } }
                    { IF_LEFT
                        { DUP 2 ;
-                         GET 7 ;
+                         GET 11 ;
                          IF { PUSH nat 2 ; FAILWITH }
                             { PUSH mutez 0 ;
                               AMOUNT ;
@@ -155,7 +161,7 @@
                               GT ;
                               IF { PUSH nat 10 ; FAILWITH }
                                  { DUP 2 ;
-                                   GET 11 ;
+                                   GET 15 ;
                                    SENDER ;
                                    COMPARE ;
                                    NEQ ;
@@ -164,671 +170,545 @@
                                         DUP 2 ;
                                         COMPARE ;
                                         GT ;
-                                        IF { PUSH nat 38 ; FAILWITH } { UPDATE 19 ; NIL operation ; PAIR } } } } }
+                                        IF { PUSH nat 38 ; FAILWITH } { UPDATE 23 ; NIL operation ; PAIR } } } } }
                        { IF_LEFT
-                           { UNPAIR 5 ;
-                             CONTRACT %xtzToToken
-                               (pair (address %to) (pair (nat %minTokensBought) (timestamp %deadline))) ;
-                             IF_NONE { PUSH nat 31 ; FAILWITH } {} ;
-                             DUP 6 ;
-                             GET 7 ;
-                             IF { PUSH nat 2 ; FAILWITH }
+                           { DUP 2 ;
+                             GET 21 ;
+                             SENDER ;
+                             COMPARE ;
+                             NEQ ;
+                             DUP 3 ;
+                             GET 9 ;
+                             NOT ;
+                             OR ;
+                             IF { PUSH nat 49 ; FAILWITH }
                                 { PUSH mutez 0 ;
                                   AMOUNT ;
                                   COMPARE ;
                                   GT ;
                                   IF { PUSH nat 10 ; FAILWITH }
-                                     { DUP 5 ;
-                                       NOW ;
+                                     { DUP 2 ;
+                                       GET 5 ;
                                        COMPARE ;
-                                       GE ;
-                                       IF { PUSH nat 3 ; FAILWITH }
-                                          { PUSH nat 10000 ;
-                                            DUP 7 ;
-                                            GET 19 ;
-                                            DUP 6 ;
-                                            MUL ;
-                                            EDIV ;
-                                            IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                            DUP ;
-                                            DUP 6 ;
-                                            SUB ;
-                                            ISNAT ;
-                                            IF_NONE { PUSH nat 34 ; FAILWITH } {} ;
-                                            PUSH nat 997 ;
+                                       NEQ ;
+                                       IF { PUSH nat 50 ; FAILWITH }
+                                          { PUSH nat 0 ;
                                             DUP 2 ;
-                                            MUL ;
-                                            PUSH nat 1000 ;
-                                            DUP 10 ;
+                                            GET 5 ;
+                                            COMPARE ;
+                                            EQ ;
+                                            PUSH nat 0 ;
+                                            DUP 3 ;
                                             CAR ;
-                                            MUL ;
-                                            ADD ;
-                                            PUSH mutez 1 ;
-                                            DUP 10 ;
-                                            GET 3 ;
-                                            EDIV ;
-                                            IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                            PUSH nat 997 ;
-                                            DUP 4 ;
-                                            MUL ;
-                                            MUL ;
-                                            EDIV ;
-                                            IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                            PUSH mutez 1 ;
-                                            DUP 10 ;
-                                            GET 3 ;
-                                            EDIV ;
-                                            IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                            DUP 2 ;
-                                            SWAP ;
-                                            SUB ;
-                                            ISNAT ;
-                                            IF_NONE { PUSH nat 36 ; FAILWITH } {} ;
-                                            PUSH mutez 1 ;
-                                            SWAP ;
-                                            MUL ;
-                                            PUSH mutez 1 ;
-                                            DIG 2 ;
-                                            MUL ;
-                                            DUP 10 ;
-                                            DIG 3 ;
-                                            DUP 11 ;
-                                            CAR ;
-                                            ADD ;
-                                            UPDATE 1 ;
-                                            DIG 2 ;
-                                            UPDATE 3 ;
-                                            DIG 2 ;
-                                            DIG 8 ;
-                                            GET 24 ;
-                                            ADD ;
-                                            UPDATE 24 ;
-                                            DIG 5 ;
-                                            SELF_ADDRESS ;
-                                            SENDER ;
-                                            DUP 4 ;
-                                            DUP ;
-                                            GET 13 ;
-                                            CONTRACT %transfer (list (pair address (list (pair address (pair nat nat))))) ;
-                                            IF_NONE { PUSH nat 0 ; FAILWITH } {} ;
+                                            COMPARE ;
+                                            EQ ;
                                             PUSH mutez 0 ;
-                                            NIL (pair address (list (pair address (pair nat nat)))) ;
-                                            NIL (pair address (pair nat nat)) ;
-                                            DIG 7 ;
-                                            DIG 5 ;
-                                            GET 15 ;
-                                            PAIR ;
-                                            DIG 6 ;
-                                            PAIR ;
-                                            CONS ;
-                                            DIG 4 ;
-                                            PAIR ;
-                                            CONS ;
-                                            TRANSFER_TOKENS ;
-                                            DIG 3 ;
-                                            DIG 3 ;
-                                            DIG 6 ;
-                                            DIG 5 ;
-                                            DIG 6 ;
-                                            PAIR 3 ;
-                                            TRANSFER_TOKENS ;
-                                            DIG 2 ;
-                                            NIL operation ;
-                                            DIG 2 ;
-                                            CONS ;
-                                            DIG 2 ;
-                                            CONS ;
-                                            PAIR } } } }
+                                            DUP 4 ;
+                                            GET 3 ;
+                                            COMPARE ;
+                                            EQ ;
+                                            OR ;
+                                            OR ;
+                                            IF { PUSH nat 47 ; FAILWITH }
+                                               { PUSH bool True ;
+                                                 UPDATE 7 ;
+                                                 PUSH bool False ;
+                                                 UPDATE 9 ;
+                                                 NIL operation ;
+                                                 PAIR } } } } }
                            { IF_LEFT
                                { DUP 2 ;
-                                 GET 13 ;
-                                 SENDER ;
-                                 COMPARE ;
-                                 NEQ ;
-                                 DUP 3 ;
-                                 GET 7 ;
-                                 NOT ;
-                                 OR ;
-                                 IF { PUSH nat 29 ; FAILWITH }
+                                 GET 11 ;
+                                 IF { PUSH nat 2 ; FAILWITH }
                                     { PUSH mutez 0 ;
                                       AMOUNT ;
                                       COMPARE ;
                                       GT ;
                                       IF { PUSH nat 10 ; FAILWITH }
-                                         { IF_CONS { SWAP ; DROP ; SOME } { NONE (pair (pair address nat) nat) } ;
-                                           IF_NONE { PUSH nat 32 ; FAILWITH } { CDR } ;
-                                           DUP 2 ;
-                                           GET 24 ;
-                                           SWAP ;
-                                           SUB ;
-                                           ISNAT ;
-                                           IF_NONE { PUSH nat 42 ; FAILWITH } {} ;
-                                           UPDATE 1 ;
-                                           PUSH bool False ;
-                                           UPDATE 7 ;
-                                           NIL operation ;
-                                           PAIR } } }
+                                         { DUP 2 ;
+                                           GET 15 ;
+                                           SENDER ;
+                                           COMPARE ;
+                                           NEQ ;
+                                           IF { PUSH nat 45 ; FAILWITH }
+                                              { DUP 2 ;
+                                                GET 9 ;
+                                                DUP 3 ;
+                                                GET 7 ;
+                                                OR ;
+                                                IF { PUSH nat 44 ; FAILWITH }
+                                                   { PUSH address "tz1Ke2h7sDdakHJQh8WX4Z372du1KChsksyU" ;
+                                                     DUP 3 ;
+                                                     GET 21 ;
+                                                     COMPARE ;
+                                                     EQ ;
+                                                     IF { PUSH nat 46 ; FAILWITH }
+                                                        { DUP ;
+                                                          CAR ;
+                                                          BALANCE ;
+                                                          COMPARE ;
+                                                          NEQ ;
+                                                          DUP 2 ;
+                                                          GET 4 ;
+                                                          DUP 4 ;
+                                                          GET 5 ;
+                                                          COMPARE ;
+                                                          NEQ ;
+                                                          DUP 3 ;
+                                                          GET 3 ;
+                                                          DUP 5 ;
+                                                          CAR ;
+                                                          COMPARE ;
+                                                          NEQ ;
+                                                          DUP 4 ;
+                                                          CAR ;
+                                                          DUP 6 ;
+                                                          GET 3 ;
+                                                          COMPARE ;
+                                                          NEQ ;
+                                                          PUSH nat 0 ;
+                                                          DUP 6 ;
+                                                          GET 4 ;
+                                                          COMPARE ;
+                                                          EQ ;
+                                                          PUSH nat 0 ;
+                                                          DUP 7 ;
+                                                          GET 3 ;
+                                                          COMPARE ;
+                                                          EQ ;
+                                                          PUSH mutez 0 ;
+                                                          DIG 7 ;
+                                                          CAR ;
+                                                          COMPARE ;
+                                                          EQ ;
+                                                          OR ;
+                                                          OR ;
+                                                          OR ;
+                                                          OR ;
+                                                          OR ;
+                                                          OR ;
+                                                          IF { PUSH nat 47 ; FAILWITH }
+                                                             { SELF_ADDRESS ;
+                                                               CONTRACT %activateInternal nat ;
+                                                               IF_NONE
+                                                                 { PUSH string "Cannot get activateInternal entrypoint" ; FAILWITH }
+                                                                 {} ;
+                                                               DUP 2 ;
+                                                               GET 21 ;
+                                                               CONTRACT %getTotalSupply (pair (unit %request) (contract %callback nat)) ;
+                                                               IF_NONE { PUSH nat 48 ; FAILWITH } {} ;
+                                                               PUSH mutez 0 ;
+                                                               DIG 2 ;
+                                                               UNIT ;
+                                                               PAIR ;
+                                                               TRANSFER_TOKENS ;
+                                                               SWAP ;
+                                                               PUSH bool True ;
+                                                               UPDATE 9 ;
+                                                               NIL operation ;
+                                                               DIG 2 ;
+                                                               CONS ;
+                                                               PAIR } } } } } } }
                                { IF_LEFT
-                                   { DROP ;
-                                     SOURCE ;
-                                     SENDER ;
-                                     COMPARE ;
-                                     NEQ ;
-                                     IF { PUSH nat 25 ; FAILWITH }
-                                        { PUSH mutez 0 ;
-                                          AMOUNT ;
+                                   { UNPAIR 5 ;
+                                     CONTRACT %xtzToToken
+                                       (pair (address %to) (pair (nat %minTokensBought) (timestamp %deadline))) ;
+                                     IF_NONE { PUSH nat 31 ; FAILWITH } {} ;
+                                     DUP 6 ;
+                                     GET 11 ;
+                                     IF { PUSH nat 2 ; FAILWITH }
+                                        { PUSH nat 0 ;
+                                          DUP 7 ;
+                                          GET 5 ;
                                           COMPARE ;
                                           GT ;
-                                          IF { PUSH nat 10 ; FAILWITH }
-                                             { DUP ;
-                                               GET 7 ;
-                                               IF { PUSH nat 33 ; FAILWITH }
-                                                  { SELF_ADDRESS ;
-                                                    CONTRACT %updateTokenPoolInternal (list (pair (pair address nat) nat)) ;
-                                                    IF_NONE
-                                                      { PUSH string "Cannot get updateTokenPoolInternal entrypoint" ; FAILWITH }
-                                                      {} ;
-                                                    DUP 2 ;
-                                                    GET 13 ;
-                                                    CONTRACT %balance_of
-                                                      (pair (list (pair address nat)) (contract (list (pair (pair address nat) nat)))) ;
-                                                    IF_NONE { PUSH nat 28 ; FAILWITH } {} ;
-                                                    PUSH mutez 0 ;
-                                                    DIG 2 ;
-                                                    NIL (pair address nat) ;
-                                                    DUP 5 ;
-                                                    GET 15 ;
-                                                    SELF_ADDRESS ;
-                                                    PAIR ;
-                                                    CONS ;
-                                                    PAIR ;
-                                                    TRANSFER_TOKENS ;
-                                                    SWAP ;
-                                                    PUSH bool True ;
-                                                    UPDATE 7 ;
-                                                    NIL operation ;
-                                                    DIG 2 ;
-                                                    CONS ;
-                                                    PAIR } } } }
+                                          PUSH nat 0 ;
+                                          DUP 8 ;
+                                          CAR ;
+                                          COMPARE ;
+                                          GT ;
+                                          PUSH mutez 0 ;
+                                          DUP 9 ;
+                                          GET 3 ;
+                                          COMPARE ;
+                                          GT ;
+                                          DUP 9 ;
+                                          GET 7 ;
+                                          AND ;
+                                          AND ;
+                                          AND ;
+                                          IF { PUSH mutez 0 ;
+                                               AMOUNT ;
+                                               COMPARE ;
+                                               GT ;
+                                               IF { PUSH nat 10 ; FAILWITH }
+                                                  { DUP 5 ;
+                                                    NOW ;
+                                                    COMPARE ;
+                                                    GE ;
+                                                    IF { PUSH nat 3 ; FAILWITH }
+                                                       { PUSH nat 10000 ;
+                                                         DUP 7 ;
+                                                         GET 23 ;
+                                                         DUP 6 ;
+                                                         MUL ;
+                                                         EDIV ;
+                                                         IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                         DUP ;
+                                                         DUP 6 ;
+                                                         SUB ;
+                                                         ISNAT ;
+                                                         IF_NONE { PUSH nat 34 ; FAILWITH } {} ;
+                                                         PUSH nat 997 ;
+                                                         DUP 2 ;
+                                                         MUL ;
+                                                         PUSH nat 1000 ;
+                                                         DUP 10 ;
+                                                         CAR ;
+                                                         MUL ;
+                                                         ADD ;
+                                                         PUSH mutez 1 ;
+                                                         DUP 10 ;
+                                                         GET 3 ;
+                                                         EDIV ;
+                                                         IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                         PUSH nat 997 ;
+                                                         DUP 4 ;
+                                                         MUL ;
+                                                         MUL ;
+                                                         EDIV ;
+                                                         IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                         PUSH mutez 1 ;
+                                                         DUP 10 ;
+                                                         GET 3 ;
+                                                         EDIV ;
+                                                         IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                         DUP 2 ;
+                                                         SWAP ;
+                                                         SUB ;
+                                                         ISNAT ;
+                                                         IF_NONE { PUSH nat 36 ; FAILWITH } {} ;
+                                                         PUSH mutez 1 ;
+                                                         SWAP ;
+                                                         MUL ;
+                                                         PUSH mutez 1 ;
+                                                         DIG 2 ;
+                                                         MUL ;
+                                                         DUP 10 ;
+                                                         DIG 3 ;
+                                                         DUP 11 ;
+                                                         CAR ;
+                                                         ADD ;
+                                                         UPDATE 1 ;
+                                                         DIG 2 ;
+                                                         UPDATE 3 ;
+                                                         DIG 2 ;
+                                                         DIG 8 ;
+                                                         GET 28 ;
+                                                         ADD ;
+                                                         UPDATE 28 ;
+                                                         DIG 5 ;
+                                                         SELF_ADDRESS ;
+                                                         SENDER ;
+                                                         DUP 4 ;
+                                                         DUP ;
+                                                         GET 17 ;
+                                                         CONTRACT %transfer (list (pair address (list (pair address (pair nat nat))))) ;
+                                                         IF_NONE { PUSH nat 0 ; FAILWITH } {} ;
+                                                         PUSH mutez 0 ;
+                                                         NIL (pair address (list (pair address (pair nat nat)))) ;
+                                                         NIL (pair address (pair nat nat)) ;
+                                                         DIG 7 ;
+                                                         DIG 5 ;
+                                                         GET 19 ;
+                                                         PAIR ;
+                                                         DIG 6 ;
+                                                         PAIR ;
+                                                         CONS ;
+                                                         DIG 4 ;
+                                                         PAIR ;
+                                                         CONS ;
+                                                         TRANSFER_TOKENS ;
+                                                         DIG 3 ;
+                                                         DIG 3 ;
+                                                         DIG 6 ;
+                                                         DIG 5 ;
+                                                         DIG 6 ;
+                                                         PAIR 3 ;
+                                                         TRANSFER_TOKENS ;
+                                                         DIG 2 ;
+                                                         NIL operation ;
+                                                         DIG 2 ;
+                                                         CONS ;
+                                                         DIG 2 ;
+                                                         CONS ;
+                                                         PAIR } } }
+                                             { PUSH nat 43 ; FAILWITH } } }
                                    { IF_LEFT
                                        { DUP 2 ;
-                                         GET 7 ;
-                                         IF { PUSH nat 2 ; FAILWITH }
+                                         GET 17 ;
+                                         SENDER ;
+                                         COMPARE ;
+                                         NEQ ;
+                                         DUP 3 ;
+                                         GET 11 ;
+                                         NOT ;
+                                         OR ;
+                                         IF { PUSH nat 29 ; FAILWITH }
                                             { PUSH mutez 0 ;
                                               AMOUNT ;
                                               COMPARE ;
                                               GT ;
                                               IF { PUSH nat 10 ; FAILWITH }
-                                                 { DUP 2 ;
-                                                   GET 11 ;
-                                                   SENDER ;
-                                                   COMPARE ;
-                                                   NEQ ;
-                                                   IF { PUSH nat 23 ; FAILWITH }
-                                                      { PUSH address "tz1Ke2h7sDdakHJQh8WX4Z372du1KChsksyU" ;
-                                                        DUP 3 ;
-                                                        GET 17 ;
-                                                        COMPARE ;
-                                                        NEQ ;
-                                                        IF { PUSH nat 24 ; FAILWITH } { UPDATE 17 ; NIL operation ; PAIR } } } } }
+                                                 { IF_CONS
+                                                     { UNPAIR ;
+                                                       UNPAIR ;
+                                                       DIG 3 ;
+                                                       IF_CONS
+                                                         { PUSH nat 32 ; FAILWITH }
+                                                         { DUP 4 ;
+                                                           GET 19 ;
+                                                           DIG 2 ;
+                                                           COMPARE ;
+                                                           EQ ;
+                                                           SELF_ADDRESS ;
+                                                           DIG 2 ;
+                                                           COMPARE ;
+                                                           EQ ;
+                                                           AND ;
+                                                           IF {} { PUSH nat 32 ; FAILWITH } } }
+                                                     { PUSH nat 32 ; FAILWITH } ;
+                                                   DUP 2 ;
+                                                   GET 28 ;
+                                                   SWAP ;
+                                                   SUB ;
+                                                   ISNAT ;
+                                                   IF_NONE { PUSH nat 42 ; FAILWITH } {} ;
+                                                   UPDATE 1 ;
+                                                   PUSH bool False ;
+                                                   UPDATE 11 ;
+                                                   NIL operation ;
+                                                   PAIR } } }
                                        { IF_LEFT
-                                           { DUP 2 ;
-                                             GET 7 ;
-                                             IF { PUSH nat 2 ; FAILWITH }
+                                           { DROP ;
+                                             SOURCE ;
+                                             SENDER ;
+                                             COMPARE ;
+                                             NEQ ;
+                                             IF { PUSH nat 25 ; FAILWITH }
                                                 { PUSH mutez 0 ;
                                                   AMOUNT ;
                                                   COMPARE ;
                                                   GT ;
                                                   IF { PUSH nat 10 ; FAILWITH }
-                                                     { DUP 2 ;
+                                                     { DUP ;
                                                        GET 11 ;
-                                                       SENDER ;
-                                                       COMPARE ;
-                                                       NEQ ;
-                                                       IF { PUSH nat 21 ; FAILWITH } { UPDATE 11 ; NIL operation ; PAIR } } } }
+                                                       IF { PUSH nat 33 ; FAILWITH }
+                                                          { DUP ;
+                                                            GET 15 ;
+                                                            SENDER ;
+                                                            COMPARE ;
+                                                            NEQ ;
+                                                            DUP 2 ;
+                                                            GET 7 ;
+                                                            NOT ;
+                                                            AND ;
+                                                            IF { PUSH nat 45 ; FAILWITH }
+                                                               { SELF_ADDRESS ;
+                                                                 CONTRACT %updateTokenPoolInternal (list (pair (pair address nat) nat)) ;
+                                                                 IF_NONE
+                                                                   { PUSH string "Cannot get updateTokenPoolInternal entrypoint" ; FAILWITH }
+                                                                   {} ;
+                                                                 DUP 2 ;
+                                                                 GET 17 ;
+                                                                 CONTRACT %balance_of
+                                                                   (pair (list (pair address nat)) (contract (list (pair (pair address nat) nat)))) ;
+                                                                 IF_NONE { PUSH nat 28 ; FAILWITH } {} ;
+                                                                 PUSH mutez 0 ;
+                                                                 DIG 2 ;
+                                                                 NIL (pair address nat) ;
+                                                                 DUP 5 ;
+                                                                 GET 19 ;
+                                                                 SELF_ADDRESS ;
+                                                                 PAIR ;
+                                                                 CONS ;
+                                                                 PAIR ;
+                                                                 TRANSFER_TOKENS ;
+                                                                 SWAP ;
+                                                                 PUSH bool True ;
+                                                                 UPDATE 11 ;
+                                                                 NIL operation ;
+                                                                 DIG 2 ;
+                                                                 CONS ;
+                                                                 PAIR } } } } }
                                            { IF_LEFT
-                                               { UNPAIR ;
-                                                 DUP 3 ;
-                                                 GET 7 ;
+                                               { DUP 2 ;
+                                                 GET 11 ;
                                                  IF { PUSH nat 2 ; FAILWITH }
                                                     { PUSH mutez 0 ;
                                                       AMOUNT ;
                                                       COMPARE ;
                                                       GT ;
                                                       IF { PUSH nat 10 ; FAILWITH }
-                                                         { DUP 3 ;
-                                                           GET 11 ;
+                                                         { DUP 2 ;
+                                                           GET 15 ;
                                                            SENDER ;
                                                            COMPARE ;
                                                            NEQ ;
-                                                           IF { PUSH nat 20 ; FAILWITH }
-                                                              { DUP 3 ;
-                                                                GET 9 ;
-                                                                IF { PUSH nat 22 ; FAILWITH }
-                                                                   { DUG 2 ; UPDATE 9 ; NIL operation ; DIG 2 ; SET_DELEGATE ; CONS ; PAIR } } } } }
+                                                           IF { PUSH nat 23 ; FAILWITH }
+                                                              { PUSH address "tz1Ke2h7sDdakHJQh8WX4Z372du1KChsksyU" ;
+                                                                DUP 3 ;
+                                                                GET 21 ;
+                                                                COMPARE ;
+                                                                NEQ ;
+                                                                IF { PUSH nat 24 ; FAILWITH } { UPDATE 21 ; NIL operation ; PAIR } } } } }
                                                { IF_LEFT
-                                                   { DROP ;
-                                                     DUP ;
-                                                     GET 7 ;
+                                                   { DUP 2 ;
+                                                     GET 11 ;
                                                      IF { PUSH nat 2 ; FAILWITH }
-                                                        { DUP ; AMOUNT ; DIG 2 ; GET 3 ; ADD ; UPDATE 3 ; NIL operation ; PAIR } }
+                                                        { PUSH mutez 0 ;
+                                                          AMOUNT ;
+                                                          COMPARE ;
+                                                          GT ;
+                                                          IF { PUSH nat 10 ; FAILWITH }
+                                                             { DUP 2 ;
+                                                               GET 15 ;
+                                                               SENDER ;
+                                                               COMPARE ;
+                                                               NEQ ;
+                                                               IF { PUSH nat 21 ; FAILWITH } { UPDATE 15 ; NIL operation ; PAIR } } } }
                                                    { IF_LEFT
-                                                       { UNPAIR 4 ;
-                                                         DUP 5 ;
-                                                         GET 7 ;
+                                                       { UNPAIR ;
+                                                         DUP 3 ;
+                                                         GET 11 ;
                                                          IF { PUSH nat 2 ; FAILWITH }
-                                                            { DIG 3 ;
-                                                              NOW ;
+                                                            { PUSH mutez 0 ;
+                                                              AMOUNT ;
                                                               COMPARE ;
-                                                              GE ;
-                                                              IF { PUSH nat 3 ; FAILWITH }
-                                                                 { PUSH mutez 0 ;
-                                                                   AMOUNT ;
+                                                              GT ;
+                                                              IF { PUSH nat 10 ; FAILWITH }
+                                                                 { DUP 3 ;
+                                                                   GET 15 ;
+                                                                   SENDER ;
                                                                    COMPARE ;
-                                                                   GT ;
-                                                                   IF { PUSH nat 10 ; FAILWITH }
-                                                                      { PUSH nat 10000 ;
-                                                                        DUP 5 ;
-                                                                        GET 19 ;
-                                                                        DUP 4 ;
-                                                                        MUL ;
-                                                                        EDIV ;
-                                                                        IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                        DUP ;
-                                                                        DUP 4 ;
-                                                                        SUB ;
-                                                                        ISNAT ;
-                                                                        IF_NONE { PUSH nat 34 ; FAILWITH } {} ;
-                                                                        PUSH nat 997 ;
-                                                                        DUP 2 ;
-                                                                        MUL ;
-                                                                        PUSH nat 1000 ;
-                                                                        DUP 8 ;
-                                                                        CAR ;
-                                                                        MUL ;
-                                                                        ADD ;
-                                                                        PUSH mutez 1 ;
-                                                                        DUP 8 ;
-                                                                        GET 3 ;
-                                                                        EDIV ;
-                                                                        IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                        PUSH nat 997 ;
-                                                                        DUP 4 ;
-                                                                        MUL ;
-                                                                        MUL ;
-                                                                        EDIV ;
-                                                                        IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                        PUSH mutez 1 ;
-                                                                        SWAP ;
-                                                                        MUL ;
-                                                                        DIG 5 ;
-                                                                        DUP 2 ;
-                                                                        COMPARE ;
-                                                                        LT ;
-                                                                        IF { PUSH nat 8 ; FAILWITH } {} ;
-                                                                        PUSH mutez 1 ;
-                                                                        DUP 7 ;
-                                                                        GET 3 ;
-                                                                        EDIV ;
-                                                                        IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                        PUSH mutez 1 ;
-                                                                        DUP 3 ;
-                                                                        EDIV ;
-                                                                        IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                        SWAP ;
-                                                                        SUB ;
-                                                                        ISNAT ;
-                                                                        IF_NONE { PUSH nat 36 ; FAILWITH } {} ;
-                                                                        PUSH mutez 1 ;
-                                                                        SWAP ;
-                                                                        MUL ;
-                                                                        DIG 5 ;
-                                                                        SELF_ADDRESS ;
-                                                                        SENDER ;
-                                                                        DUP 9 ;
-                                                                        DUP ;
+                                                                   NEQ ;
+                                                                   IF { PUSH nat 20 ; FAILWITH }
+                                                                      { DUP 3 ;
                                                                         GET 13 ;
-                                                                        CONTRACT %transfer (list (pair address (list (pair address (pair nat nat))))) ;
-                                                                        IF_NONE { PUSH nat 0 ; FAILWITH } {} ;
-                                                                        PUSH mutez 0 ;
-                                                                        NIL (pair address (list (pair address (pair nat nat)))) ;
-                                                                        NIL (pair address (pair nat nat)) ;
-                                                                        DIG 7 ;
-                                                                        DIG 5 ;
-                                                                        GET 15 ;
-                                                                        PAIR ;
-                                                                        DIG 6 ;
-                                                                        PAIR ;
-                                                                        CONS ;
-                                                                        DIG 4 ;
-                                                                        PAIR ;
-                                                                        CONS ;
-                                                                        TRANSFER_TOKENS ;
-                                                                        DIG 5 ;
-                                                                        CONTRACT unit ;
-                                                                        IF_NONE { PUSH nat 9 ; FAILWITH } {} ;
-                                                                        DIG 3 ;
-                                                                        UNIT ;
-                                                                        TRANSFER_TOKENS ;
-                                                                        DUP 6 ;
-                                                                        DIG 4 ;
-                                                                        DUP 7 ;
-                                                                        CAR ;
-                                                                        ADD ;
-                                                                        UPDATE 1 ;
-                                                                        DIG 3 ;
-                                                                        UPDATE 3 ;
-                                                                        DIG 3 ;
-                                                                        DIG 4 ;
-                                                                        GET 24 ;
-                                                                        ADD ;
-                                                                        UPDATE 24 ;
-                                                                        NIL operation ;
-                                                                        DIG 2 ;
-                                                                        CONS ;
-                                                                        DIG 2 ;
-                                                                        CONS ;
-                                                                        PAIR } } } }
+                                                                        IF { PUSH nat 22 ; FAILWITH }
+                                                                           { DUG 2 ; UPDATE 13 ; NIL operation ; DIG 2 ; SET_DELEGATE ; CONS ; PAIR } } } } }
                                                        { IF_LEFT
-                                                           { UNPAIR 3 ;
-                                                             DUP 4 ;
-                                                             GET 7 ;
+                                                           { DROP ;
+                                                             DUP ;
+                                                             GET 11 ;
                                                              IF { PUSH nat 2 ; FAILWITH }
-                                                                { DIG 2 ;
-                                                                  NOW ;
+                                                                { DUP ;
+                                                                  GET 15 ;
+                                                                  SENDER ;
                                                                   COMPARE ;
-                                                                  GE ;
-                                                                  IF { PUSH nat 3 ; FAILWITH }
-                                                                     { PUSH mutez 1 ;
-                                                                       DUP 4 ;
-                                                                       GET 3 ;
-                                                                       EDIV ;
-                                                                       IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                       PUSH mutez 1 ;
-                                                                       AMOUNT ;
-                                                                       EDIV ;
-                                                                       IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                       PUSH nat 10000 ;
-                                                                       DUP 6 ;
-                                                                       GET 19 ;
-                                                                       DUP 3 ;
-                                                                       MUL ;
-                                                                       EDIV ;
-                                                                       IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                       DUP ;
-                                                                       DIG 2 ;
-                                                                       SUB ;
-                                                                       ISNAT ;
-                                                                       IF_NONE { PUSH nat 34 ; FAILWITH } {} ;
-                                                                       PUSH nat 997 ;
-                                                                       DUP 2 ;
-                                                                       MUL ;
-                                                                       PUSH nat 1000 ;
-                                                                       DIG 4 ;
-                                                                       MUL ;
-                                                                       ADD ;
-                                                                       DUP 6 ;
-                                                                       CAR ;
-                                                                       PUSH nat 997 ;
-                                                                       DUP 4 ;
-                                                                       MUL ;
-                                                                       MUL ;
-                                                                       EDIV ;
-                                                                       IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                       DIG 4 ;
-                                                                       DUP 2 ;
-                                                                       COMPARE ;
-                                                                       LT ;
-                                                                       IF { PUSH nat 18 ; FAILWITH } {} ;
-                                                                       DUP ;
-                                                                       DUP 6 ;
-                                                                       CAR ;
-                                                                       SUB ;
-                                                                       ISNAT ;
-                                                                       IF_NONE { PUSH nat 19 ; FAILWITH } {} ;
-                                                                       PUSH mutez 1 ;
-                                                                       DIG 4 ;
-                                                                       MUL ;
-                                                                       PUSH mutez 1 ;
-                                                                       DIG 4 ;
-                                                                       MUL ;
-                                                                       DUP 6 ;
-                                                                       SWAP ;
-                                                                       DUP 7 ;
-                                                                       GET 3 ;
-                                                                       ADD ;
-                                                                       UPDATE 3 ;
-                                                                       DIG 2 ;
-                                                                       UPDATE 1 ;
-                                                                       SWAP ;
-                                                                       DIG 4 ;
-                                                                       GET 23 ;
-                                                                       ADD ;
-                                                                       UPDATE 23 ;
-                                                                       SWAP ;
-                                                                       DIG 2 ;
-                                                                       SELF_ADDRESS ;
-                                                                       DUP 4 ;
-                                                                       DUP ;
-                                                                       GET 13 ;
-                                                                       CONTRACT %transfer (list (pair address (list (pair address (pair nat nat))))) ;
-                                                                       IF_NONE { PUSH nat 0 ; FAILWITH } {} ;
-                                                                       PUSH mutez 0 ;
-                                                                       NIL (pair address (list (pair address (pair nat nat)))) ;
-                                                                       NIL (pair address (pair nat nat)) ;
-                                                                       DIG 7 ;
-                                                                       DIG 5 ;
-                                                                       GET 15 ;
-                                                                       PAIR ;
-                                                                       DIG 6 ;
-                                                                       PAIR ;
-                                                                       CONS ;
-                                                                       DIG 4 ;
-                                                                       PAIR ;
-                                                                       CONS ;
-                                                                       TRANSFER_TOKENS ;
-                                                                       SWAP ;
-                                                                       NIL operation ;
-                                                                       DIG 2 ;
-                                                                       CONS ;
-                                                                       PAIR } } }
+                                                                  NEQ ;
+                                                                  DUP 2 ;
+                                                                  GET 7 ;
+                                                                  NOT ;
+                                                                  AND ;
+                                                                  IF { PUSH nat 45 ; FAILWITH }
+                                                                     { DUP ; AMOUNT ; DIG 2 ; GET 3 ; ADD ; UPDATE 3 ; NIL operation ; PAIR } } }
                                                            { IF_LEFT
-                                                               { UNPAIR 5 ;
-                                                                 DUP 6 ;
-                                                                 GET 7 ;
+                                                               { UNPAIR 4 ;
+                                                                 DUP 5 ;
+                                                                 GET 11 ;
                                                                  IF { PUSH nat 2 ; FAILWITH }
-                                                                    { DIG 4 ;
-                                                                      NOW ;
+                                                                    { PUSH nat 0 ;
+                                                                      DUP 6 ;
+                                                                      GET 5 ;
                                                                       COMPARE ;
-                                                                      GE ;
-                                                                      IF { PUSH nat 3 ; FAILWITH }
-                                                                         { PUSH mutez 0 ;
-                                                                           AMOUNT ;
+                                                                      GT ;
+                                                                      PUSH nat 0 ;
+                                                                      DUP 7 ;
+                                                                      CAR ;
+                                                                      COMPARE ;
+                                                                      GT ;
+                                                                      PUSH mutez 0 ;
+                                                                      DUP 8 ;
+                                                                      GET 3 ;
+                                                                      COMPARE ;
+                                                                      GT ;
+                                                                      DUP 8 ;
+                                                                      GET 7 ;
+                                                                      AND ;
+                                                                      AND ;
+                                                                      AND ;
+                                                                      IF { DIG 3 ;
+                                                                           NOW ;
                                                                            COMPARE ;
-                                                                           GT ;
-                                                                           IF { PUSH nat 10 ; FAILWITH }
-                                                                              { DUP 5 ;
-                                                                                GET 5 ;
-                                                                                PUSH mutez 1 ;
-                                                                                DUP 7 ;
-                                                                                GET 3 ;
-                                                                                EDIV ;
-                                                                                IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                                DUP 4 ;
-                                                                                MUL ;
-                                                                                EDIV ;
-                                                                                IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                                PUSH mutez 1 ;
-                                                                                SWAP ;
-                                                                                MUL ;
-                                                                                DUP 6 ;
-                                                                                GET 5 ;
-                                                                                DUP 7 ;
-                                                                                CAR ;
-                                                                                DUP 5 ;
-                                                                                MUL ;
-                                                                                EDIV ;
-                                                                                IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                                DIG 4 ;
-                                                                                DUP 3 ;
+                                                                           GE ;
+                                                                           IF { PUSH nat 3 ; FAILWITH }
+                                                                              { PUSH mutez 0 ;
+                                                                                AMOUNT ;
                                                                                 COMPARE ;
-                                                                                LT ;
-                                                                                IF { PUSH nat 11 ; FAILWITH }
-                                                                                   { DIG 4 ;
+                                                                                GT ;
+                                                                                IF { PUSH nat 10 ; FAILWITH }
+                                                                                   { PUSH nat 10000 ;
+                                                                                     DUP 5 ;
+                                                                                     GET 23 ;
+                                                                                     DUP 4 ;
+                                                                                     MUL ;
+                                                                                     EDIV ;
+                                                                                     IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                     DUP ;
+                                                                                     DUP 4 ;
+                                                                                     SUB ;
+                                                                                     ISNAT ;
+                                                                                     IF_NONE { PUSH nat 34 ; FAILWITH } {} ;
+                                                                                     PUSH nat 997 ;
+                                                                                     DUP 2 ;
+                                                                                     MUL ;
+                                                                                     PUSH nat 1000 ;
+                                                                                     DUP 8 ;
+                                                                                     CAR ;
+                                                                                     MUL ;
+                                                                                     ADD ;
+                                                                                     PUSH mutez 1 ;
+                                                                                     DUP 8 ;
+                                                                                     GET 3 ;
+                                                                                     EDIV ;
+                                                                                     IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                     PUSH nat 997 ;
+                                                                                     DUP 4 ;
+                                                                                     MUL ;
+                                                                                     MUL ;
+                                                                                     EDIV ;
+                                                                                     IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                     PUSH mutez 1 ;
+                                                                                     SWAP ;
+                                                                                     MUL ;
+                                                                                     DIG 5 ;
                                                                                      DUP 2 ;
                                                                                      COMPARE ;
                                                                                      LT ;
-                                                                                     IF { PUSH nat 13 ; FAILWITH }
-                                                                                        { DUP 4 ;
-                                                                                          DUP 6 ;
-                                                                                          GET 5 ;
-                                                                                          SUB ;
-                                                                                          ISNAT ;
-                                                                                          IF_NONE { PUSH nat 14 ; FAILWITH } {} ;
-                                                                                          DUP 2 ;
-                                                                                          DUP 7 ;
-                                                                                          CAR ;
-                                                                                          SUB ;
-                                                                                          ISNAT ;
-                                                                                          IF_NONE { PUSH nat 15 ; FAILWITH } {} ;
-                                                                                          PUSH mutez 1 ;
-                                                                                          DUP 8 ;
-                                                                                          GET 3 ;
-                                                                                          EDIV ;
-                                                                                          IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                                          PUSH mutez 1 ;
-                                                                                          DUP 6 ;
-                                                                                          EDIV ;
-                                                                                          IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                                          SWAP ;
-                                                                                          SUB ;
-                                                                                          ISNAT ;
-                                                                                          IF_NONE { PUSH nat 36 ; FAILWITH } {} ;
-                                                                                          PUSH mutez 1 ;
-                                                                                          SWAP ;
-                                                                                          MUL ;
-                                                                                          DIG 6 ;
-                                                                                          PUSH int 0 ;
-                                                                                          SUB ;
-                                                                                          SENDER ;
-                                                                                          DUP 9 ;
-                                                                                          GET 17 ;
-                                                                                          CONTRACT %mintOrBurn (pair (int %quantity) (address %target)) ;
-                                                                                          IF_NONE { PUSH nat 12 ; FAILWITH } {} ;
-                                                                                          PUSH mutez 0 ;
-                                                                                          DIG 2 ;
-                                                                                          DIG 3 ;
-                                                                                          PAIR ;
-                                                                                          TRANSFER_TOKENS ;
-                                                                                          DIG 4 ;
-                                                                                          DUP 7 ;
-                                                                                          SELF_ADDRESS ;
-                                                                                          DUP 10 ;
-                                                                                          DUP ;
-                                                                                          GET 13 ;
-                                                                                          CONTRACT %transfer (list (pair address (list (pair address (pair nat nat))))) ;
-                                                                                          IF_NONE { PUSH nat 0 ; FAILWITH } {} ;
-                                                                                          PUSH mutez 0 ;
-                                                                                          NIL (pair address (list (pair address (pair nat nat)))) ;
-                                                                                          NIL (pair address (pair nat nat)) ;
-                                                                                          DIG 7 ;
-                                                                                          DIG 5 ;
-                                                                                          GET 15 ;
-                                                                                          PAIR ;
-                                                                                          DIG 6 ;
-                                                                                          PAIR ;
-                                                                                          CONS ;
-                                                                                          DIG 4 ;
-                                                                                          PAIR ;
-                                                                                          CONS ;
-                                                                                          TRANSFER_TOKENS ;
-                                                                                          DIG 6 ;
-                                                                                          CONTRACT unit ;
-                                                                                          IF_NONE { PUSH nat 9 ; FAILWITH } {} ;
-                                                                                          DIG 6 ;
-                                                                                          UNIT ;
-                                                                                          TRANSFER_TOKENS ;
-                                                                                          DIG 6 ;
-                                                                                          DIG 4 ;
-                                                                                          UPDATE 3 ;
-                                                                                          DIG 5 ;
-                                                                                          UPDATE 5 ;
-                                                                                          DIG 4 ;
-                                                                                          UPDATE 1 ;
-                                                                                          NIL operation ;
-                                                                                          DIG 2 ;
-                                                                                          CONS ;
-                                                                                          DIG 2 ;
-                                                                                          CONS ;
-                                                                                          DIG 2 ;
-                                                                                          CONS ;
-                                                                                          PAIR } } } } } }
-                                                               { UNPAIR 4 ;
-                                                                 DUP 5 ;
-                                                                 GET 7 ;
-                                                                 IF { PUSH nat 2 ; FAILWITH }
-                                                                    { DIG 3 ;
-                                                                      NOW ;
-                                                                      COMPARE ;
-                                                                      GE ;
-                                                                      IF { PUSH nat 3 ; FAILWITH }
-                                                                         { PUSH mutez 1 ;
-                                                                           DUP 5 ;
-                                                                           GET 3 ;
-                                                                           EDIV ;
-                                                                           IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                           PUSH mutez 1 ;
-                                                                           AMOUNT ;
-                                                                           EDIV ;
-                                                                           IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                           DUP 2 ;
-                                                                           DUP 7 ;
-                                                                           GET 5 ;
-                                                                           DUP 3 ;
-                                                                           MUL ;
-                                                                           EDIV ;
-                                                                           IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                           DIG 2 ;
-                                                                           DUP 7 ;
-                                                                           CAR ;
-                                                                           DIG 3 ;
-                                                                           MUL ;
-                                                                           EDIV ;
-                                                                           IF_NONE
-                                                                             { PUSH string "DIV by 0" ; FAILWITH }
-                                                                             { UNPAIR ; SWAP ; INT ; EQ ; IF {} { PUSH nat 1 ; ADD } } ;
-                                                                           DIG 4 ;
-                                                                           DUP 2 ;
-                                                                           COMPARE ;
-                                                                           GT ;
-                                                                           IF { PUSH nat 4 ; FAILWITH }
-                                                                              { DIG 3 ;
-                                                                                DUP 3 ;
-                                                                                COMPARE ;
-                                                                                LT ;
-                                                                                IF { PUSH nat 5 ; FAILWITH }
-                                                                                   { DUP 4 ;
-                                                                                     DUP 3 ;
-                                                                                     DUP 6 ;
-                                                                                     GET 5 ;
-                                                                                     ADD ;
-                                                                                     UPDATE 5 ;
-                                                                                     DUP 2 ;
-                                                                                     DUP 6 ;
-                                                                                     CAR ;
-                                                                                     ADD ;
-                                                                                     UPDATE 1 ;
-                                                                                     AMOUNT ;
-                                                                                     DIG 5 ;
+                                                                                     IF { PUSH nat 8 ; FAILWITH } {} ;
+                                                                                     PUSH mutez 1 ;
+                                                                                     DUP 7 ;
                                                                                      GET 3 ;
-                                                                                     ADD ;
-                                                                                     UPDATE 3 ;
+                                                                                     EDIV ;
+                                                                                     IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                     PUSH mutez 1 ;
+                                                                                     DUP 3 ;
+                                                                                     EDIV ;
+                                                                                     IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
                                                                                      SWAP ;
+                                                                                     SUB ;
+                                                                                     ISNAT ;
+                                                                                     IF_NONE { PUSH nat 36 ; FAILWITH } {} ;
+                                                                                     PUSH mutez 1 ;
+                                                                                     SWAP ;
+                                                                                     MUL ;
+                                                                                     DIG 5 ;
                                                                                      SELF_ADDRESS ;
                                                                                      SENDER ;
-                                                                                     DUP 4 ;
+                                                                                     DUP 9 ;
                                                                                      DUP ;
-                                                                                     GET 13 ;
+                                                                                     GET 17 ;
                                                                                      CONTRACT %transfer (list (pair address (list (pair address (pair nat nat))))) ;
                                                                                      IF_NONE { PUSH nat 0 ; FAILWITH } {} ;
                                                                                      PUSH mutez 0 ;
@@ -836,7 +716,7 @@
                                                                                      NIL (pair address (pair nat nat)) ;
                                                                                      DIG 7 ;
                                                                                      DIG 5 ;
-                                                                                     GET 15 ;
+                                                                                     GET 19 ;
                                                                                      PAIR ;
                                                                                      DIG 6 ;
                                                                                      PAIR ;
@@ -845,25 +725,430 @@
                                                                                      PAIR ;
                                                                                      CONS ;
                                                                                      TRANSFER_TOKENS ;
-                                                                                     DIG 2 ;
-                                                                                     INT ;
+                                                                                     DIG 5 ;
+                                                                                     CONTRACT unit ;
+                                                                                     IF_NONE { PUSH nat 9 ; FAILWITH } {} ;
                                                                                      DIG 3 ;
-                                                                                     DUP 4 ;
-                                                                                     GET 17 ;
-                                                                                     CONTRACT %mintOrBurn (pair (int %quantity) (address %target)) ;
-                                                                                     IF_NONE { PUSH nat 12 ; FAILWITH } {} ;
-                                                                                     PUSH mutez 0 ;
-                                                                                     DIG 2 ;
-                                                                                     DIG 3 ;
-                                                                                     PAIR ;
+                                                                                     UNIT ;
                                                                                      TRANSFER_TOKENS ;
-                                                                                     DIG 2 ;
+                                                                                     DUP 6 ;
+                                                                                     DIG 4 ;
+                                                                                     DUP 7 ;
+                                                                                     CAR ;
+                                                                                     ADD ;
+                                                                                     UPDATE 1 ;
+                                                                                     DIG 3 ;
+                                                                                     UPDATE 3 ;
+                                                                                     DIG 3 ;
+                                                                                     DIG 4 ;
+                                                                                     GET 28 ;
+                                                                                     ADD ;
+                                                                                     UPDATE 28 ;
                                                                                      NIL operation ;
                                                                                      DIG 2 ;
                                                                                      CONS ;
                                                                                      DIG 2 ;
                                                                                      CONS ;
-                                                                                     PAIR } } } } } } } } } } } } } } } } } } } ;
+                                                                                     PAIR } } }
+                                                                         { PUSH nat 43 ; FAILWITH } } }
+                                                               { IF_LEFT
+                                                                   { UNPAIR 3 ;
+                                                                     DUP 4 ;
+                                                                     GET 11 ;
+                                                                     IF { PUSH nat 2 ; FAILWITH }
+                                                                        { PUSH nat 0 ;
+                                                                          DUP 5 ;
+                                                                          GET 5 ;
+                                                                          COMPARE ;
+                                                                          GT ;
+                                                                          PUSH nat 0 ;
+                                                                          DUP 6 ;
+                                                                          CAR ;
+                                                                          COMPARE ;
+                                                                          GT ;
+                                                                          PUSH mutez 0 ;
+                                                                          DUP 7 ;
+                                                                          GET 3 ;
+                                                                          COMPARE ;
+                                                                          GT ;
+                                                                          DUP 7 ;
+                                                                          GET 7 ;
+                                                                          AND ;
+                                                                          AND ;
+                                                                          AND ;
+                                                                          IF { DIG 2 ;
+                                                                               NOW ;
+                                                                               COMPARE ;
+                                                                               GE ;
+                                                                               IF { PUSH nat 3 ; FAILWITH }
+                                                                                  { PUSH mutez 1 ;
+                                                                                    DUP 4 ;
+                                                                                    GET 3 ;
+                                                                                    EDIV ;
+                                                                                    IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                    PUSH mutez 1 ;
+                                                                                    AMOUNT ;
+                                                                                    EDIV ;
+                                                                                    IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                    PUSH nat 10000 ;
+                                                                                    DUP 6 ;
+                                                                                    GET 23 ;
+                                                                                    DUP 3 ;
+                                                                                    MUL ;
+                                                                                    EDIV ;
+                                                                                    IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                    DUP ;
+                                                                                    DIG 2 ;
+                                                                                    SUB ;
+                                                                                    ISNAT ;
+                                                                                    IF_NONE { PUSH nat 34 ; FAILWITH } {} ;
+                                                                                    PUSH nat 997 ;
+                                                                                    DUP 2 ;
+                                                                                    MUL ;
+                                                                                    PUSH nat 1000 ;
+                                                                                    DIG 4 ;
+                                                                                    MUL ;
+                                                                                    ADD ;
+                                                                                    DUP 6 ;
+                                                                                    CAR ;
+                                                                                    PUSH nat 997 ;
+                                                                                    DUP 4 ;
+                                                                                    MUL ;
+                                                                                    MUL ;
+                                                                                    EDIV ;
+                                                                                    IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                    DIG 4 ;
+                                                                                    DUP 2 ;
+                                                                                    COMPARE ;
+                                                                                    LT ;
+                                                                                    IF { PUSH nat 18 ; FAILWITH } {} ;
+                                                                                    DUP ;
+                                                                                    DUP 6 ;
+                                                                                    CAR ;
+                                                                                    SUB ;
+                                                                                    ISNAT ;
+                                                                                    IF_NONE { PUSH nat 19 ; FAILWITH } {} ;
+                                                                                    PUSH mutez 1 ;
+                                                                                    DIG 4 ;
+                                                                                    MUL ;
+                                                                                    PUSH mutez 1 ;
+                                                                                    DIG 4 ;
+                                                                                    MUL ;
+                                                                                    DUP 6 ;
+                                                                                    SWAP ;
+                                                                                    DUP 7 ;
+                                                                                    GET 3 ;
+                                                                                    ADD ;
+                                                                                    UPDATE 3 ;
+                                                                                    DIG 2 ;
+                                                                                    UPDATE 1 ;
+                                                                                    SWAP ;
+                                                                                    DIG 4 ;
+                                                                                    GET 27 ;
+                                                                                    ADD ;
+                                                                                    UPDATE 27 ;
+                                                                                    SWAP ;
+                                                                                    DIG 2 ;
+                                                                                    SELF_ADDRESS ;
+                                                                                    DUP 4 ;
+                                                                                    DUP ;
+                                                                                    GET 17 ;
+                                                                                    CONTRACT %transfer (list (pair address (list (pair address (pair nat nat))))) ;
+                                                                                    IF_NONE { PUSH nat 0 ; FAILWITH } {} ;
+                                                                                    PUSH mutez 0 ;
+                                                                                    NIL (pair address (list (pair address (pair nat nat)))) ;
+                                                                                    NIL (pair address (pair nat nat)) ;
+                                                                                    DIG 7 ;
+                                                                                    DIG 5 ;
+                                                                                    GET 19 ;
+                                                                                    PAIR ;
+                                                                                    DIG 6 ;
+                                                                                    PAIR ;
+                                                                                    CONS ;
+                                                                                    DIG 4 ;
+                                                                                    PAIR ;
+                                                                                    CONS ;
+                                                                                    TRANSFER_TOKENS ;
+                                                                                    SWAP ;
+                                                                                    NIL operation ;
+                                                                                    DIG 2 ;
+                                                                                    CONS ;
+                                                                                    PAIR } }
+                                                                             { PUSH nat 43 ; FAILWITH } } }
+                                                                   { IF_LEFT
+                                                                       { UNPAIR 5 ;
+                                                                         DUP 6 ;
+                                                                         GET 11 ;
+                                                                         IF { PUSH nat 2 ; FAILWITH }
+                                                                            { PUSH nat 0 ;
+                                                                              DUP 7 ;
+                                                                              GET 5 ;
+                                                                              COMPARE ;
+                                                                              GT ;
+                                                                              PUSH nat 0 ;
+                                                                              DUP 8 ;
+                                                                              CAR ;
+                                                                              COMPARE ;
+                                                                              GT ;
+                                                                              PUSH mutez 0 ;
+                                                                              DUP 9 ;
+                                                                              GET 3 ;
+                                                                              COMPARE ;
+                                                                              GT ;
+                                                                              DUP 9 ;
+                                                                              GET 7 ;
+                                                                              AND ;
+                                                                              AND ;
+                                                                              AND ;
+                                                                              IF { DIG 4 ;
+                                                                                   NOW ;
+                                                                                   COMPARE ;
+                                                                                   GE ;
+                                                                                   IF { PUSH nat 3 ; FAILWITH }
+                                                                                      { PUSH mutez 0 ;
+                                                                                        AMOUNT ;
+                                                                                        COMPARE ;
+                                                                                        GT ;
+                                                                                        IF { PUSH nat 10 ; FAILWITH }
+                                                                                           { DUP 5 ;
+                                                                                             GET 5 ;
+                                                                                             PUSH mutez 1 ;
+                                                                                             DUP 7 ;
+                                                                                             GET 3 ;
+                                                                                             EDIV ;
+                                                                                             IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                             DUP 4 ;
+                                                                                             MUL ;
+                                                                                             EDIV ;
+                                                                                             IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                             PUSH mutez 1 ;
+                                                                                             SWAP ;
+                                                                                             MUL ;
+                                                                                             DUP 6 ;
+                                                                                             GET 5 ;
+                                                                                             DUP 7 ;
+                                                                                             CAR ;
+                                                                                             DUP 5 ;
+                                                                                             MUL ;
+                                                                                             EDIV ;
+                                                                                             IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                             DIG 4 ;
+                                                                                             DUP 3 ;
+                                                                                             COMPARE ;
+                                                                                             LT ;
+                                                                                             IF { PUSH nat 11 ; FAILWITH }
+                                                                                                { DIG 4 ;
+                                                                                                  DUP 2 ;
+                                                                                                  COMPARE ;
+                                                                                                  LT ;
+                                                                                                  IF { PUSH nat 13 ; FAILWITH }
+                                                                                                     { DUP 4 ;
+                                                                                                       DUP 6 ;
+                                                                                                       GET 5 ;
+                                                                                                       SUB ;
+                                                                                                       ISNAT ;
+                                                                                                       IF_NONE { PUSH nat 14 ; FAILWITH } {} ;
+                                                                                                       DUP 2 ;
+                                                                                                       DUP 7 ;
+                                                                                                       CAR ;
+                                                                                                       SUB ;
+                                                                                                       ISNAT ;
+                                                                                                       IF_NONE { PUSH nat 15 ; FAILWITH } {} ;
+                                                                                                       PUSH mutez 1 ;
+                                                                                                       DUP 8 ;
+                                                                                                       GET 3 ;
+                                                                                                       EDIV ;
+                                                                                                       IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                                       PUSH mutez 1 ;
+                                                                                                       DUP 6 ;
+                                                                                                       EDIV ;
+                                                                                                       IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                                       SWAP ;
+                                                                                                       SUB ;
+                                                                                                       ISNAT ;
+                                                                                                       IF_NONE { PUSH nat 36 ; FAILWITH } {} ;
+                                                                                                       PUSH mutez 1 ;
+                                                                                                       SWAP ;
+                                                                                                       MUL ;
+                                                                                                       DIG 6 ;
+                                                                                                       PUSH int 0 ;
+                                                                                                       SUB ;
+                                                                                                       SENDER ;
+                                                                                                       DUP 9 ;
+                                                                                                       GET 21 ;
+                                                                                                       CONTRACT %mintOrBurn (pair (int %quantity) (address %target)) ;
+                                                                                                       IF_NONE { PUSH nat 12 ; FAILWITH } {} ;
+                                                                                                       PUSH mutez 0 ;
+                                                                                                       DIG 2 ;
+                                                                                                       DIG 3 ;
+                                                                                                       PAIR ;
+                                                                                                       TRANSFER_TOKENS ;
+                                                                                                       DIG 4 ;
+                                                                                                       DUP 7 ;
+                                                                                                       SELF_ADDRESS ;
+                                                                                                       DUP 10 ;
+                                                                                                       DUP ;
+                                                                                                       GET 17 ;
+                                                                                                       CONTRACT %transfer (list (pair address (list (pair address (pair nat nat))))) ;
+                                                                                                       IF_NONE { PUSH nat 0 ; FAILWITH } {} ;
+                                                                                                       PUSH mutez 0 ;
+                                                                                                       NIL (pair address (list (pair address (pair nat nat)))) ;
+                                                                                                       NIL (pair address (pair nat nat)) ;
+                                                                                                       DIG 7 ;
+                                                                                                       DIG 5 ;
+                                                                                                       GET 19 ;
+                                                                                                       PAIR ;
+                                                                                                       DIG 6 ;
+                                                                                                       PAIR ;
+                                                                                                       CONS ;
+                                                                                                       DIG 4 ;
+                                                                                                       PAIR ;
+                                                                                                       CONS ;
+                                                                                                       TRANSFER_TOKENS ;
+                                                                                                       DIG 6 ;
+                                                                                                       CONTRACT unit ;
+                                                                                                       IF_NONE { PUSH nat 9 ; FAILWITH } {} ;
+                                                                                                       DIG 6 ;
+                                                                                                       UNIT ;
+                                                                                                       TRANSFER_TOKENS ;
+                                                                                                       DIG 6 ;
+                                                                                                       DIG 4 ;
+                                                                                                       UPDATE 3 ;
+                                                                                                       DIG 5 ;
+                                                                                                       UPDATE 5 ;
+                                                                                                       DIG 4 ;
+                                                                                                       UPDATE 1 ;
+                                                                                                       NIL operation ;
+                                                                                                       DIG 2 ;
+                                                                                                       CONS ;
+                                                                                                       DIG 2 ;
+                                                                                                       CONS ;
+                                                                                                       DIG 2 ;
+                                                                                                       CONS ;
+                                                                                                       PAIR } } } } }
+                                                                                 { PUSH nat 43 ; FAILWITH } } }
+                                                                       { UNPAIR 4 ;
+                                                                         DUP 5 ;
+                                                                         GET 11 ;
+                                                                         IF { PUSH nat 2 ; FAILWITH }
+                                                                            { PUSH nat 0 ;
+                                                                              DUP 6 ;
+                                                                              GET 5 ;
+                                                                              COMPARE ;
+                                                                              GT ;
+                                                                              PUSH nat 0 ;
+                                                                              DUP 7 ;
+                                                                              CAR ;
+                                                                              COMPARE ;
+                                                                              GT ;
+                                                                              PUSH mutez 0 ;
+                                                                              DUP 8 ;
+                                                                              GET 3 ;
+                                                                              COMPARE ;
+                                                                              GT ;
+                                                                              DUP 8 ;
+                                                                              GET 7 ;
+                                                                              AND ;
+                                                                              AND ;
+                                                                              AND ;
+                                                                              IF { DIG 3 ;
+                                                                                   NOW ;
+                                                                                   COMPARE ;
+                                                                                   GE ;
+                                                                                   IF { PUSH nat 3 ; FAILWITH }
+                                                                                      { PUSH mutez 1 ;
+                                                                                        DUP 5 ;
+                                                                                        GET 3 ;
+                                                                                        EDIV ;
+                                                                                        IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                        PUSH mutez 1 ;
+                                                                                        AMOUNT ;
+                                                                                        EDIV ;
+                                                                                        IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                        DUP 2 ;
+                                                                                        DUP 7 ;
+                                                                                        GET 5 ;
+                                                                                        DUP 3 ;
+                                                                                        MUL ;
+                                                                                        EDIV ;
+                                                                                        IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                        DIG 2 ;
+                                                                                        DUP 7 ;
+                                                                                        CAR ;
+                                                                                        DIG 3 ;
+                                                                                        MUL ;
+                                                                                        EDIV ;
+                                                                                        IF_NONE
+                                                                                          { PUSH string "DIV by 0" ; FAILWITH }
+                                                                                          { UNPAIR ; SWAP ; INT ; EQ ; IF {} { PUSH nat 1 ; ADD } } ;
+                                                                                        DIG 4 ;
+                                                                                        DUP 2 ;
+                                                                                        COMPARE ;
+                                                                                        GT ;
+                                                                                        IF { PUSH nat 4 ; FAILWITH }
+                                                                                           { DIG 3 ;
+                                                                                             DUP 3 ;
+                                                                                             COMPARE ;
+                                                                                             LT ;
+                                                                                             IF { PUSH nat 5 ; FAILWITH }
+                                                                                                { DUP 4 ;
+                                                                                                  DUP 3 ;
+                                                                                                  DUP 6 ;
+                                                                                                  GET 5 ;
+                                                                                                  ADD ;
+                                                                                                  UPDATE 5 ;
+                                                                                                  DUP 2 ;
+                                                                                                  DUP 6 ;
+                                                                                                  CAR ;
+                                                                                                  ADD ;
+                                                                                                  UPDATE 1 ;
+                                                                                                  AMOUNT ;
+                                                                                                  DIG 5 ;
+                                                                                                  GET 3 ;
+                                                                                                  ADD ;
+                                                                                                  UPDATE 3 ;
+                                                                                                  SWAP ;
+                                                                                                  SELF_ADDRESS ;
+                                                                                                  SENDER ;
+                                                                                                  DUP 4 ;
+                                                                                                  DUP ;
+                                                                                                  GET 17 ;
+                                                                                                  CONTRACT %transfer (list (pair address (list (pair address (pair nat nat))))) ;
+                                                                                                  IF_NONE { PUSH nat 0 ; FAILWITH } {} ;
+                                                                                                  PUSH mutez 0 ;
+                                                                                                  NIL (pair address (list (pair address (pair nat nat)))) ;
+                                                                                                  NIL (pair address (pair nat nat)) ;
+                                                                                                  DIG 7 ;
+                                                                                                  DIG 5 ;
+                                                                                                  GET 19 ;
+                                                                                                  PAIR ;
+                                                                                                  DIG 6 ;
+                                                                                                  PAIR ;
+                                                                                                  CONS ;
+                                                                                                  DIG 4 ;
+                                                                                                  PAIR ;
+                                                                                                  CONS ;
+                                                                                                  TRANSFER_TOKENS ;
+                                                                                                  DIG 2 ;
+                                                                                                  INT ;
+                                                                                                  DIG 3 ;
+                                                                                                  DUP 4 ;
+                                                                                                  GET 21 ;
+                                                                                                  CONTRACT %mintOrBurn (pair (int %quantity) (address %target)) ;
+                                                                                                  IF_NONE { PUSH nat 12 ; FAILWITH } {} ;
+                                                                                                  PUSH mutez 0 ;
+                                                                                                  DIG 2 ;
+                                                                                                  DIG 3 ;
+                                                                                                  PAIR ;
+                                                                                                  TRANSFER_TOKENS ;
+                                                                                                  DIG 2 ;
+                                                                                                  NIL operation ;
+                                                                                                  DIG 2 ;
+                                                                                                  CONS ;
+                                                                                                  DIG 2 ;
+                                                                                                  CONS ;
+                                                                                                  PAIR } } } }
+                                                                                 { PUSH nat 43 ; FAILWITH } } } } } } } } } } } } } } } } } } } ;
   view "get_reserves"
        unit
        (pair nat nat)
@@ -878,16 +1163,40 @@
          IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
          PAIR } ;
   view "get_lqt_total" unit nat { GET 7 } ;
+  view "is_active"
+       unit
+       bool
+       { CDR ;
+         PUSH nat 0 ;
+         DUP 2 ;
+         GET 5 ;
+         COMPARE ;
+         GT ;
+         PUSH nat 0 ;
+         DUP 3 ;
+         CAR ;
+         COMPARE ;
+         GT ;
+         PUSH mutez 0 ;
+         DUP 4 ;
+         GET 3 ;
+         COMPARE ;
+         GT ;
+         DIG 3 ;
+         GET 7 ;
+         AND ;
+         AND ;
+         AND } ;
   view "get_fee_bp"
        unit
        (pair nat (pair nat nat))
        { CDR ;
          DUP ;
-         GET 19 ;
+         GET 23 ;
          PUSH nat 30 ;
          ADD ;
          SWAP ;
-         GET 19 ;
+         GET 23 ;
          PUSH nat 30 ;
          PAIR 3 } ;
   view "quote_tez_to_token"
@@ -910,12 +1219,16 @@
          DUP 5 ;
          INT ;
          EQ ;
+         DUP 7 ;
+         GET 7 ;
+         NOT ;
+         OR ;
          OR ;
          OR ;
          IF { DROP 4 ; PUSH nat 0 }
             { PUSH nat 10000 ;
               DIG 4 ;
-              GET 19 ;
+              GET 23 ;
               DUP 5 ;
               MUL ;
               EDIV ;
@@ -958,12 +1271,16 @@
          DUP 5 ;
          INT ;
          EQ ;
+         DUP 7 ;
+         GET 7 ;
+         NOT ;
+         OR ;
          OR ;
          OR ;
          IF { DROP 4 ; PUSH nat 0 }
             { PUSH nat 10000 ;
               DIG 4 ;
-              GET 19 ;
+              GET 23 ;
               DUP 5 ;
               MUL ;
               EDIV ;

--- a/dex/compiled_contracts/pool_mod.tz
+++ b/dex/compiled_contracts/pool_mod.tz
@@ -3,44 +3,50 @@
         (or (unit %claimProtocolFeeXtz)
             (or (address %setProtocolFeeRecipient)
                 (or (nat %setProtocolFee)
-                    (or (pair %tokenToToken
-                           (address %outputDexterContract)
-                           (pair (nat %minTokensBought)
-                                 (pair (address %to) (pair (nat %tokensSold) (timestamp %deadline)))))
-                        (or (nat %updateTokenPoolInternal)
-                            (or (unit %updateTokenPool)
-                                (or (address %setLqtAddress)
-                                    (or (address %setManager)
-                                        (or (pair %setBaker (option %baker key_hash) (bool %freezeBaker))
-                                            (or (unit %default)
-                                                (or (pair %tokenToXtz
-                                                       (address %to)
-                                                       (pair (nat %tokensSold) (pair (mutez %minXtzBought) (timestamp %deadline))))
-                                                    (or (pair %xtzToToken (address %to) (pair (nat %minTokensBought) (timestamp %deadline)))
-                                                        (or (pair %removeLiquidity
+                    (or (nat %activateInternal)
+                        (or (pair %activate
+                               (mutez %expectedXtzPool)
+                               (pair (nat %expectedTokenPool) (nat %expectedLqtTotal)))
+                            (or (pair %tokenToToken
+                                   (address %outputDexterContract)
+                                   (pair (nat %minTokensBought)
+                                         (pair (address %to) (pair (nat %tokensSold) (timestamp %deadline)))))
+                                (or (nat %updateTokenPoolInternal)
+                                    (or (unit %updateTokenPool)
+                                        (or (address %setLqtAddress)
+                                            (or (address %setManager)
+                                                (or (pair %setBaker (option %baker key_hash) (bool %freezeBaker))
+                                                    (or (unit %default)
+                                                        (or (pair %tokenToXtz
                                                                (address %to)
-                                                               (pair (nat %lqtBurned)
-                                                                     (pair (mutez %minXtzWithdrawn) (pair (nat %minTokensWithdrawn) (timestamp %deadline)))))
-                                                            (pair %addLiquidity
-                                                               (address %owner)
-                                                               (pair (nat %minLqtMinted) (pair (nat %maxTokensDeposited) (timestamp %deadline)))))))))))))))))) ;
+                                                               (pair (nat %tokensSold) (pair (mutez %minXtzBought) (timestamp %deadline))))
+                                                            (or (pair %xtzToToken (address %to) (pair (nat %minTokensBought) (timestamp %deadline)))
+                                                                (or (pair %removeLiquidity
+                                                                       (address %to)
+                                                                       (pair (nat %lqtBurned)
+                                                                             (pair (mutez %minXtzWithdrawn) (pair (nat %minTokensWithdrawn) (timestamp %deadline)))))
+                                                                    (pair %addLiquidity
+                                                                       (address %owner)
+                                                                       (pair (nat %minLqtMinted) (pair (nat %maxTokensDeposited) (timestamp %deadline)))))))))))))))))))) ;
   storage
     (pair (nat %tokenPool)
           (pair (mutez %xtzPool)
                 (pair (nat %lqtTotal)
-                      (pair (bool %selfIsUpdatingTokenPool)
-                            (pair (bool %freezeBaker)
-                                  (pair (address %manager)
-                                        (pair (address %tokenAddress)
-                                              (pair (address %lqtAddress)
-                                                    (pair (nat %protocol_fee_bp)
-                                                          (pair (address %protocol_fee_recipient)
-                                                                (pair (mutez %accumulated_protocol_fee_xtz) (nat %accumulated_protocol_fee_token)))))))))))) ;
+                      (pair (bool %active)
+                            (pair (bool %activationPending)
+                                  (pair (bool %selfIsUpdatingTokenPool)
+                                        (pair (bool %freezeBaker)
+                                              (pair (address %manager)
+                                                    (pair (address %tokenAddress)
+                                                          (pair (address %lqtAddress)
+                                                                (pair (nat %protocol_fee_bp)
+                                                                      (pair (address %protocol_fee_recipient)
+                                                                            (pair (mutez %accumulated_protocol_fee_xtz) (nat %accumulated_protocol_fee_token)))))))))))))) ;
   code { UNPAIR ;
          IF_LEFT
            { DROP ;
              DUP ;
-             GET 7 ;
+             GET 11 ;
              IF { PUSH nat 2 ; FAILWITH }
                 { PUSH mutez 0 ;
                   AMOUNT ;
@@ -48,27 +54,27 @@
                   GT ;
                   IF { PUSH nat 10 ; FAILWITH }
                      { DUP ;
-                       GET 19 ;
+                       GET 23 ;
                        SENDER ;
                        COMPARE ;
                        NEQ ;
                        IF { PUSH nat 39 ; FAILWITH }
                           { PUSH nat 0 ;
                             DUP 2 ;
-                            GET 22 ;
+                            GET 26 ;
                             COMPARE ;
                             EQ ;
                             IF { PUSH nat 40 ; FAILWITH }
                                { DUP ;
                                  PUSH nat 0 ;
-                                 UPDATE 22 ;
+                                 UPDATE 26 ;
                                  SWAP ;
-                                 GET 22 ;
+                                 GET 26 ;
                                  DUP 2 ;
-                                 GET 19 ;
+                                 GET 23 ;
                                  SELF_ADDRESS ;
                                  DUP 4 ;
-                                 GET 13 ;
+                                 GET 17 ;
                                  CONTRACT %transfer (pair address (pair address nat)) ;
                                  IF_NONE { PUSH nat 0 ; FAILWITH } {} ;
                                  PUSH mutez 0 ;
@@ -86,7 +92,7 @@
            { IF_LEFT
                { DROP ;
                  DUP ;
-                 GET 7 ;
+                 GET 11 ;
                  IF { PUSH nat 2 ; FAILWITH }
                     { PUSH mutez 0 ;
                       AMOUNT ;
@@ -94,26 +100,26 @@
                       GT ;
                       IF { PUSH nat 10 ; FAILWITH }
                          { DUP ;
-                           GET 19 ;
+                           GET 23 ;
                            SENDER ;
                            COMPARE ;
                            NEQ ;
                            IF { PUSH nat 39 ; FAILWITH }
                               { PUSH mutez 0 ;
                                 DUP 2 ;
-                                GET 21 ;
+                                GET 25 ;
                                 COMPARE ;
                                 EQ ;
                                 IF { PUSH nat 40 ; FAILWITH }
                                    { DUP ;
                                      PUSH mutez 0 ;
-                                     UPDATE 21 ;
+                                     UPDATE 25 ;
                                      DUP ;
-                                     GET 19 ;
+                                     GET 23 ;
                                      CONTRACT unit ;
                                      IF_NONE { PUSH nat 9 ; FAILWITH } {} ;
                                      DIG 2 ;
-                                     GET 21 ;
+                                     GET 25 ;
                                      UNIT ;
                                      TRANSFER_TOKENS ;
                                      SWAP ;
@@ -123,7 +129,7 @@
                                      PAIR } } } } }
                { IF_LEFT
                    { DUP 2 ;
-                     GET 7 ;
+                     GET 11 ;
                      IF { PUSH nat 2 ; FAILWITH }
                         { PUSH mutez 0 ;
                           AMOUNT ;
@@ -131,14 +137,14 @@
                           GT ;
                           IF { PUSH nat 10 ; FAILWITH }
                              { DUP 2 ;
-                               GET 11 ;
+                               GET 15 ;
                                SENDER ;
                                COMPARE ;
                                NEQ ;
-                               IF { PUSH nat 41 ; FAILWITH } { UPDATE 19 ; NIL operation ; PAIR } } } }
+                               IF { PUSH nat 41 ; FAILWITH } { UPDATE 23 ; NIL operation ; PAIR } } } }
                    { IF_LEFT
                        { DUP 2 ;
-                         GET 7 ;
+                         GET 11 ;
                          IF { PUSH nat 2 ; FAILWITH }
                             { PUSH mutez 0 ;
                               AMOUNT ;
@@ -146,7 +152,7 @@
                               GT ;
                               IF { PUSH nat 10 ; FAILWITH }
                                  { DUP 2 ;
-                                   GET 11 ;
+                                   GET 15 ;
                                    SENDER ;
                                    COMPARE ;
                                    NEQ ;
@@ -155,630 +161,512 @@
                                         DUP 2 ;
                                         COMPARE ;
                                         GT ;
-                                        IF { PUSH nat 38 ; FAILWITH } { UPDATE 17 ; NIL operation ; PAIR } } } } }
+                                        IF { PUSH nat 38 ; FAILWITH } { UPDATE 21 ; NIL operation ; PAIR } } } } }
                        { IF_LEFT
-                           { UNPAIR 5 ;
-                             CONTRACT %xtzToToken
-                               (pair (address %to) (pair (nat %minTokensBought) (timestamp %deadline))) ;
-                             IF_NONE { PUSH nat 31 ; FAILWITH } {} ;
-                             DUP 6 ;
-                             GET 7 ;
-                             IF { PUSH nat 2 ; FAILWITH }
+                           { DUP 2 ;
+                             GET 19 ;
+                             SENDER ;
+                             COMPARE ;
+                             NEQ ;
+                             DUP 3 ;
+                             GET 9 ;
+                             NOT ;
+                             OR ;
+                             IF { PUSH nat 49 ; FAILWITH }
                                 { PUSH mutez 0 ;
                                   AMOUNT ;
                                   COMPARE ;
                                   GT ;
                                   IF { PUSH nat 10 ; FAILWITH }
-                                     { DUP 5 ;
-                                       NOW ;
+                                     { DUP 2 ;
+                                       GET 5 ;
                                        COMPARE ;
-                                       GE ;
-                                       IF { PUSH nat 3 ; FAILWITH }
-                                          { PUSH nat 10000 ;
-                                            DUP 7 ;
-                                            GET 17 ;
-                                            DUP 6 ;
-                                            MUL ;
-                                            EDIV ;
-                                            IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                            DUP ;
-                                            DUP 6 ;
-                                            SUB ;
-                                            ISNAT ;
-                                            IF_NONE { PUSH nat 34 ; FAILWITH } {} ;
-                                            PUSH nat 997 ;
+                                       NEQ ;
+                                       IF { PUSH nat 50 ; FAILWITH }
+                                          { PUSH nat 0 ;
                                             DUP 2 ;
-                                            MUL ;
-                                            PUSH nat 1000 ;
-                                            DUP 10 ;
+                                            GET 5 ;
+                                            COMPARE ;
+                                            EQ ;
+                                            PUSH nat 0 ;
+                                            DUP 3 ;
                                             CAR ;
-                                            MUL ;
-                                            ADD ;
-                                            PUSH mutez 1 ;
-                                            DUP 10 ;
-                                            GET 3 ;
-                                            EDIV ;
-                                            IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                            PUSH nat 997 ;
-                                            DUP 4 ;
-                                            MUL ;
-                                            MUL ;
-                                            EDIV ;
-                                            IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                            PUSH mutez 1 ;
-                                            DUP 10 ;
-                                            GET 3 ;
-                                            EDIV ;
-                                            IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                            DUP 2 ;
-                                            SWAP ;
-                                            SUB ;
-                                            ISNAT ;
-                                            IF_NONE { PUSH nat 36 ; FAILWITH } {} ;
-                                            PUSH mutez 1 ;
-                                            SWAP ;
-                                            MUL ;
-                                            PUSH mutez 1 ;
-                                            DIG 2 ;
-                                            MUL ;
-                                            DUP 10 ;
-                                            DIG 3 ;
-                                            DUP 11 ;
-                                            CAR ;
-                                            ADD ;
-                                            UPDATE 1 ;
-                                            DIG 2 ;
-                                            UPDATE 3 ;
-                                            DIG 2 ;
-                                            DIG 8 ;
-                                            GET 22 ;
-                                            ADD ;
-                                            UPDATE 22 ;
-                                            DIG 5 ;
-                                            SELF_ADDRESS ;
-                                            SENDER ;
-                                            DUP 4 ;
-                                            GET 13 ;
-                                            CONTRACT %transfer (pair address (pair address nat)) ;
-                                            IF_NONE { PUSH nat 0 ; FAILWITH } {} ;
+                                            COMPARE ;
+                                            EQ ;
                                             PUSH mutez 0 ;
-                                            DIG 4 ;
-                                            DIG 4 ;
-                                            PAIR ;
-                                            DIG 3 ;
-                                            PAIR ;
-                                            TRANSFER_TOKENS ;
-                                            DIG 3 ;
-                                            DIG 3 ;
-                                            DIG 6 ;
-                                            DIG 5 ;
-                                            DIG 6 ;
-                                            PAIR 3 ;
-                                            TRANSFER_TOKENS ;
-                                            DIG 2 ;
-                                            NIL operation ;
-                                            DIG 2 ;
-                                            CONS ;
-                                            DIG 2 ;
-                                            CONS ;
-                                            PAIR } } } }
+                                            DUP 4 ;
+                                            GET 3 ;
+                                            COMPARE ;
+                                            EQ ;
+                                            OR ;
+                                            OR ;
+                                            IF { PUSH nat 47 ; FAILWITH }
+                                               { PUSH bool True ;
+                                                 UPDATE 7 ;
+                                                 PUSH bool False ;
+                                                 UPDATE 9 ;
+                                                 NIL operation ;
+                                                 PAIR } } } } }
                            { IF_LEFT
                                { DUP 2 ;
-                                 GET 13 ;
-                                 SENDER ;
-                                 COMPARE ;
-                                 NEQ ;
-                                 DUP 3 ;
-                                 GET 7 ;
-                                 NOT ;
-                                 OR ;
-                                 IF { PUSH nat 29 ; FAILWITH }
+                                 GET 11 ;
+                                 IF { PUSH nat 2 ; FAILWITH }
                                     { PUSH mutez 0 ;
                                       AMOUNT ;
                                       COMPARE ;
                                       GT ;
                                       IF { PUSH nat 10 ; FAILWITH }
                                          { DUP 2 ;
-                                           GET 22 ;
-                                           SWAP ;
-                                           SUB ;
-                                           ISNAT ;
-                                           IF_NONE { PUSH nat 42 ; FAILWITH } {} ;
-                                           UPDATE 1 ;
-                                           PUSH bool False ;
-                                           UPDATE 7 ;
-                                           NIL operation ;
-                                           PAIR } } }
+                                           GET 15 ;
+                                           SENDER ;
+                                           COMPARE ;
+                                           NEQ ;
+                                           IF { PUSH nat 45 ; FAILWITH }
+                                              { DUP 2 ;
+                                                GET 9 ;
+                                                DUP 3 ;
+                                                GET 7 ;
+                                                OR ;
+                                                IF { PUSH nat 44 ; FAILWITH }
+                                                   { PUSH address "tz1Ke2h7sDdakHJQh8WX4Z372du1KChsksyU" ;
+                                                     DUP 3 ;
+                                                     GET 19 ;
+                                                     COMPARE ;
+                                                     EQ ;
+                                                     IF { PUSH nat 46 ; FAILWITH }
+                                                        { DUP ;
+                                                          CAR ;
+                                                          BALANCE ;
+                                                          COMPARE ;
+                                                          NEQ ;
+                                                          DUP 2 ;
+                                                          GET 4 ;
+                                                          DUP 4 ;
+                                                          GET 5 ;
+                                                          COMPARE ;
+                                                          NEQ ;
+                                                          DUP 3 ;
+                                                          GET 3 ;
+                                                          DUP 5 ;
+                                                          CAR ;
+                                                          COMPARE ;
+                                                          NEQ ;
+                                                          DUP 4 ;
+                                                          CAR ;
+                                                          DUP 6 ;
+                                                          GET 3 ;
+                                                          COMPARE ;
+                                                          NEQ ;
+                                                          PUSH nat 0 ;
+                                                          DUP 6 ;
+                                                          GET 4 ;
+                                                          COMPARE ;
+                                                          EQ ;
+                                                          PUSH nat 0 ;
+                                                          DUP 7 ;
+                                                          GET 3 ;
+                                                          COMPARE ;
+                                                          EQ ;
+                                                          PUSH mutez 0 ;
+                                                          DIG 7 ;
+                                                          CAR ;
+                                                          COMPARE ;
+                                                          EQ ;
+                                                          OR ;
+                                                          OR ;
+                                                          OR ;
+                                                          OR ;
+                                                          OR ;
+                                                          OR ;
+                                                          IF { PUSH nat 47 ; FAILWITH }
+                                                             { SELF_ADDRESS ;
+                                                               CONTRACT %activateInternal nat ;
+                                                               IF_NONE
+                                                                 { PUSH string "Cannot get activateInternal entrypoint" ; FAILWITH }
+                                                                 {} ;
+                                                               DUP 2 ;
+                                                               GET 19 ;
+                                                               CONTRACT %getTotalSupply (pair (unit %request) (contract %callback nat)) ;
+                                                               IF_NONE { PUSH nat 48 ; FAILWITH } {} ;
+                                                               PUSH mutez 0 ;
+                                                               DIG 2 ;
+                                                               UNIT ;
+                                                               PAIR ;
+                                                               TRANSFER_TOKENS ;
+                                                               SWAP ;
+                                                               PUSH bool True ;
+                                                               UPDATE 9 ;
+                                                               NIL operation ;
+                                                               DIG 2 ;
+                                                               CONS ;
+                                                               PAIR } } } } } } }
                                { IF_LEFT
-                                   { DROP ;
-                                     SOURCE ;
-                                     SENDER ;
-                                     COMPARE ;
-                                     NEQ ;
-                                     IF { PUSH nat 25 ; FAILWITH }
-                                        { PUSH mutez 0 ;
-                                          AMOUNT ;
+                                   { UNPAIR 5 ;
+                                     CONTRACT %xtzToToken
+                                       (pair (address %to) (pair (nat %minTokensBought) (timestamp %deadline))) ;
+                                     IF_NONE { PUSH nat 31 ; FAILWITH } {} ;
+                                     DUP 6 ;
+                                     GET 11 ;
+                                     IF { PUSH nat 2 ; FAILWITH }
+                                        { PUSH nat 0 ;
+                                          DUP 7 ;
+                                          GET 5 ;
                                           COMPARE ;
                                           GT ;
-                                          IF { PUSH nat 10 ; FAILWITH }
-                                             { DUP ;
-                                               GET 7 ;
-                                               IF { PUSH nat 33 ; FAILWITH }
-                                                  { SELF_ADDRESS ;
-                                                    CONTRACT %updateTokenPoolInternal nat ;
-                                                    IF_NONE
-                                                      { PUSH string "Cannot get updateTokenPoolInternal entrypoint" ; FAILWITH }
-                                                      {} ;
-                                                    DUP 2 ;
-                                                    GET 13 ;
-                                                    CONTRACT %getBalance (pair address (contract nat)) ;
-                                                    IF_NONE { PUSH nat 28 ; FAILWITH } {} ;
-                                                    PUSH mutez 0 ;
-                                                    DIG 2 ;
-                                                    SELF_ADDRESS ;
-                                                    PAIR ;
-                                                    TRANSFER_TOKENS ;
-                                                    SWAP ;
-                                                    PUSH bool True ;
-                                                    UPDATE 7 ;
-                                                    NIL operation ;
-                                                    DIG 2 ;
-                                                    CONS ;
-                                                    PAIR } } } }
+                                          PUSH nat 0 ;
+                                          DUP 8 ;
+                                          CAR ;
+                                          COMPARE ;
+                                          GT ;
+                                          PUSH mutez 0 ;
+                                          DUP 9 ;
+                                          GET 3 ;
+                                          COMPARE ;
+                                          GT ;
+                                          DUP 9 ;
+                                          GET 7 ;
+                                          AND ;
+                                          AND ;
+                                          AND ;
+                                          IF { PUSH mutez 0 ;
+                                               AMOUNT ;
+                                               COMPARE ;
+                                               GT ;
+                                               IF { PUSH nat 10 ; FAILWITH }
+                                                  { DUP 5 ;
+                                                    NOW ;
+                                                    COMPARE ;
+                                                    GE ;
+                                                    IF { PUSH nat 3 ; FAILWITH }
+                                                       { PUSH nat 10000 ;
+                                                         DUP 7 ;
+                                                         GET 21 ;
+                                                         DUP 6 ;
+                                                         MUL ;
+                                                         EDIV ;
+                                                         IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                         DUP ;
+                                                         DUP 6 ;
+                                                         SUB ;
+                                                         ISNAT ;
+                                                         IF_NONE { PUSH nat 34 ; FAILWITH } {} ;
+                                                         PUSH nat 997 ;
+                                                         DUP 2 ;
+                                                         MUL ;
+                                                         PUSH nat 1000 ;
+                                                         DUP 10 ;
+                                                         CAR ;
+                                                         MUL ;
+                                                         ADD ;
+                                                         PUSH mutez 1 ;
+                                                         DUP 10 ;
+                                                         GET 3 ;
+                                                         EDIV ;
+                                                         IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                         PUSH nat 997 ;
+                                                         DUP 4 ;
+                                                         MUL ;
+                                                         MUL ;
+                                                         EDIV ;
+                                                         IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                         PUSH mutez 1 ;
+                                                         DUP 10 ;
+                                                         GET 3 ;
+                                                         EDIV ;
+                                                         IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                         DUP 2 ;
+                                                         SWAP ;
+                                                         SUB ;
+                                                         ISNAT ;
+                                                         IF_NONE { PUSH nat 36 ; FAILWITH } {} ;
+                                                         PUSH mutez 1 ;
+                                                         SWAP ;
+                                                         MUL ;
+                                                         PUSH mutez 1 ;
+                                                         DIG 2 ;
+                                                         MUL ;
+                                                         DUP 10 ;
+                                                         DIG 3 ;
+                                                         DUP 11 ;
+                                                         CAR ;
+                                                         ADD ;
+                                                         UPDATE 1 ;
+                                                         DIG 2 ;
+                                                         UPDATE 3 ;
+                                                         DIG 2 ;
+                                                         DIG 8 ;
+                                                         GET 26 ;
+                                                         ADD ;
+                                                         UPDATE 26 ;
+                                                         DIG 5 ;
+                                                         SELF_ADDRESS ;
+                                                         SENDER ;
+                                                         DUP 4 ;
+                                                         GET 17 ;
+                                                         CONTRACT %transfer (pair address (pair address nat)) ;
+                                                         IF_NONE { PUSH nat 0 ; FAILWITH } {} ;
+                                                         PUSH mutez 0 ;
+                                                         DIG 4 ;
+                                                         DIG 4 ;
+                                                         PAIR ;
+                                                         DIG 3 ;
+                                                         PAIR ;
+                                                         TRANSFER_TOKENS ;
+                                                         DIG 3 ;
+                                                         DIG 3 ;
+                                                         DIG 6 ;
+                                                         DIG 5 ;
+                                                         DIG 6 ;
+                                                         PAIR 3 ;
+                                                         TRANSFER_TOKENS ;
+                                                         DIG 2 ;
+                                                         NIL operation ;
+                                                         DIG 2 ;
+                                                         CONS ;
+                                                         DIG 2 ;
+                                                         CONS ;
+                                                         PAIR } } }
+                                             { PUSH nat 43 ; FAILWITH } } }
                                    { IF_LEFT
                                        { DUP 2 ;
-                                         GET 7 ;
-                                         IF { PUSH nat 2 ; FAILWITH }
+                                         GET 17 ;
+                                         SENDER ;
+                                         COMPARE ;
+                                         NEQ ;
+                                         DUP 3 ;
+                                         GET 11 ;
+                                         NOT ;
+                                         OR ;
+                                         IF { PUSH nat 29 ; FAILWITH }
                                             { PUSH mutez 0 ;
                                               AMOUNT ;
                                               COMPARE ;
                                               GT ;
                                               IF { PUSH nat 10 ; FAILWITH }
                                                  { DUP 2 ;
-                                                   GET 11 ;
-                                                   SENDER ;
-                                                   COMPARE ;
-                                                   NEQ ;
-                                                   IF { PUSH nat 23 ; FAILWITH }
-                                                      { PUSH address "tz1Ke2h7sDdakHJQh8WX4Z372du1KChsksyU" ;
-                                                        DUP 3 ;
-                                                        GET 15 ;
-                                                        COMPARE ;
-                                                        NEQ ;
-                                                        IF { PUSH nat 24 ; FAILWITH } { UPDATE 15 ; NIL operation ; PAIR } } } } }
+                                                   GET 26 ;
+                                                   SWAP ;
+                                                   SUB ;
+                                                   ISNAT ;
+                                                   IF_NONE { PUSH nat 42 ; FAILWITH } {} ;
+                                                   UPDATE 1 ;
+                                                   PUSH bool False ;
+                                                   UPDATE 11 ;
+                                                   NIL operation ;
+                                                   PAIR } } }
                                        { IF_LEFT
-                                           { DUP 2 ;
-                                             GET 7 ;
-                                             IF { PUSH nat 2 ; FAILWITH }
+                                           { DROP ;
+                                             SOURCE ;
+                                             SENDER ;
+                                             COMPARE ;
+                                             NEQ ;
+                                             IF { PUSH nat 25 ; FAILWITH }
                                                 { PUSH mutez 0 ;
                                                   AMOUNT ;
                                                   COMPARE ;
                                                   GT ;
                                                   IF { PUSH nat 10 ; FAILWITH }
-                                                     { DUP 2 ;
+                                                     { DUP ;
                                                        GET 11 ;
-                                                       SENDER ;
-                                                       COMPARE ;
-                                                       NEQ ;
-                                                       IF { PUSH nat 21 ; FAILWITH } { UPDATE 11 ; NIL operation ; PAIR } } } }
+                                                       IF { PUSH nat 33 ; FAILWITH }
+                                                          { DUP ;
+                                                            GET 15 ;
+                                                            SENDER ;
+                                                            COMPARE ;
+                                                            NEQ ;
+                                                            DUP 2 ;
+                                                            GET 7 ;
+                                                            NOT ;
+                                                            AND ;
+                                                            IF { PUSH nat 45 ; FAILWITH }
+                                                               { SELF_ADDRESS ;
+                                                                 CONTRACT %updateTokenPoolInternal nat ;
+                                                                 IF_NONE
+                                                                   { PUSH string "Cannot get updateTokenPoolInternal entrypoint" ; FAILWITH }
+                                                                   {} ;
+                                                                 DUP 2 ;
+                                                                 GET 17 ;
+                                                                 CONTRACT %getBalance (pair address (contract nat)) ;
+                                                                 IF_NONE { PUSH nat 28 ; FAILWITH } {} ;
+                                                                 PUSH mutez 0 ;
+                                                                 DIG 2 ;
+                                                                 SELF_ADDRESS ;
+                                                                 PAIR ;
+                                                                 TRANSFER_TOKENS ;
+                                                                 SWAP ;
+                                                                 PUSH bool True ;
+                                                                 UPDATE 11 ;
+                                                                 NIL operation ;
+                                                                 DIG 2 ;
+                                                                 CONS ;
+                                                                 PAIR } } } } }
                                            { IF_LEFT
-                                               { UNPAIR ;
-                                                 DUP 3 ;
-                                                 GET 7 ;
+                                               { DUP 2 ;
+                                                 GET 11 ;
                                                  IF { PUSH nat 2 ; FAILWITH }
                                                     { PUSH mutez 0 ;
                                                       AMOUNT ;
                                                       COMPARE ;
                                                       GT ;
                                                       IF { PUSH nat 10 ; FAILWITH }
-                                                         { DUP 3 ;
-                                                           GET 11 ;
+                                                         { DUP 2 ;
+                                                           GET 15 ;
                                                            SENDER ;
                                                            COMPARE ;
                                                            NEQ ;
-                                                           IF { PUSH nat 20 ; FAILWITH }
-                                                              { DUP 3 ;
-                                                                GET 9 ;
-                                                                IF { PUSH nat 22 ; FAILWITH }
-                                                                   { DUG 2 ; UPDATE 9 ; NIL operation ; DIG 2 ; SET_DELEGATE ; CONS ; PAIR } } } } }
+                                                           IF { PUSH nat 23 ; FAILWITH }
+                                                              { PUSH address "tz1Ke2h7sDdakHJQh8WX4Z372du1KChsksyU" ;
+                                                                DUP 3 ;
+                                                                GET 19 ;
+                                                                COMPARE ;
+                                                                NEQ ;
+                                                                IF { PUSH nat 24 ; FAILWITH } { UPDATE 19 ; NIL operation ; PAIR } } } } }
                                                { IF_LEFT
-                                                   { DROP ;
-                                                     DUP ;
-                                                     GET 7 ;
+                                                   { DUP 2 ;
+                                                     GET 11 ;
                                                      IF { PUSH nat 2 ; FAILWITH }
-                                                        { DUP ; AMOUNT ; DIG 2 ; GET 3 ; ADD ; UPDATE 3 ; NIL operation ; PAIR } }
+                                                        { PUSH mutez 0 ;
+                                                          AMOUNT ;
+                                                          COMPARE ;
+                                                          GT ;
+                                                          IF { PUSH nat 10 ; FAILWITH }
+                                                             { DUP 2 ;
+                                                               GET 15 ;
+                                                               SENDER ;
+                                                               COMPARE ;
+                                                               NEQ ;
+                                                               IF { PUSH nat 21 ; FAILWITH } { UPDATE 15 ; NIL operation ; PAIR } } } }
                                                    { IF_LEFT
-                                                       { UNPAIR 4 ;
-                                                         DUP 5 ;
-                                                         GET 7 ;
+                                                       { UNPAIR ;
+                                                         DUP 3 ;
+                                                         GET 11 ;
                                                          IF { PUSH nat 2 ; FAILWITH }
-                                                            { DIG 3 ;
-                                                              NOW ;
+                                                            { PUSH mutez 0 ;
+                                                              AMOUNT ;
                                                               COMPARE ;
-                                                              GE ;
-                                                              IF { PUSH nat 3 ; FAILWITH }
-                                                                 { PUSH mutez 0 ;
-                                                                   AMOUNT ;
+                                                              GT ;
+                                                              IF { PUSH nat 10 ; FAILWITH }
+                                                                 { DUP 3 ;
+                                                                   GET 15 ;
+                                                                   SENDER ;
                                                                    COMPARE ;
-                                                                   GT ;
-                                                                   IF { PUSH nat 10 ; FAILWITH }
-                                                                      { PUSH nat 10000 ;
-                                                                        DUP 5 ;
-                                                                        GET 17 ;
-                                                                        DUP 4 ;
-                                                                        MUL ;
-                                                                        EDIV ;
-                                                                        IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                        DUP ;
-                                                                        DUP 4 ;
-                                                                        SUB ;
-                                                                        ISNAT ;
-                                                                        IF_NONE { PUSH nat 34 ; FAILWITH } {} ;
-                                                                        PUSH nat 997 ;
-                                                                        DUP 2 ;
-                                                                        MUL ;
-                                                                        PUSH nat 1000 ;
-                                                                        DUP 8 ;
-                                                                        CAR ;
-                                                                        MUL ;
-                                                                        ADD ;
-                                                                        PUSH mutez 1 ;
-                                                                        DUP 8 ;
-                                                                        GET 3 ;
-                                                                        EDIV ;
-                                                                        IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                        PUSH nat 997 ;
-                                                                        DUP 4 ;
-                                                                        MUL ;
-                                                                        MUL ;
-                                                                        EDIV ;
-                                                                        IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                        PUSH mutez 1 ;
-                                                                        SWAP ;
-                                                                        MUL ;
-                                                                        DIG 5 ;
-                                                                        DUP 2 ;
-                                                                        COMPARE ;
-                                                                        LT ;
-                                                                        IF { PUSH nat 8 ; FAILWITH } {} ;
-                                                                        PUSH mutez 1 ;
-                                                                        DUP 7 ;
-                                                                        GET 3 ;
-                                                                        EDIV ;
-                                                                        IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                        PUSH mutez 1 ;
-                                                                        DUP 3 ;
-                                                                        EDIV ;
-                                                                        IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                        SWAP ;
-                                                                        SUB ;
-                                                                        ISNAT ;
-                                                                        IF_NONE { PUSH nat 36 ; FAILWITH } {} ;
-                                                                        PUSH mutez 1 ;
-                                                                        SWAP ;
-                                                                        MUL ;
-                                                                        DIG 5 ;
-                                                                        SELF_ADDRESS ;
-                                                                        SENDER ;
-                                                                        DUP 9 ;
+                                                                   NEQ ;
+                                                                   IF { PUSH nat 20 ; FAILWITH }
+                                                                      { DUP 3 ;
                                                                         GET 13 ;
-                                                                        CONTRACT %transfer (pair address (pair address nat)) ;
-                                                                        IF_NONE { PUSH nat 0 ; FAILWITH } {} ;
-                                                                        PUSH mutez 0 ;
-                                                                        DIG 4 ;
-                                                                        DIG 4 ;
-                                                                        PAIR ;
-                                                                        DIG 3 ;
-                                                                        PAIR ;
-                                                                        TRANSFER_TOKENS ;
-                                                                        DIG 5 ;
-                                                                        CONTRACT unit ;
-                                                                        IF_NONE { PUSH nat 9 ; FAILWITH } {} ;
-                                                                        DIG 3 ;
-                                                                        UNIT ;
-                                                                        TRANSFER_TOKENS ;
-                                                                        DUP 6 ;
-                                                                        DIG 4 ;
-                                                                        DUP 7 ;
-                                                                        CAR ;
-                                                                        ADD ;
-                                                                        UPDATE 1 ;
-                                                                        DIG 3 ;
-                                                                        UPDATE 3 ;
-                                                                        DIG 3 ;
-                                                                        DIG 4 ;
-                                                                        GET 22 ;
-                                                                        ADD ;
-                                                                        UPDATE 22 ;
-                                                                        NIL operation ;
-                                                                        DIG 2 ;
-                                                                        CONS ;
-                                                                        DIG 2 ;
-                                                                        CONS ;
-                                                                        PAIR } } } }
+                                                                        IF { PUSH nat 22 ; FAILWITH }
+                                                                           { DUG 2 ; UPDATE 13 ; NIL operation ; DIG 2 ; SET_DELEGATE ; CONS ; PAIR } } } } }
                                                        { IF_LEFT
-                                                           { UNPAIR 3 ;
-                                                             DUP 4 ;
-                                                             GET 7 ;
+                                                           { DROP ;
+                                                             DUP ;
+                                                             GET 11 ;
                                                              IF { PUSH nat 2 ; FAILWITH }
-                                                                { DIG 2 ;
-                                                                  NOW ;
+                                                                { DUP ;
+                                                                  GET 15 ;
+                                                                  SENDER ;
                                                                   COMPARE ;
-                                                                  GE ;
-                                                                  IF { PUSH nat 3 ; FAILWITH }
-                                                                     { PUSH mutez 1 ;
-                                                                       DUP 4 ;
-                                                                       GET 3 ;
-                                                                       EDIV ;
-                                                                       IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                       PUSH mutez 1 ;
-                                                                       AMOUNT ;
-                                                                       EDIV ;
-                                                                       IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                       PUSH nat 10000 ;
-                                                                       DUP 6 ;
-                                                                       GET 17 ;
-                                                                       DUP 3 ;
-                                                                       MUL ;
-                                                                       EDIV ;
-                                                                       IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                       DUP ;
-                                                                       DIG 2 ;
-                                                                       SUB ;
-                                                                       ISNAT ;
-                                                                       IF_NONE { PUSH nat 34 ; FAILWITH } {} ;
-                                                                       PUSH nat 997 ;
-                                                                       DUP 2 ;
-                                                                       MUL ;
-                                                                       PUSH nat 1000 ;
-                                                                       DIG 4 ;
-                                                                       MUL ;
-                                                                       ADD ;
-                                                                       DUP 6 ;
-                                                                       CAR ;
-                                                                       PUSH nat 997 ;
-                                                                       DUP 4 ;
-                                                                       MUL ;
-                                                                       MUL ;
-                                                                       EDIV ;
-                                                                       IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                       DIG 4 ;
-                                                                       DUP 2 ;
-                                                                       COMPARE ;
-                                                                       LT ;
-                                                                       IF { PUSH nat 18 ; FAILWITH } {} ;
-                                                                       DUP ;
-                                                                       DUP 6 ;
-                                                                       CAR ;
-                                                                       SUB ;
-                                                                       ISNAT ;
-                                                                       IF_NONE { PUSH nat 19 ; FAILWITH } {} ;
-                                                                       PUSH mutez 1 ;
-                                                                       DIG 4 ;
-                                                                       MUL ;
-                                                                       PUSH mutez 1 ;
-                                                                       DIG 4 ;
-                                                                       MUL ;
-                                                                       DUP 6 ;
-                                                                       SWAP ;
-                                                                       DUP 7 ;
-                                                                       GET 3 ;
-                                                                       ADD ;
-                                                                       UPDATE 3 ;
-                                                                       DIG 2 ;
-                                                                       UPDATE 1 ;
-                                                                       SWAP ;
-                                                                       DIG 4 ;
-                                                                       GET 21 ;
-                                                                       ADD ;
-                                                                       UPDATE 21 ;
-                                                                       SWAP ;
-                                                                       DIG 2 ;
-                                                                       SELF_ADDRESS ;
-                                                                       DUP 4 ;
-                                                                       GET 13 ;
-                                                                       CONTRACT %transfer (pair address (pair address nat)) ;
-                                                                       IF_NONE { PUSH nat 0 ; FAILWITH } {} ;
-                                                                       PUSH mutez 0 ;
-                                                                       DIG 4 ;
-                                                                       DIG 4 ;
-                                                                       PAIR ;
-                                                                       DIG 3 ;
-                                                                       PAIR ;
-                                                                       TRANSFER_TOKENS ;
-                                                                       SWAP ;
-                                                                       NIL operation ;
-                                                                       DIG 2 ;
-                                                                       CONS ;
-                                                                       PAIR } } }
+                                                                  NEQ ;
+                                                                  DUP 2 ;
+                                                                  GET 7 ;
+                                                                  NOT ;
+                                                                  AND ;
+                                                                  IF { PUSH nat 45 ; FAILWITH }
+                                                                     { DUP ; AMOUNT ; DIG 2 ; GET 3 ; ADD ; UPDATE 3 ; NIL operation ; PAIR } } }
                                                            { IF_LEFT
-                                                               { UNPAIR 5 ;
-                                                                 DUP 6 ;
-                                                                 GET 7 ;
+                                                               { UNPAIR 4 ;
+                                                                 DUP 5 ;
+                                                                 GET 11 ;
                                                                  IF { PUSH nat 2 ; FAILWITH }
-                                                                    { DIG 4 ;
-                                                                      NOW ;
+                                                                    { PUSH nat 0 ;
+                                                                      DUP 6 ;
+                                                                      GET 5 ;
                                                                       COMPARE ;
-                                                                      GE ;
-                                                                      IF { PUSH nat 3 ; FAILWITH }
-                                                                         { PUSH mutez 0 ;
-                                                                           AMOUNT ;
+                                                                      GT ;
+                                                                      PUSH nat 0 ;
+                                                                      DUP 7 ;
+                                                                      CAR ;
+                                                                      COMPARE ;
+                                                                      GT ;
+                                                                      PUSH mutez 0 ;
+                                                                      DUP 8 ;
+                                                                      GET 3 ;
+                                                                      COMPARE ;
+                                                                      GT ;
+                                                                      DUP 8 ;
+                                                                      GET 7 ;
+                                                                      AND ;
+                                                                      AND ;
+                                                                      AND ;
+                                                                      IF { DIG 3 ;
+                                                                           NOW ;
                                                                            COMPARE ;
-                                                                           GT ;
-                                                                           IF { PUSH nat 10 ; FAILWITH }
-                                                                              { DUP 5 ;
-                                                                                GET 5 ;
-                                                                                PUSH mutez 1 ;
-                                                                                DUP 7 ;
-                                                                                GET 3 ;
-                                                                                EDIV ;
-                                                                                IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                                DUP 4 ;
-                                                                                MUL ;
-                                                                                EDIV ;
-                                                                                IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                                PUSH mutez 1 ;
-                                                                                SWAP ;
-                                                                                MUL ;
-                                                                                DUP 6 ;
-                                                                                GET 5 ;
-                                                                                DUP 7 ;
-                                                                                CAR ;
-                                                                                DUP 5 ;
-                                                                                MUL ;
-                                                                                EDIV ;
-                                                                                IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                                DIG 4 ;
-                                                                                DUP 3 ;
+                                                                           GE ;
+                                                                           IF { PUSH nat 3 ; FAILWITH }
+                                                                              { PUSH mutez 0 ;
+                                                                                AMOUNT ;
                                                                                 COMPARE ;
-                                                                                LT ;
-                                                                                IF { PUSH nat 11 ; FAILWITH }
-                                                                                   { DIG 4 ;
+                                                                                GT ;
+                                                                                IF { PUSH nat 10 ; FAILWITH }
+                                                                                   { PUSH nat 10000 ;
+                                                                                     DUP 5 ;
+                                                                                     GET 21 ;
+                                                                                     DUP 4 ;
+                                                                                     MUL ;
+                                                                                     EDIV ;
+                                                                                     IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                     DUP ;
+                                                                                     DUP 4 ;
+                                                                                     SUB ;
+                                                                                     ISNAT ;
+                                                                                     IF_NONE { PUSH nat 34 ; FAILWITH } {} ;
+                                                                                     PUSH nat 997 ;
+                                                                                     DUP 2 ;
+                                                                                     MUL ;
+                                                                                     PUSH nat 1000 ;
+                                                                                     DUP 8 ;
+                                                                                     CAR ;
+                                                                                     MUL ;
+                                                                                     ADD ;
+                                                                                     PUSH mutez 1 ;
+                                                                                     DUP 8 ;
+                                                                                     GET 3 ;
+                                                                                     EDIV ;
+                                                                                     IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                     PUSH nat 997 ;
+                                                                                     DUP 4 ;
+                                                                                     MUL ;
+                                                                                     MUL ;
+                                                                                     EDIV ;
+                                                                                     IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                     PUSH mutez 1 ;
+                                                                                     SWAP ;
+                                                                                     MUL ;
+                                                                                     DIG 5 ;
                                                                                      DUP 2 ;
                                                                                      COMPARE ;
                                                                                      LT ;
-                                                                                     IF { PUSH nat 13 ; FAILWITH }
-                                                                                        { DUP 4 ;
-                                                                                          DUP 6 ;
-                                                                                          GET 5 ;
-                                                                                          SUB ;
-                                                                                          ISNAT ;
-                                                                                          IF_NONE { PUSH nat 14 ; FAILWITH } {} ;
-                                                                                          DUP 2 ;
-                                                                                          DUP 7 ;
-                                                                                          CAR ;
-                                                                                          SUB ;
-                                                                                          ISNAT ;
-                                                                                          IF_NONE { PUSH nat 15 ; FAILWITH } {} ;
-                                                                                          PUSH mutez 1 ;
-                                                                                          DUP 8 ;
-                                                                                          GET 3 ;
-                                                                                          EDIV ;
-                                                                                          IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                                          PUSH mutez 1 ;
-                                                                                          DUP 6 ;
-                                                                                          EDIV ;
-                                                                                          IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                                          SWAP ;
-                                                                                          SUB ;
-                                                                                          ISNAT ;
-                                                                                          IF_NONE { PUSH nat 36 ; FAILWITH } {} ;
-                                                                                          PUSH mutez 1 ;
-                                                                                          SWAP ;
-                                                                                          MUL ;
-                                                                                          DIG 6 ;
-                                                                                          PUSH int 0 ;
-                                                                                          SUB ;
-                                                                                          SENDER ;
-                                                                                          DUP 9 ;
-                                                                                          GET 15 ;
-                                                                                          CONTRACT %mintOrBurn (pair (int %quantity) (address %target)) ;
-                                                                                          IF_NONE { PUSH nat 12 ; FAILWITH } {} ;
-                                                                                          PUSH mutez 0 ;
-                                                                                          DIG 2 ;
-                                                                                          DIG 3 ;
-                                                                                          PAIR ;
-                                                                                          TRANSFER_TOKENS ;
-                                                                                          DIG 4 ;
-                                                                                          DUP 7 ;
-                                                                                          SELF_ADDRESS ;
-                                                                                          DUP 10 ;
-                                                                                          GET 13 ;
-                                                                                          CONTRACT %transfer (pair address (pair address nat)) ;
-                                                                                          IF_NONE { PUSH nat 0 ; FAILWITH } {} ;
-                                                                                          PUSH mutez 0 ;
-                                                                                          DIG 4 ;
-                                                                                          DIG 4 ;
-                                                                                          PAIR ;
-                                                                                          DIG 3 ;
-                                                                                          PAIR ;
-                                                                                          TRANSFER_TOKENS ;
-                                                                                          DIG 6 ;
-                                                                                          CONTRACT unit ;
-                                                                                          IF_NONE { PUSH nat 9 ; FAILWITH } {} ;
-                                                                                          DIG 6 ;
-                                                                                          UNIT ;
-                                                                                          TRANSFER_TOKENS ;
-                                                                                          DIG 6 ;
-                                                                                          DIG 4 ;
-                                                                                          UPDATE 3 ;
-                                                                                          DIG 5 ;
-                                                                                          UPDATE 5 ;
-                                                                                          DIG 4 ;
-                                                                                          UPDATE 1 ;
-                                                                                          NIL operation ;
-                                                                                          DIG 2 ;
-                                                                                          CONS ;
-                                                                                          DIG 2 ;
-                                                                                          CONS ;
-                                                                                          DIG 2 ;
-                                                                                          CONS ;
-                                                                                          PAIR } } } } } }
-                                                               { UNPAIR 4 ;
-                                                                 DUP 5 ;
-                                                                 GET 7 ;
-                                                                 IF { PUSH nat 2 ; FAILWITH }
-                                                                    { DIG 3 ;
-                                                                      NOW ;
-                                                                      COMPARE ;
-                                                                      GE ;
-                                                                      IF { PUSH nat 3 ; FAILWITH }
-                                                                         { PUSH mutez 1 ;
-                                                                           DUP 5 ;
-                                                                           GET 3 ;
-                                                                           EDIV ;
-                                                                           IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                           PUSH mutez 1 ;
-                                                                           AMOUNT ;
-                                                                           EDIV ;
-                                                                           IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                           DUP 2 ;
-                                                                           DUP 7 ;
-                                                                           GET 5 ;
-                                                                           DUP 3 ;
-                                                                           MUL ;
-                                                                           EDIV ;
-                                                                           IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                           DIG 2 ;
-                                                                           DUP 7 ;
-                                                                           CAR ;
-                                                                           DIG 3 ;
-                                                                           MUL ;
-                                                                           EDIV ;
-                                                                           IF_NONE
-                                                                             { PUSH string "DIV by 0" ; FAILWITH }
-                                                                             { UNPAIR ; SWAP ; INT ; EQ ; IF {} { PUSH nat 1 ; ADD } } ;
-                                                                           DIG 4 ;
-                                                                           DUP 2 ;
-                                                                           COMPARE ;
-                                                                           GT ;
-                                                                           IF { PUSH nat 4 ; FAILWITH }
-                                                                              { DIG 3 ;
-                                                                                DUP 3 ;
-                                                                                COMPARE ;
-                                                                                LT ;
-                                                                                IF { PUSH nat 5 ; FAILWITH }
-                                                                                   { DUP 4 ;
-                                                                                     DUP 3 ;
-                                                                                     DUP 6 ;
-                                                                                     GET 5 ;
-                                                                                     ADD ;
-                                                                                     UPDATE 5 ;
-                                                                                     DUP 2 ;
-                                                                                     DUP 6 ;
-                                                                                     CAR ;
-                                                                                     ADD ;
-                                                                                     UPDATE 1 ;
-                                                                                     AMOUNT ;
-                                                                                     DIG 5 ;
+                                                                                     IF { PUSH nat 8 ; FAILWITH } {} ;
+                                                                                     PUSH mutez 1 ;
+                                                                                     DUP 7 ;
                                                                                      GET 3 ;
-                                                                                     ADD ;
-                                                                                     UPDATE 3 ;
+                                                                                     EDIV ;
+                                                                                     IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                     PUSH mutez 1 ;
+                                                                                     DUP 3 ;
+                                                                                     EDIV ;
+                                                                                     IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
                                                                                      SWAP ;
+                                                                                     SUB ;
+                                                                                     ISNAT ;
+                                                                                     IF_NONE { PUSH nat 36 ; FAILWITH } {} ;
+                                                                                     PUSH mutez 1 ;
+                                                                                     SWAP ;
+                                                                                     MUL ;
+                                                                                     DIG 5 ;
                                                                                      SELF_ADDRESS ;
                                                                                      SENDER ;
-                                                                                     DUP 4 ;
-                                                                                     GET 13 ;
+                                                                                     DUP 9 ;
+                                                                                     GET 17 ;
                                                                                      CONTRACT %transfer (pair address (pair address nat)) ;
                                                                                      IF_NONE { PUSH nat 0 ; FAILWITH } {} ;
                                                                                      PUSH mutez 0 ;
@@ -788,25 +676,406 @@
                                                                                      DIG 3 ;
                                                                                      PAIR ;
                                                                                      TRANSFER_TOKENS ;
-                                                                                     DIG 2 ;
-                                                                                     INT ;
+                                                                                     DIG 5 ;
+                                                                                     CONTRACT unit ;
+                                                                                     IF_NONE { PUSH nat 9 ; FAILWITH } {} ;
                                                                                      DIG 3 ;
-                                                                                     DUP 4 ;
-                                                                                     GET 15 ;
-                                                                                     CONTRACT %mintOrBurn (pair (int %quantity) (address %target)) ;
-                                                                                     IF_NONE { PUSH nat 12 ; FAILWITH } {} ;
-                                                                                     PUSH mutez 0 ;
-                                                                                     DIG 2 ;
-                                                                                     DIG 3 ;
-                                                                                     PAIR ;
+                                                                                     UNIT ;
                                                                                      TRANSFER_TOKENS ;
-                                                                                     DIG 2 ;
+                                                                                     DUP 6 ;
+                                                                                     DIG 4 ;
+                                                                                     DUP 7 ;
+                                                                                     CAR ;
+                                                                                     ADD ;
+                                                                                     UPDATE 1 ;
+                                                                                     DIG 3 ;
+                                                                                     UPDATE 3 ;
+                                                                                     DIG 3 ;
+                                                                                     DIG 4 ;
+                                                                                     GET 26 ;
+                                                                                     ADD ;
+                                                                                     UPDATE 26 ;
                                                                                      NIL operation ;
                                                                                      DIG 2 ;
                                                                                      CONS ;
                                                                                      DIG 2 ;
                                                                                      CONS ;
-                                                                                     PAIR } } } } } } } } } } } } } } } } } } } ;
+                                                                                     PAIR } } }
+                                                                         { PUSH nat 43 ; FAILWITH } } }
+                                                               { IF_LEFT
+                                                                   { UNPAIR 3 ;
+                                                                     DUP 4 ;
+                                                                     GET 11 ;
+                                                                     IF { PUSH nat 2 ; FAILWITH }
+                                                                        { PUSH nat 0 ;
+                                                                          DUP 5 ;
+                                                                          GET 5 ;
+                                                                          COMPARE ;
+                                                                          GT ;
+                                                                          PUSH nat 0 ;
+                                                                          DUP 6 ;
+                                                                          CAR ;
+                                                                          COMPARE ;
+                                                                          GT ;
+                                                                          PUSH mutez 0 ;
+                                                                          DUP 7 ;
+                                                                          GET 3 ;
+                                                                          COMPARE ;
+                                                                          GT ;
+                                                                          DUP 7 ;
+                                                                          GET 7 ;
+                                                                          AND ;
+                                                                          AND ;
+                                                                          AND ;
+                                                                          IF { DIG 2 ;
+                                                                               NOW ;
+                                                                               COMPARE ;
+                                                                               GE ;
+                                                                               IF { PUSH nat 3 ; FAILWITH }
+                                                                                  { PUSH mutez 1 ;
+                                                                                    DUP 4 ;
+                                                                                    GET 3 ;
+                                                                                    EDIV ;
+                                                                                    IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                    PUSH mutez 1 ;
+                                                                                    AMOUNT ;
+                                                                                    EDIV ;
+                                                                                    IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                    PUSH nat 10000 ;
+                                                                                    DUP 6 ;
+                                                                                    GET 21 ;
+                                                                                    DUP 3 ;
+                                                                                    MUL ;
+                                                                                    EDIV ;
+                                                                                    IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                    DUP ;
+                                                                                    DIG 2 ;
+                                                                                    SUB ;
+                                                                                    ISNAT ;
+                                                                                    IF_NONE { PUSH nat 34 ; FAILWITH } {} ;
+                                                                                    PUSH nat 997 ;
+                                                                                    DUP 2 ;
+                                                                                    MUL ;
+                                                                                    PUSH nat 1000 ;
+                                                                                    DIG 4 ;
+                                                                                    MUL ;
+                                                                                    ADD ;
+                                                                                    DUP 6 ;
+                                                                                    CAR ;
+                                                                                    PUSH nat 997 ;
+                                                                                    DUP 4 ;
+                                                                                    MUL ;
+                                                                                    MUL ;
+                                                                                    EDIV ;
+                                                                                    IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                    DIG 4 ;
+                                                                                    DUP 2 ;
+                                                                                    COMPARE ;
+                                                                                    LT ;
+                                                                                    IF { PUSH nat 18 ; FAILWITH } {} ;
+                                                                                    DUP ;
+                                                                                    DUP 6 ;
+                                                                                    CAR ;
+                                                                                    SUB ;
+                                                                                    ISNAT ;
+                                                                                    IF_NONE { PUSH nat 19 ; FAILWITH } {} ;
+                                                                                    PUSH mutez 1 ;
+                                                                                    DIG 4 ;
+                                                                                    MUL ;
+                                                                                    PUSH mutez 1 ;
+                                                                                    DIG 4 ;
+                                                                                    MUL ;
+                                                                                    DUP 6 ;
+                                                                                    SWAP ;
+                                                                                    DUP 7 ;
+                                                                                    GET 3 ;
+                                                                                    ADD ;
+                                                                                    UPDATE 3 ;
+                                                                                    DIG 2 ;
+                                                                                    UPDATE 1 ;
+                                                                                    SWAP ;
+                                                                                    DIG 4 ;
+                                                                                    GET 25 ;
+                                                                                    ADD ;
+                                                                                    UPDATE 25 ;
+                                                                                    SWAP ;
+                                                                                    DIG 2 ;
+                                                                                    SELF_ADDRESS ;
+                                                                                    DUP 4 ;
+                                                                                    GET 17 ;
+                                                                                    CONTRACT %transfer (pair address (pair address nat)) ;
+                                                                                    IF_NONE { PUSH nat 0 ; FAILWITH } {} ;
+                                                                                    PUSH mutez 0 ;
+                                                                                    DIG 4 ;
+                                                                                    DIG 4 ;
+                                                                                    PAIR ;
+                                                                                    DIG 3 ;
+                                                                                    PAIR ;
+                                                                                    TRANSFER_TOKENS ;
+                                                                                    SWAP ;
+                                                                                    NIL operation ;
+                                                                                    DIG 2 ;
+                                                                                    CONS ;
+                                                                                    PAIR } }
+                                                                             { PUSH nat 43 ; FAILWITH } } }
+                                                                   { IF_LEFT
+                                                                       { UNPAIR 5 ;
+                                                                         DUP 6 ;
+                                                                         GET 11 ;
+                                                                         IF { PUSH nat 2 ; FAILWITH }
+                                                                            { PUSH nat 0 ;
+                                                                              DUP 7 ;
+                                                                              GET 5 ;
+                                                                              COMPARE ;
+                                                                              GT ;
+                                                                              PUSH nat 0 ;
+                                                                              DUP 8 ;
+                                                                              CAR ;
+                                                                              COMPARE ;
+                                                                              GT ;
+                                                                              PUSH mutez 0 ;
+                                                                              DUP 9 ;
+                                                                              GET 3 ;
+                                                                              COMPARE ;
+                                                                              GT ;
+                                                                              DUP 9 ;
+                                                                              GET 7 ;
+                                                                              AND ;
+                                                                              AND ;
+                                                                              AND ;
+                                                                              IF { DIG 4 ;
+                                                                                   NOW ;
+                                                                                   COMPARE ;
+                                                                                   GE ;
+                                                                                   IF { PUSH nat 3 ; FAILWITH }
+                                                                                      { PUSH mutez 0 ;
+                                                                                        AMOUNT ;
+                                                                                        COMPARE ;
+                                                                                        GT ;
+                                                                                        IF { PUSH nat 10 ; FAILWITH }
+                                                                                           { DUP 5 ;
+                                                                                             GET 5 ;
+                                                                                             PUSH mutez 1 ;
+                                                                                             DUP 7 ;
+                                                                                             GET 3 ;
+                                                                                             EDIV ;
+                                                                                             IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                             DUP 4 ;
+                                                                                             MUL ;
+                                                                                             EDIV ;
+                                                                                             IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                             PUSH mutez 1 ;
+                                                                                             SWAP ;
+                                                                                             MUL ;
+                                                                                             DUP 6 ;
+                                                                                             GET 5 ;
+                                                                                             DUP 7 ;
+                                                                                             CAR ;
+                                                                                             DUP 5 ;
+                                                                                             MUL ;
+                                                                                             EDIV ;
+                                                                                             IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                             DIG 4 ;
+                                                                                             DUP 3 ;
+                                                                                             COMPARE ;
+                                                                                             LT ;
+                                                                                             IF { PUSH nat 11 ; FAILWITH }
+                                                                                                { DIG 4 ;
+                                                                                                  DUP 2 ;
+                                                                                                  COMPARE ;
+                                                                                                  LT ;
+                                                                                                  IF { PUSH nat 13 ; FAILWITH }
+                                                                                                     { DUP 4 ;
+                                                                                                       DUP 6 ;
+                                                                                                       GET 5 ;
+                                                                                                       SUB ;
+                                                                                                       ISNAT ;
+                                                                                                       IF_NONE { PUSH nat 14 ; FAILWITH } {} ;
+                                                                                                       DUP 2 ;
+                                                                                                       DUP 7 ;
+                                                                                                       CAR ;
+                                                                                                       SUB ;
+                                                                                                       ISNAT ;
+                                                                                                       IF_NONE { PUSH nat 15 ; FAILWITH } {} ;
+                                                                                                       PUSH mutez 1 ;
+                                                                                                       DUP 8 ;
+                                                                                                       GET 3 ;
+                                                                                                       EDIV ;
+                                                                                                       IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                                       PUSH mutez 1 ;
+                                                                                                       DUP 6 ;
+                                                                                                       EDIV ;
+                                                                                                       IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                                       SWAP ;
+                                                                                                       SUB ;
+                                                                                                       ISNAT ;
+                                                                                                       IF_NONE { PUSH nat 36 ; FAILWITH } {} ;
+                                                                                                       PUSH mutez 1 ;
+                                                                                                       SWAP ;
+                                                                                                       MUL ;
+                                                                                                       DIG 6 ;
+                                                                                                       PUSH int 0 ;
+                                                                                                       SUB ;
+                                                                                                       SENDER ;
+                                                                                                       DUP 9 ;
+                                                                                                       GET 19 ;
+                                                                                                       CONTRACT %mintOrBurn (pair (int %quantity) (address %target)) ;
+                                                                                                       IF_NONE { PUSH nat 12 ; FAILWITH } {} ;
+                                                                                                       PUSH mutez 0 ;
+                                                                                                       DIG 2 ;
+                                                                                                       DIG 3 ;
+                                                                                                       PAIR ;
+                                                                                                       TRANSFER_TOKENS ;
+                                                                                                       DIG 4 ;
+                                                                                                       DUP 7 ;
+                                                                                                       SELF_ADDRESS ;
+                                                                                                       DUP 10 ;
+                                                                                                       GET 17 ;
+                                                                                                       CONTRACT %transfer (pair address (pair address nat)) ;
+                                                                                                       IF_NONE { PUSH nat 0 ; FAILWITH } {} ;
+                                                                                                       PUSH mutez 0 ;
+                                                                                                       DIG 4 ;
+                                                                                                       DIG 4 ;
+                                                                                                       PAIR ;
+                                                                                                       DIG 3 ;
+                                                                                                       PAIR ;
+                                                                                                       TRANSFER_TOKENS ;
+                                                                                                       DIG 6 ;
+                                                                                                       CONTRACT unit ;
+                                                                                                       IF_NONE { PUSH nat 9 ; FAILWITH } {} ;
+                                                                                                       DIG 6 ;
+                                                                                                       UNIT ;
+                                                                                                       TRANSFER_TOKENS ;
+                                                                                                       DIG 6 ;
+                                                                                                       DIG 4 ;
+                                                                                                       UPDATE 3 ;
+                                                                                                       DIG 5 ;
+                                                                                                       UPDATE 5 ;
+                                                                                                       DIG 4 ;
+                                                                                                       UPDATE 1 ;
+                                                                                                       NIL operation ;
+                                                                                                       DIG 2 ;
+                                                                                                       CONS ;
+                                                                                                       DIG 2 ;
+                                                                                                       CONS ;
+                                                                                                       DIG 2 ;
+                                                                                                       CONS ;
+                                                                                                       PAIR } } } } }
+                                                                                 { PUSH nat 43 ; FAILWITH } } }
+                                                                       { UNPAIR 4 ;
+                                                                         DUP 5 ;
+                                                                         GET 11 ;
+                                                                         IF { PUSH nat 2 ; FAILWITH }
+                                                                            { PUSH nat 0 ;
+                                                                              DUP 6 ;
+                                                                              GET 5 ;
+                                                                              COMPARE ;
+                                                                              GT ;
+                                                                              PUSH nat 0 ;
+                                                                              DUP 7 ;
+                                                                              CAR ;
+                                                                              COMPARE ;
+                                                                              GT ;
+                                                                              PUSH mutez 0 ;
+                                                                              DUP 8 ;
+                                                                              GET 3 ;
+                                                                              COMPARE ;
+                                                                              GT ;
+                                                                              DUP 8 ;
+                                                                              GET 7 ;
+                                                                              AND ;
+                                                                              AND ;
+                                                                              AND ;
+                                                                              IF { DIG 3 ;
+                                                                                   NOW ;
+                                                                                   COMPARE ;
+                                                                                   GE ;
+                                                                                   IF { PUSH nat 3 ; FAILWITH }
+                                                                                      { PUSH mutez 1 ;
+                                                                                        DUP 5 ;
+                                                                                        GET 3 ;
+                                                                                        EDIV ;
+                                                                                        IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                        PUSH mutez 1 ;
+                                                                                        AMOUNT ;
+                                                                                        EDIV ;
+                                                                                        IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                        DUP 2 ;
+                                                                                        DUP 7 ;
+                                                                                        GET 5 ;
+                                                                                        DUP 3 ;
+                                                                                        MUL ;
+                                                                                        EDIV ;
+                                                                                        IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                        DIG 2 ;
+                                                                                        DUP 7 ;
+                                                                                        CAR ;
+                                                                                        DIG 3 ;
+                                                                                        MUL ;
+                                                                                        EDIV ;
+                                                                                        IF_NONE
+                                                                                          { PUSH string "DIV by 0" ; FAILWITH }
+                                                                                          { UNPAIR ; SWAP ; INT ; EQ ; IF {} { PUSH nat 1 ; ADD } } ;
+                                                                                        DIG 4 ;
+                                                                                        DUP 2 ;
+                                                                                        COMPARE ;
+                                                                                        GT ;
+                                                                                        IF { PUSH nat 4 ; FAILWITH }
+                                                                                           { DIG 3 ;
+                                                                                             DUP 3 ;
+                                                                                             COMPARE ;
+                                                                                             LT ;
+                                                                                             IF { PUSH nat 5 ; FAILWITH }
+                                                                                                { DUP 4 ;
+                                                                                                  DUP 3 ;
+                                                                                                  DUP 6 ;
+                                                                                                  GET 5 ;
+                                                                                                  ADD ;
+                                                                                                  UPDATE 5 ;
+                                                                                                  DUP 2 ;
+                                                                                                  DUP 6 ;
+                                                                                                  CAR ;
+                                                                                                  ADD ;
+                                                                                                  UPDATE 1 ;
+                                                                                                  AMOUNT ;
+                                                                                                  DIG 5 ;
+                                                                                                  GET 3 ;
+                                                                                                  ADD ;
+                                                                                                  UPDATE 3 ;
+                                                                                                  SWAP ;
+                                                                                                  SELF_ADDRESS ;
+                                                                                                  SENDER ;
+                                                                                                  DUP 4 ;
+                                                                                                  GET 17 ;
+                                                                                                  CONTRACT %transfer (pair address (pair address nat)) ;
+                                                                                                  IF_NONE { PUSH nat 0 ; FAILWITH } {} ;
+                                                                                                  PUSH mutez 0 ;
+                                                                                                  DIG 4 ;
+                                                                                                  DIG 4 ;
+                                                                                                  PAIR ;
+                                                                                                  DIG 3 ;
+                                                                                                  PAIR ;
+                                                                                                  TRANSFER_TOKENS ;
+                                                                                                  DIG 2 ;
+                                                                                                  INT ;
+                                                                                                  DIG 3 ;
+                                                                                                  DUP 4 ;
+                                                                                                  GET 19 ;
+                                                                                                  CONTRACT %mintOrBurn (pair (int %quantity) (address %target)) ;
+                                                                                                  IF_NONE { PUSH nat 12 ; FAILWITH } {} ;
+                                                                                                  PUSH mutez 0 ;
+                                                                                                  DIG 2 ;
+                                                                                                  DIG 3 ;
+                                                                                                  PAIR ;
+                                                                                                  TRANSFER_TOKENS ;
+                                                                                                  DIG 2 ;
+                                                                                                  NIL operation ;
+                                                                                                  DIG 2 ;
+                                                                                                  CONS ;
+                                                                                                  DIG 2 ;
+                                                                                                  CONS ;
+                                                                                                  PAIR } } } }
+                                                                                 { PUSH nat 43 ; FAILWITH } } } } } } } } } } } } } } } } } } } ;
   view "get_reserves"
        unit
        (pair nat nat)
@@ -821,16 +1090,40 @@
          IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
          PAIR } ;
   view "get_lqt_total" unit nat { GET 7 } ;
+  view "is_active"
+       unit
+       bool
+       { CDR ;
+         PUSH nat 0 ;
+         DUP 2 ;
+         GET 5 ;
+         COMPARE ;
+         GT ;
+         PUSH nat 0 ;
+         DUP 3 ;
+         CAR ;
+         COMPARE ;
+         GT ;
+         PUSH mutez 0 ;
+         DUP 4 ;
+         GET 3 ;
+         COMPARE ;
+         GT ;
+         DIG 3 ;
+         GET 7 ;
+         AND ;
+         AND ;
+         AND } ;
   view "get_fee_bp"
        unit
        (pair nat (pair nat nat))
        { CDR ;
          DUP ;
-         GET 17 ;
+         GET 21 ;
          PUSH nat 30 ;
          ADD ;
          SWAP ;
-         GET 17 ;
+         GET 21 ;
          PUSH nat 30 ;
          PAIR 3 } ;
   view "quote_tez_to_token"
@@ -853,12 +1146,16 @@
          DUP 5 ;
          INT ;
          EQ ;
+         DUP 7 ;
+         GET 7 ;
+         NOT ;
+         OR ;
          OR ;
          OR ;
          IF { DROP 4 ; PUSH nat 0 }
             { PUSH nat 10000 ;
               DIG 4 ;
-              GET 17 ;
+              GET 21 ;
               DUP 5 ;
               MUL ;
               EDIV ;
@@ -901,12 +1198,16 @@
          DUP 5 ;
          INT ;
          EQ ;
+         DUP 7 ;
+         GET 7 ;
+         NOT ;
+         OR ;
          OR ;
          OR ;
          IF { DROP 4 ; PUSH nat 0 }
             { PUSH nat 10000 ;
               DIG 4 ;
-              GET 17 ;
+              GET 21 ;
               DUP 5 ;
               MUL ;
               EDIV ;

--- a/dex/compiled_contracts/pool_mod.tz
+++ b/dex/compiled_contracts/pool_mod.tz
@@ -228,7 +228,7 @@
                                                       DUP 5 ;
                                                       CAR ;
                                                       COMPARE ;
-                                                      NEQ ;
+                                                      LT ;
                                                       DUP 4 ;
                                                       CAR ;
                                                       DUP 6 ;

--- a/dex/compiled_contracts/pool_mod.tz
+++ b/dex/compiled_contracts/pool_mod.tz
@@ -2,32 +2,31 @@
     (or (unit %claimProtocolFeeToken)
         (or (unit %claimProtocolFeeXtz)
             (or (address %setProtocolFeeRecipient)
-                (or (nat %setProtocolFee)
-                    (or (nat %activateInternal)
-                        (or (pair %activate
-                               (mutez %expectedXtzPool)
-                               (pair (nat %expectedTokenPool) (nat %expectedLqtTotal)))
-                            (or (pair %tokenToToken
-                                   (address %outputDexterContract)
-                                   (pair (nat %minTokensBought)
-                                         (pair (address %to) (pair (nat %tokensSold) (timestamp %deadline)))))
-                                (or (nat %updateTokenPoolInternal)
-                                    (or (unit %updateTokenPool)
-                                        (or (address %setLqtAddress)
-                                            (or (address %setManager)
-                                                (or (pair %setBaker (option %baker key_hash) (bool %freezeBaker))
-                                                    (or (unit %default)
-                                                        (or (pair %tokenToXtz
-                                                               (address %to)
-                                                               (pair (nat %tokensSold) (pair (mutez %minXtzBought) (timestamp %deadline))))
-                                                            (or (pair %xtzToToken (address %to) (pair (nat %minTokensBought) (timestamp %deadline)))
-                                                                (or (pair %removeLiquidity
-                                                                       (address %to)
-                                                                       (pair (nat %lqtBurned)
-                                                                             (pair (mutez %minXtzWithdrawn) (pair (nat %minTokensWithdrawn) (timestamp %deadline)))))
-                                                                    (pair %addLiquidity
-                                                                       (address %owner)
-                                                                       (pair (nat %minLqtMinted) (pair (nat %maxTokensDeposited) (timestamp %deadline)))))))))))))))))))) ;
+                (or (nat %activateInternal)
+                    (or (pair %activate
+                           (mutez %expectedXtzPool)
+                           (pair (nat %expectedTokenPool) (nat %expectedLqtTotal)))
+                        (or (pair %tokenToToken
+                               (address %outputDexterContract)
+                               (pair (nat %minTokensBought)
+                                     (pair (address %to) (pair (nat %tokensSold) (timestamp %deadline)))))
+                            (or (nat %updateTokenPoolInternal)
+                                (or (unit %updateTokenPool)
+                                    (or (address %setLqtAddress)
+                                        (or (address %setManager)
+                                            (or (pair %setBaker (option %baker key_hash) (bool %freezeBaker))
+                                                (or (unit %default)
+                                                    (or (pair %tokenToXtz
+                                                           (address %to)
+                                                           (pair (nat %tokensSold) (pair (mutez %minXtzBought) (timestamp %deadline))))
+                                                        (or (pair %xtzToToken (address %to) (pair (nat %minTokensBought) (timestamp %deadline)))
+                                                            (or (pair %removeLiquidity
+                                                                   (address %to)
+                                                                   (pair (nat %lqtBurned)
+                                                                         (pair (mutez %minXtzWithdrawn) (pair (nat %minTokensWithdrawn) (timestamp %deadline)))))
+                                                                (pair %addLiquidity
+                                                                   (address %owner)
+                                                                   (pair (nat %minLqtMinted) (pair (nat %maxTokensDeposited) (timestamp %deadline))))))))))))))))))) ;
   storage
     (pair (nat %tokenPool)
           (pair (mutez %xtzPool)
@@ -39,9 +38,8 @@
                                               (pair (address %manager)
                                                     (pair (address %tokenAddress)
                                                           (pair (address %lqtAddress)
-                                                                (pair (nat %protocol_fee_bp)
-                                                                      (pair (address %protocol_fee_recipient)
-                                                                            (pair (mutez %accumulated_protocol_fee_xtz) (nat %accumulated_protocol_fee_token)))))))))))))) ;
+                                                                (pair (address %protocol_fee_recipient)
+                                                                      (pair (mutez %accumulated_protocol_fee_xtz) (nat %accumulated_protocol_fee_token))))))))))))) ;
   code { UNPAIR ;
          IF_LEFT
            { DROP ;
@@ -54,24 +52,24 @@
                   GT ;
                   IF { PUSH nat 10 ; FAILWITH }
                      { DUP ;
-                       GET 23 ;
+                       GET 21 ;
                        SENDER ;
                        COMPARE ;
                        NEQ ;
                        IF { PUSH nat 39 ; FAILWITH }
                           { PUSH nat 0 ;
                             DUP 2 ;
-                            GET 26 ;
+                            GET 24 ;
                             COMPARE ;
                             EQ ;
                             IF { PUSH nat 40 ; FAILWITH }
                                { DUP ;
                                  PUSH nat 0 ;
-                                 UPDATE 26 ;
+                                 UPDATE 24 ;
                                  SWAP ;
-                                 GET 26 ;
+                                 GET 24 ;
                                  DUP 2 ;
-                                 GET 23 ;
+                                 GET 21 ;
                                  SELF_ADDRESS ;
                                  DUP 4 ;
                                  GET 17 ;
@@ -100,26 +98,26 @@
                       GT ;
                       IF { PUSH nat 10 ; FAILWITH }
                          { DUP ;
-                           GET 23 ;
+                           GET 21 ;
                            SENDER ;
                            COMPARE ;
                            NEQ ;
                            IF { PUSH nat 39 ; FAILWITH }
                               { PUSH mutez 0 ;
                                 DUP 2 ;
-                                GET 25 ;
+                                GET 23 ;
                                 COMPARE ;
                                 EQ ;
                                 IF { PUSH nat 40 ; FAILWITH }
                                    { DUP ;
                                      PUSH mutez 0 ;
-                                     UPDATE 25 ;
+                                     UPDATE 23 ;
                                      DUP ;
-                                     GET 23 ;
+                                     GET 21 ;
                                      CONTRACT unit ;
                                      IF_NONE { PUSH nat 9 ; FAILWITH } {} ;
                                      DIG 2 ;
-                                     GET 25 ;
+                                     GET 23 ;
                                      UNIT ;
                                      TRANSFER_TOKENS ;
                                      SWAP ;
@@ -141,365 +139,365 @@
                                SENDER ;
                                COMPARE ;
                                NEQ ;
-                               IF { PUSH nat 41 ; FAILWITH } { UPDATE 23 ; NIL operation ; PAIR } } } }
+                               IF { PUSH nat 41 ; FAILWITH } { UPDATE 21 ; NIL operation ; PAIR } } } }
                    { IF_LEFT
                        { DUP 2 ;
-                         GET 11 ;
-                         IF { PUSH nat 2 ; FAILWITH }
+                         GET 19 ;
+                         SENDER ;
+                         COMPARE ;
+                         NEQ ;
+                         DUP 3 ;
+                         GET 9 ;
+                         NOT ;
+                         OR ;
+                         IF { PUSH nat 49 ; FAILWITH }
                             { PUSH mutez 0 ;
                               AMOUNT ;
                               COMPARE ;
                               GT ;
                               IF { PUSH nat 10 ; FAILWITH }
                                  { DUP 2 ;
-                                   GET 15 ;
-                                   SENDER ;
+                                   GET 5 ;
                                    COMPARE ;
                                    NEQ ;
-                                   IF { PUSH nat 37 ; FAILWITH }
-                                      { PUSH nat 1000 ;
+                                   IF { PUSH nat 50 ; FAILWITH }
+                                      { PUSH nat 0 ;
                                         DUP 2 ;
+                                        GET 5 ;
                                         COMPARE ;
-                                        GT ;
-                                        IF { PUSH nat 38 ; FAILWITH } { UPDATE 21 ; NIL operation ; PAIR } } } } }
+                                        EQ ;
+                                        PUSH nat 0 ;
+                                        DUP 3 ;
+                                        CAR ;
+                                        COMPARE ;
+                                        EQ ;
+                                        PUSH mutez 0 ;
+                                        DUP 4 ;
+                                        GET 3 ;
+                                        COMPARE ;
+                                        EQ ;
+                                        OR ;
+                                        OR ;
+                                        IF { PUSH nat 47 ; FAILWITH }
+                                           { PUSH bool True ;
+                                             UPDATE 7 ;
+                                             PUSH bool False ;
+                                             UPDATE 9 ;
+                                             NIL operation ;
+                                             PAIR } } } } }
                        { IF_LEFT
                            { DUP 2 ;
-                             GET 19 ;
-                             SENDER ;
-                             COMPARE ;
-                             NEQ ;
-                             DUP 3 ;
-                             GET 9 ;
-                             NOT ;
-                             OR ;
-                             IF { PUSH nat 49 ; FAILWITH }
+                             GET 11 ;
+                             IF { PUSH nat 2 ; FAILWITH }
                                 { PUSH mutez 0 ;
                                   AMOUNT ;
                                   COMPARE ;
                                   GT ;
                                   IF { PUSH nat 10 ; FAILWITH }
                                      { DUP 2 ;
-                                       GET 5 ;
+                                       GET 15 ;
+                                       SENDER ;
                                        COMPARE ;
                                        NEQ ;
-                                       IF { PUSH nat 50 ; FAILWITH }
-                                          { PUSH nat 0 ;
-                                            DUP 2 ;
-                                            GET 5 ;
-                                            COMPARE ;
-                                            EQ ;
-                                            PUSH nat 0 ;
+                                       IF { PUSH nat 45 ; FAILWITH }
+                                          { DUP 2 ;
+                                            GET 9 ;
                                             DUP 3 ;
-                                            CAR ;
-                                            COMPARE ;
-                                            EQ ;
-                                            PUSH mutez 0 ;
-                                            DUP 4 ;
-                                            GET 3 ;
-                                            COMPARE ;
-                                            EQ ;
+                                            GET 7 ;
                                             OR ;
-                                            OR ;
-                                            IF { PUSH nat 47 ; FAILWITH }
-                                               { PUSH bool True ;
-                                                 UPDATE 7 ;
-                                                 PUSH bool False ;
-                                                 UPDATE 9 ;
-                                                 NIL operation ;
-                                                 PAIR } } } } }
+                                            IF { PUSH nat 44 ; FAILWITH }
+                                               { PUSH address "tz1Ke2h7sDdakHJQh8WX4Z372du1KChsksyU" ;
+                                                 DUP 3 ;
+                                                 GET 19 ;
+                                                 COMPARE ;
+                                                 EQ ;
+                                                 IF { PUSH nat 46 ; FAILWITH }
+                                                    { DUP ;
+                                                      CAR ;
+                                                      BALANCE ;
+                                                      COMPARE ;
+                                                      NEQ ;
+                                                      DUP 2 ;
+                                                      GET 4 ;
+                                                      DUP 4 ;
+                                                      GET 5 ;
+                                                      COMPARE ;
+                                                      NEQ ;
+                                                      DUP 3 ;
+                                                      GET 3 ;
+                                                      DUP 5 ;
+                                                      CAR ;
+                                                      COMPARE ;
+                                                      NEQ ;
+                                                      DUP 4 ;
+                                                      CAR ;
+                                                      DUP 6 ;
+                                                      GET 3 ;
+                                                      COMPARE ;
+                                                      NEQ ;
+                                                      PUSH nat 0 ;
+                                                      DUP 6 ;
+                                                      GET 4 ;
+                                                      COMPARE ;
+                                                      EQ ;
+                                                      PUSH nat 0 ;
+                                                      DUP 7 ;
+                                                      GET 3 ;
+                                                      COMPARE ;
+                                                      EQ ;
+                                                      PUSH mutez 0 ;
+                                                      DIG 7 ;
+                                                      CAR ;
+                                                      COMPARE ;
+                                                      EQ ;
+                                                      OR ;
+                                                      OR ;
+                                                      OR ;
+                                                      OR ;
+                                                      OR ;
+                                                      OR ;
+                                                      IF { PUSH nat 47 ; FAILWITH }
+                                                         { SELF_ADDRESS ;
+                                                           CONTRACT %activateInternal nat ;
+                                                           IF_NONE
+                                                             { PUSH string "Cannot get activateInternal entrypoint" ; FAILWITH }
+                                                             {} ;
+                                                           DUP 2 ;
+                                                           GET 19 ;
+                                                           CONTRACT %getTotalSupply (pair (unit %request) (contract %callback nat)) ;
+                                                           IF_NONE { PUSH nat 48 ; FAILWITH } {} ;
+                                                           PUSH mutez 0 ;
+                                                           DIG 2 ;
+                                                           UNIT ;
+                                                           PAIR ;
+                                                           TRANSFER_TOKENS ;
+                                                           SWAP ;
+                                                           PUSH bool True ;
+                                                           UPDATE 9 ;
+                                                           NIL operation ;
+                                                           DIG 2 ;
+                                                           CONS ;
+                                                           PAIR } } } } } } }
                            { IF_LEFT
-                               { DUP 2 ;
+                               { UNPAIR 5 ;
+                                 CONTRACT %xtzToToken
+                                   (pair (address %to) (pair (nat %minTokensBought) (timestamp %deadline))) ;
+                                 IF_NONE { PUSH nat 31 ; FAILWITH } {} ;
+                                 DUP 6 ;
                                  GET 11 ;
                                  IF { PUSH nat 2 ; FAILWITH }
-                                    { PUSH mutez 0 ;
-                                      AMOUNT ;
+                                    { PUSH nat 0 ;
+                                      DUP 7 ;
+                                      GET 5 ;
                                       COMPARE ;
                                       GT ;
-                                      IF { PUSH nat 10 ; FAILWITH }
-                                         { DUP 2 ;
-                                           GET 15 ;
-                                           SENDER ;
+                                      PUSH nat 0 ;
+                                      DUP 8 ;
+                                      CAR ;
+                                      COMPARE ;
+                                      GT ;
+                                      PUSH mutez 0 ;
+                                      DUP 9 ;
+                                      GET 3 ;
+                                      COMPARE ;
+                                      GT ;
+                                      DUP 9 ;
+                                      GET 7 ;
+                                      AND ;
+                                      AND ;
+                                      AND ;
+                                      IF { PUSH mutez 0 ;
+                                           AMOUNT ;
                                            COMPARE ;
-                                           NEQ ;
-                                           IF { PUSH nat 45 ; FAILWITH }
-                                              { DUP 2 ;
-                                                GET 9 ;
-                                                DUP 3 ;
-                                                GET 7 ;
-                                                OR ;
-                                                IF { PUSH nat 44 ; FAILWITH }
-                                                   { PUSH address "tz1Ke2h7sDdakHJQh8WX4Z372du1KChsksyU" ;
-                                                     DUP 3 ;
-                                                     GET 19 ;
-                                                     COMPARE ;
-                                                     EQ ;
-                                                     IF { PUSH nat 46 ; FAILWITH }
-                                                        { DUP ;
-                                                          CAR ;
-                                                          BALANCE ;
-                                                          COMPARE ;
-                                                          NEQ ;
-                                                          DUP 2 ;
-                                                          GET 4 ;
-                                                          DUP 4 ;
-                                                          GET 5 ;
-                                                          COMPARE ;
-                                                          NEQ ;
-                                                          DUP 3 ;
-                                                          GET 3 ;
-                                                          DUP 5 ;
-                                                          CAR ;
-                                                          COMPARE ;
-                                                          NEQ ;
-                                                          DUP 4 ;
-                                                          CAR ;
-                                                          DUP 6 ;
-                                                          GET 3 ;
-                                                          COMPARE ;
-                                                          NEQ ;
-                                                          PUSH nat 0 ;
-                                                          DUP 6 ;
-                                                          GET 4 ;
-                                                          COMPARE ;
-                                                          EQ ;
-                                                          PUSH nat 0 ;
-                                                          DUP 7 ;
-                                                          GET 3 ;
-                                                          COMPARE ;
-                                                          EQ ;
-                                                          PUSH mutez 0 ;
-                                                          DIG 7 ;
-                                                          CAR ;
-                                                          COMPARE ;
-                                                          EQ ;
-                                                          OR ;
-                                                          OR ;
-                                                          OR ;
-                                                          OR ;
-                                                          OR ;
-                                                          OR ;
-                                                          IF { PUSH nat 47 ; FAILWITH }
-                                                             { SELF_ADDRESS ;
-                                                               CONTRACT %activateInternal nat ;
-                                                               IF_NONE
-                                                                 { PUSH string "Cannot get activateInternal entrypoint" ; FAILWITH }
-                                                                 {} ;
-                                                               DUP 2 ;
-                                                               GET 19 ;
-                                                               CONTRACT %getTotalSupply (pair (unit %request) (contract %callback nat)) ;
-                                                               IF_NONE { PUSH nat 48 ; FAILWITH } {} ;
-                                                               PUSH mutez 0 ;
-                                                               DIG 2 ;
-                                                               UNIT ;
-                                                               PAIR ;
-                                                               TRANSFER_TOKENS ;
-                                                               SWAP ;
-                                                               PUSH bool True ;
-                                                               UPDATE 9 ;
-                                                               NIL operation ;
-                                                               DIG 2 ;
-                                                               CONS ;
-                                                               PAIR } } } } } } }
+                                           GT ;
+                                           IF { PUSH nat 10 ; FAILWITH }
+                                              { DUP 5 ;
+                                                NOW ;
+                                                COMPARE ;
+                                                GE ;
+                                                IF { PUSH nat 3 ; FAILWITH }
+                                                   { PUSH nat 10000 ;
+                                                     PUSH nat 5 ;
+                                                     DUP 6 ;
+                                                     MUL ;
+                                                     EDIV ;
+                                                     IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                     DUP ;
+                                                     DUP 6 ;
+                                                     SUB ;
+                                                     ISNAT ;
+                                                     IF_NONE { PUSH nat 34 ; FAILWITH } {} ;
+                                                     PUSH nat 997 ;
+                                                     DUP 7 ;
+                                                     MUL ;
+                                                     PUSH nat 1000 ;
+                                                     DUP 10 ;
+                                                     CAR ;
+                                                     MUL ;
+                                                     ADD ;
+                                                     PUSH mutez 1 ;
+                                                     DUP 10 ;
+                                                     GET 3 ;
+                                                     EDIV ;
+                                                     IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                     PUSH nat 997 ;
+                                                     DUP 9 ;
+                                                     MUL ;
+                                                     MUL ;
+                                                     EDIV ;
+                                                     IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                     PUSH mutez 1 ;
+                                                     DUP 10 ;
+                                                     GET 3 ;
+                                                     EDIV ;
+                                                     IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                     DUP 2 ;
+                                                     SWAP ;
+                                                     SUB ;
+                                                     ISNAT ;
+                                                     IF_NONE { PUSH nat 36 ; FAILWITH } {} ;
+                                                     PUSH mutez 1 ;
+                                                     SWAP ;
+                                                     MUL ;
+                                                     PUSH mutez 1 ;
+                                                     DIG 2 ;
+                                                     MUL ;
+                                                     DUP 10 ;
+                                                     DIG 3 ;
+                                                     DUP 11 ;
+                                                     CAR ;
+                                                     ADD ;
+                                                     UPDATE 1 ;
+                                                     DIG 2 ;
+                                                     UPDATE 3 ;
+                                                     DIG 2 ;
+                                                     DIG 8 ;
+                                                     GET 24 ;
+                                                     ADD ;
+                                                     UPDATE 24 ;
+                                                     DIG 5 ;
+                                                     SELF_ADDRESS ;
+                                                     SENDER ;
+                                                     DUP 4 ;
+                                                     GET 17 ;
+                                                     CONTRACT %transfer (pair address (pair address nat)) ;
+                                                     IF_NONE { PUSH nat 0 ; FAILWITH } {} ;
+                                                     PUSH mutez 0 ;
+                                                     DIG 4 ;
+                                                     DIG 4 ;
+                                                     PAIR ;
+                                                     DIG 3 ;
+                                                     PAIR ;
+                                                     TRANSFER_TOKENS ;
+                                                     DIG 3 ;
+                                                     DIG 3 ;
+                                                     DIG 6 ;
+                                                     DIG 5 ;
+                                                     DIG 6 ;
+                                                     PAIR 3 ;
+                                                     TRANSFER_TOKENS ;
+                                                     DIG 2 ;
+                                                     NIL operation ;
+                                                     DIG 2 ;
+                                                     CONS ;
+                                                     DIG 2 ;
+                                                     CONS ;
+                                                     PAIR } } }
+                                         { PUSH nat 43 ; FAILWITH } } }
                                { IF_LEFT
-                                   { UNPAIR 5 ;
-                                     CONTRACT %xtzToToken
-                                       (pair (address %to) (pair (nat %minTokensBought) (timestamp %deadline))) ;
-                                     IF_NONE { PUSH nat 31 ; FAILWITH } {} ;
-                                     DUP 6 ;
+                                   { DUP 2 ;
+                                     GET 17 ;
+                                     SENDER ;
+                                     COMPARE ;
+                                     NEQ ;
+                                     DUP 3 ;
                                      GET 11 ;
-                                     IF { PUSH nat 2 ; FAILWITH }
-                                        { PUSH nat 0 ;
-                                          DUP 7 ;
-                                          GET 5 ;
+                                     NOT ;
+                                     OR ;
+                                     IF { PUSH nat 29 ; FAILWITH }
+                                        { PUSH mutez 0 ;
+                                          AMOUNT ;
                                           COMPARE ;
                                           GT ;
-                                          PUSH nat 0 ;
-                                          DUP 8 ;
-                                          CAR ;
-                                          COMPARE ;
-                                          GT ;
-                                          PUSH mutez 0 ;
-                                          DUP 9 ;
-                                          GET 3 ;
-                                          COMPARE ;
-                                          GT ;
-                                          DUP 9 ;
-                                          GET 7 ;
-                                          AND ;
-                                          AND ;
-                                          AND ;
-                                          IF { PUSH mutez 0 ;
-                                               AMOUNT ;
-                                               COMPARE ;
-                                               GT ;
-                                               IF { PUSH nat 10 ; FAILWITH }
-                                                  { DUP 5 ;
-                                                    NOW ;
-                                                    COMPARE ;
-                                                    GE ;
-                                                    IF { PUSH nat 3 ; FAILWITH }
-                                                       { PUSH nat 10000 ;
-                                                         DUP 7 ;
-                                                         GET 21 ;
-                                                         DUP 6 ;
-                                                         MUL ;
-                                                         EDIV ;
-                                                         IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                         DUP ;
-                                                         DUP 6 ;
-                                                         SUB ;
-                                                         ISNAT ;
-                                                         IF_NONE { PUSH nat 34 ; FAILWITH } {} ;
-                                                         PUSH nat 997 ;
-                                                         DUP 2 ;
-                                                         MUL ;
-                                                         PUSH nat 1000 ;
-                                                         DUP 10 ;
-                                                         CAR ;
-                                                         MUL ;
-                                                         ADD ;
-                                                         PUSH mutez 1 ;
-                                                         DUP 10 ;
-                                                         GET 3 ;
-                                                         EDIV ;
-                                                         IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                         PUSH nat 997 ;
-                                                         DUP 4 ;
-                                                         MUL ;
-                                                         MUL ;
-                                                         EDIV ;
-                                                         IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                         PUSH mutez 1 ;
-                                                         DUP 10 ;
-                                                         GET 3 ;
-                                                         EDIV ;
-                                                         IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                         DUP 2 ;
-                                                         SWAP ;
-                                                         SUB ;
-                                                         ISNAT ;
-                                                         IF_NONE { PUSH nat 36 ; FAILWITH } {} ;
-                                                         PUSH mutez 1 ;
-                                                         SWAP ;
-                                                         MUL ;
-                                                         PUSH mutez 1 ;
-                                                         DIG 2 ;
-                                                         MUL ;
-                                                         DUP 10 ;
-                                                         DIG 3 ;
-                                                         DUP 11 ;
-                                                         CAR ;
-                                                         ADD ;
-                                                         UPDATE 1 ;
-                                                         DIG 2 ;
-                                                         UPDATE 3 ;
-                                                         DIG 2 ;
-                                                         DIG 8 ;
-                                                         GET 26 ;
-                                                         ADD ;
-                                                         UPDATE 26 ;
-                                                         DIG 5 ;
-                                                         SELF_ADDRESS ;
-                                                         SENDER ;
-                                                         DUP 4 ;
-                                                         GET 17 ;
-                                                         CONTRACT %transfer (pair address (pair address nat)) ;
-                                                         IF_NONE { PUSH nat 0 ; FAILWITH } {} ;
-                                                         PUSH mutez 0 ;
-                                                         DIG 4 ;
-                                                         DIG 4 ;
-                                                         PAIR ;
-                                                         DIG 3 ;
-                                                         PAIR ;
-                                                         TRANSFER_TOKENS ;
-                                                         DIG 3 ;
-                                                         DIG 3 ;
-                                                         DIG 6 ;
-                                                         DIG 5 ;
-                                                         DIG 6 ;
-                                                         PAIR 3 ;
-                                                         TRANSFER_TOKENS ;
-                                                         DIG 2 ;
-                                                         NIL operation ;
-                                                         DIG 2 ;
-                                                         CONS ;
-                                                         DIG 2 ;
-                                                         CONS ;
-                                                         PAIR } } }
-                                             { PUSH nat 43 ; FAILWITH } } }
+                                          IF { PUSH nat 10 ; FAILWITH }
+                                             { DUP 2 ;
+                                               GET 24 ;
+                                               SWAP ;
+                                               SUB ;
+                                               ISNAT ;
+                                               IF_NONE { PUSH nat 42 ; FAILWITH } {} ;
+                                               UPDATE 1 ;
+                                               PUSH bool False ;
+                                               UPDATE 11 ;
+                                               NIL operation ;
+                                               PAIR } } }
                                    { IF_LEFT
-                                       { DUP 2 ;
-                                         GET 17 ;
+                                       { DROP ;
+                                         SOURCE ;
                                          SENDER ;
                                          COMPARE ;
                                          NEQ ;
-                                         DUP 3 ;
-                                         GET 11 ;
-                                         NOT ;
-                                         OR ;
-                                         IF { PUSH nat 29 ; FAILWITH }
+                                         IF { PUSH nat 25 ; FAILWITH }
                                             { PUSH mutez 0 ;
                                               AMOUNT ;
                                               COMPARE ;
                                               GT ;
                                               IF { PUSH nat 10 ; FAILWITH }
-                                                 { DUP 2 ;
-                                                   GET 26 ;
-                                                   SWAP ;
-                                                   SUB ;
-                                                   ISNAT ;
-                                                   IF_NONE { PUSH nat 42 ; FAILWITH } {} ;
-                                                   UPDATE 1 ;
-                                                   PUSH bool False ;
-                                                   UPDATE 11 ;
-                                                   NIL operation ;
-                                                   PAIR } } }
+                                                 { DUP ;
+                                                   GET 11 ;
+                                                   IF { PUSH nat 33 ; FAILWITH }
+                                                      { DUP ;
+                                                        GET 15 ;
+                                                        SENDER ;
+                                                        COMPARE ;
+                                                        NEQ ;
+                                                        DUP 2 ;
+                                                        GET 7 ;
+                                                        NOT ;
+                                                        AND ;
+                                                        IF { PUSH nat 45 ; FAILWITH }
+                                                           { SELF_ADDRESS ;
+                                                             CONTRACT %updateTokenPoolInternal nat ;
+                                                             IF_NONE
+                                                               { PUSH string "Cannot get updateTokenPoolInternal entrypoint" ; FAILWITH }
+                                                               {} ;
+                                                             DUP 2 ;
+                                                             GET 17 ;
+                                                             CONTRACT %getBalance (pair address (contract nat)) ;
+                                                             IF_NONE { PUSH nat 28 ; FAILWITH } {} ;
+                                                             PUSH mutez 0 ;
+                                                             DIG 2 ;
+                                                             SELF_ADDRESS ;
+                                                             PAIR ;
+                                                             TRANSFER_TOKENS ;
+                                                             SWAP ;
+                                                             PUSH bool True ;
+                                                             UPDATE 11 ;
+                                                             NIL operation ;
+                                                             DIG 2 ;
+                                                             CONS ;
+                                                             PAIR } } } } }
                                        { IF_LEFT
-                                           { DROP ;
-                                             SOURCE ;
-                                             SENDER ;
-                                             COMPARE ;
-                                             NEQ ;
-                                             IF { PUSH nat 25 ; FAILWITH }
+                                           { DUP 2 ;
+                                             GET 11 ;
+                                             IF { PUSH nat 2 ; FAILWITH }
                                                 { PUSH mutez 0 ;
                                                   AMOUNT ;
                                                   COMPARE ;
                                                   GT ;
                                                   IF { PUSH nat 10 ; FAILWITH }
-                                                     { DUP ;
-                                                       GET 11 ;
-                                                       IF { PUSH nat 33 ; FAILWITH }
-                                                          { DUP ;
-                                                            GET 15 ;
-                                                            SENDER ;
+                                                     { DUP 2 ;
+                                                       GET 15 ;
+                                                       SENDER ;
+                                                       COMPARE ;
+                                                       NEQ ;
+                                                       IF { PUSH nat 23 ; FAILWITH }
+                                                          { PUSH address "tz1Ke2h7sDdakHJQh8WX4Z372du1KChsksyU" ;
+                                                            DUP 3 ;
+                                                            GET 19 ;
                                                             COMPARE ;
                                                             NEQ ;
-                                                            DUP 2 ;
-                                                            GET 7 ;
-                                                            NOT ;
-                                                            AND ;
-                                                            IF { PUSH nat 45 ; FAILWITH }
-                                                               { SELF_ADDRESS ;
-                                                                 CONTRACT %updateTokenPoolInternal nat ;
-                                                                 IF_NONE
-                                                                   { PUSH string "Cannot get updateTokenPoolInternal entrypoint" ; FAILWITH }
-                                                                   {} ;
-                                                                 DUP 2 ;
-                                                                 GET 17 ;
-                                                                 CONTRACT %getBalance (pair address (contract nat)) ;
-                                                                 IF_NONE { PUSH nat 28 ; FAILWITH } {} ;
-                                                                 PUSH mutez 0 ;
-                                                                 DIG 2 ;
-                                                                 SELF_ADDRESS ;
-                                                                 PAIR ;
-                                                                 TRANSFER_TOKENS ;
-                                                                 SWAP ;
-                                                                 PUSH bool True ;
-                                                                 UPDATE 11 ;
-                                                                 NIL operation ;
-                                                                 DIG 2 ;
-                                                                 CONS ;
-                                                                 PAIR } } } } }
+                                                            IF { PUSH nat 24 ; FAILWITH } { UPDATE 19 ; NIL operation ; PAIR } } } } }
                                            { IF_LEFT
                                                { DUP 2 ;
                                                  GET 11 ;
@@ -514,15 +512,10 @@
                                                            SENDER ;
                                                            COMPARE ;
                                                            NEQ ;
-                                                           IF { PUSH nat 23 ; FAILWITH }
-                                                              { PUSH address "tz1Ke2h7sDdakHJQh8WX4Z372du1KChsksyU" ;
-                                                                DUP 3 ;
-                                                                GET 19 ;
-                                                                COMPARE ;
-                                                                NEQ ;
-                                                                IF { PUSH nat 24 ; FAILWITH } { UPDATE 19 ; NIL operation ; PAIR } } } } }
+                                                           IF { PUSH nat 21 ; FAILWITH } { UPDATE 15 ; NIL operation ; PAIR } } } }
                                                { IF_LEFT
-                                                   { DUP 2 ;
+                                                   { UNPAIR ;
+                                                     DUP 3 ;
                                                      GET 11 ;
                                                      IF { PUSH nat 2 ; FAILWITH }
                                                         { PUSH mutez 0 ;
@@ -530,210 +523,451 @@
                                                           COMPARE ;
                                                           GT ;
                                                           IF { PUSH nat 10 ; FAILWITH }
-                                                             { DUP 2 ;
+                                                             { DUP 3 ;
                                                                GET 15 ;
                                                                SENDER ;
                                                                COMPARE ;
                                                                NEQ ;
-                                                               IF { PUSH nat 21 ; FAILWITH } { UPDATE 15 ; NIL operation ; PAIR } } } }
+                                                               IF { PUSH nat 20 ; FAILWITH }
+                                                                  { DUP 3 ;
+                                                                    GET 13 ;
+                                                                    IF { PUSH nat 22 ; FAILWITH }
+                                                                       { DUG 2 ; UPDATE 13 ; NIL operation ; DIG 2 ; SET_DELEGATE ; CONS ; PAIR } } } } }
                                                    { IF_LEFT
-                                                       { UNPAIR ;
-                                                         DUP 3 ;
+                                                       { DROP ;
+                                                         DUP ;
                                                          GET 11 ;
                                                          IF { PUSH nat 2 ; FAILWITH }
-                                                            { PUSH mutez 0 ;
-                                                              AMOUNT ;
+                                                            { DUP ;
+                                                              GET 15 ;
+                                                              SENDER ;
                                                               COMPARE ;
-                                                              GT ;
-                                                              IF { PUSH nat 10 ; FAILWITH }
-                                                                 { DUP 3 ;
-                                                                   GET 15 ;
-                                                                   SENDER ;
-                                                                   COMPARE ;
-                                                                   NEQ ;
-                                                                   IF { PUSH nat 20 ; FAILWITH }
-                                                                      { DUP 3 ;
-                                                                        GET 13 ;
-                                                                        IF { PUSH nat 22 ; FAILWITH }
-                                                                           { DUG 2 ; UPDATE 13 ; NIL operation ; DIG 2 ; SET_DELEGATE ; CONS ; PAIR } } } } }
+                                                              NEQ ;
+                                                              DUP 2 ;
+                                                              GET 7 ;
+                                                              NOT ;
+                                                              AND ;
+                                                              IF { PUSH nat 45 ; FAILWITH }
+                                                                 { DUP ; AMOUNT ; DIG 2 ; GET 3 ; ADD ; UPDATE 3 ; NIL operation ; PAIR } } }
                                                        { IF_LEFT
-                                                           { DROP ;
-                                                             DUP ;
+                                                           { UNPAIR 4 ;
+                                                             DUP 5 ;
                                                              GET 11 ;
                                                              IF { PUSH nat 2 ; FAILWITH }
-                                                                { DUP ;
-                                                                  GET 15 ;
-                                                                  SENDER ;
+                                                                { PUSH nat 0 ;
+                                                                  DUP 6 ;
+                                                                  GET 5 ;
                                                                   COMPARE ;
-                                                                  NEQ ;
-                                                                  DUP 2 ;
+                                                                  GT ;
+                                                                  PUSH nat 0 ;
+                                                                  DUP 7 ;
+                                                                  CAR ;
+                                                                  COMPARE ;
+                                                                  GT ;
+                                                                  PUSH mutez 0 ;
+                                                                  DUP 8 ;
+                                                                  GET 3 ;
+                                                                  COMPARE ;
+                                                                  GT ;
+                                                                  DUP 8 ;
                                                                   GET 7 ;
-                                                                  NOT ;
                                                                   AND ;
-                                                                  IF { PUSH nat 45 ; FAILWITH }
-                                                                     { DUP ; AMOUNT ; DIG 2 ; GET 3 ; ADD ; UPDATE 3 ; NIL operation ; PAIR } } }
+                                                                  AND ;
+                                                                  AND ;
+                                                                  IF { DIG 3 ;
+                                                                       NOW ;
+                                                                       COMPARE ;
+                                                                       GE ;
+                                                                       IF { PUSH nat 3 ; FAILWITH }
+                                                                          { PUSH mutez 0 ;
+                                                                            AMOUNT ;
+                                                                            COMPARE ;
+                                                                            GT ;
+                                                                            IF { PUSH nat 10 ; FAILWITH }
+                                                                               { PUSH nat 10000 ;
+                                                                                 PUSH nat 5 ;
+                                                                                 DUP 4 ;
+                                                                                 MUL ;
+                                                                                 EDIV ;
+                                                                                 IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                 DUP ;
+                                                                                 DUP 4 ;
+                                                                                 SUB ;
+                                                                                 ISNAT ;
+                                                                                 IF_NONE { PUSH nat 34 ; FAILWITH } {} ;
+                                                                                 PUSH nat 997 ;
+                                                                                 DUP 5 ;
+                                                                                 MUL ;
+                                                                                 PUSH nat 1000 ;
+                                                                                 DUP 8 ;
+                                                                                 CAR ;
+                                                                                 MUL ;
+                                                                                 ADD ;
+                                                                                 PUSH mutez 1 ;
+                                                                                 DUP 8 ;
+                                                                                 GET 3 ;
+                                                                                 EDIV ;
+                                                                                 IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                 PUSH nat 997 ;
+                                                                                 DUP 7 ;
+                                                                                 MUL ;
+                                                                                 MUL ;
+                                                                                 EDIV ;
+                                                                                 IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                 PUSH mutez 1 ;
+                                                                                 SWAP ;
+                                                                                 MUL ;
+                                                                                 DIG 5 ;
+                                                                                 DUP 2 ;
+                                                                                 COMPARE ;
+                                                                                 LT ;
+                                                                                 IF { PUSH nat 8 ; FAILWITH } {} ;
+                                                                                 PUSH mutez 1 ;
+                                                                                 DUP 7 ;
+                                                                                 GET 3 ;
+                                                                                 EDIV ;
+                                                                                 IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                 PUSH mutez 1 ;
+                                                                                 DUP 3 ;
+                                                                                 EDIV ;
+                                                                                 IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                 SWAP ;
+                                                                                 SUB ;
+                                                                                 ISNAT ;
+                                                                                 IF_NONE { PUSH nat 36 ; FAILWITH } {} ;
+                                                                                 PUSH mutez 1 ;
+                                                                                 SWAP ;
+                                                                                 MUL ;
+                                                                                 DIG 5 ;
+                                                                                 SELF_ADDRESS ;
+                                                                                 SENDER ;
+                                                                                 DUP 9 ;
+                                                                                 GET 17 ;
+                                                                                 CONTRACT %transfer (pair address (pair address nat)) ;
+                                                                                 IF_NONE { PUSH nat 0 ; FAILWITH } {} ;
+                                                                                 PUSH mutez 0 ;
+                                                                                 DIG 4 ;
+                                                                                 DIG 4 ;
+                                                                                 PAIR ;
+                                                                                 DIG 3 ;
+                                                                                 PAIR ;
+                                                                                 TRANSFER_TOKENS ;
+                                                                                 DIG 5 ;
+                                                                                 CONTRACT unit ;
+                                                                                 IF_NONE { PUSH nat 9 ; FAILWITH } {} ;
+                                                                                 DIG 3 ;
+                                                                                 UNIT ;
+                                                                                 TRANSFER_TOKENS ;
+                                                                                 DUP 6 ;
+                                                                                 DIG 4 ;
+                                                                                 DUP 7 ;
+                                                                                 CAR ;
+                                                                                 ADD ;
+                                                                                 UPDATE 1 ;
+                                                                                 DIG 3 ;
+                                                                                 UPDATE 3 ;
+                                                                                 DIG 3 ;
+                                                                                 DIG 4 ;
+                                                                                 GET 24 ;
+                                                                                 ADD ;
+                                                                                 UPDATE 24 ;
+                                                                                 NIL operation ;
+                                                                                 DIG 2 ;
+                                                                                 CONS ;
+                                                                                 DIG 2 ;
+                                                                                 CONS ;
+                                                                                 PAIR } } }
+                                                                     { PUSH nat 43 ; FAILWITH } } }
                                                            { IF_LEFT
-                                                               { UNPAIR 4 ;
-                                                                 DUP 5 ;
+                                                               { UNPAIR 3 ;
+                                                                 DUP 4 ;
                                                                  GET 11 ;
                                                                  IF { PUSH nat 2 ; FAILWITH }
                                                                     { PUSH nat 0 ;
-                                                                      DUP 6 ;
+                                                                      DUP 5 ;
                                                                       GET 5 ;
                                                                       COMPARE ;
                                                                       GT ;
                                                                       PUSH nat 0 ;
-                                                                      DUP 7 ;
+                                                                      DUP 6 ;
                                                                       CAR ;
                                                                       COMPARE ;
                                                                       GT ;
                                                                       PUSH mutez 0 ;
-                                                                      DUP 8 ;
+                                                                      DUP 7 ;
                                                                       GET 3 ;
                                                                       COMPARE ;
                                                                       GT ;
-                                                                      DUP 8 ;
+                                                                      DUP 7 ;
                                                                       GET 7 ;
                                                                       AND ;
                                                                       AND ;
                                                                       AND ;
-                                                                      IF { DIG 3 ;
+                                                                      IF { DIG 2 ;
                                                                            NOW ;
                                                                            COMPARE ;
                                                                            GE ;
                                                                            IF { PUSH nat 3 ; FAILWITH }
-                                                                              { PUSH mutez 0 ;
+                                                                              { PUSH mutez 1 ;
+                                                                                DUP 4 ;
+                                                                                GET 3 ;
+                                                                                EDIV ;
+                                                                                IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                PUSH mutez 1 ;
                                                                                 AMOUNT ;
+                                                                                EDIV ;
+                                                                                IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                PUSH nat 10000 ;
+                                                                                PUSH nat 5 ;
+                                                                                DUP 3 ;
+                                                                                MUL ;
+                                                                                EDIV ;
+                                                                                IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                DUP ;
+                                                                                DUP 3 ;
+                                                                                SUB ;
+                                                                                ISNAT ;
+                                                                                IF_NONE { PUSH nat 34 ; FAILWITH } {} ;
+                                                                                PUSH nat 997 ;
+                                                                                DUP 4 ;
+                                                                                MUL ;
+                                                                                PUSH nat 1000 ;
+                                                                                DIG 5 ;
+                                                                                MUL ;
+                                                                                ADD ;
+                                                                                DUP 7 ;
+                                                                                CAR ;
+                                                                                PUSH nat 997 ;
+                                                                                DIG 5 ;
+                                                                                MUL ;
+                                                                                MUL ;
+                                                                                EDIV ;
+                                                                                IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                DIG 4 ;
+                                                                                DUP 2 ;
                                                                                 COMPARE ;
-                                                                                GT ;
-                                                                                IF { PUSH nat 10 ; FAILWITH }
-                                                                                   { PUSH nat 10000 ;
-                                                                                     DUP 5 ;
-                                                                                     GET 21 ;
-                                                                                     DUP 4 ;
-                                                                                     MUL ;
-                                                                                     EDIV ;
-                                                                                     IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                                     DUP ;
-                                                                                     DUP 4 ;
-                                                                                     SUB ;
-                                                                                     ISNAT ;
-                                                                                     IF_NONE { PUSH nat 34 ; FAILWITH } {} ;
-                                                                                     PUSH nat 997 ;
-                                                                                     DUP 2 ;
-                                                                                     MUL ;
-                                                                                     PUSH nat 1000 ;
-                                                                                     DUP 8 ;
-                                                                                     CAR ;
-                                                                                     MUL ;
-                                                                                     ADD ;
-                                                                                     PUSH mutez 1 ;
-                                                                                     DUP 8 ;
-                                                                                     GET 3 ;
-                                                                                     EDIV ;
-                                                                                     IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                                     PUSH nat 997 ;
-                                                                                     DUP 4 ;
-                                                                                     MUL ;
-                                                                                     MUL ;
-                                                                                     EDIV ;
-                                                                                     IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                                     PUSH mutez 1 ;
-                                                                                     SWAP ;
-                                                                                     MUL ;
-                                                                                     DIG 5 ;
-                                                                                     DUP 2 ;
-                                                                                     COMPARE ;
-                                                                                     LT ;
-                                                                                     IF { PUSH nat 8 ; FAILWITH } {} ;
-                                                                                     PUSH mutez 1 ;
-                                                                                     DUP 7 ;
-                                                                                     GET 3 ;
-                                                                                     EDIV ;
-                                                                                     IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                                     PUSH mutez 1 ;
-                                                                                     DUP 3 ;
-                                                                                     EDIV ;
-                                                                                     IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                                     SWAP ;
-                                                                                     SUB ;
-                                                                                     ISNAT ;
-                                                                                     IF_NONE { PUSH nat 36 ; FAILWITH } {} ;
-                                                                                     PUSH mutez 1 ;
-                                                                                     SWAP ;
-                                                                                     MUL ;
-                                                                                     DIG 5 ;
-                                                                                     SELF_ADDRESS ;
-                                                                                     SENDER ;
-                                                                                     DUP 9 ;
-                                                                                     GET 17 ;
-                                                                                     CONTRACT %transfer (pair address (pair address nat)) ;
-                                                                                     IF_NONE { PUSH nat 0 ; FAILWITH } {} ;
-                                                                                     PUSH mutez 0 ;
-                                                                                     DIG 4 ;
-                                                                                     DIG 4 ;
-                                                                                     PAIR ;
-                                                                                     DIG 3 ;
-                                                                                     PAIR ;
-                                                                                     TRANSFER_TOKENS ;
-                                                                                     DIG 5 ;
-                                                                                     CONTRACT unit ;
-                                                                                     IF_NONE { PUSH nat 9 ; FAILWITH } {} ;
-                                                                                     DIG 3 ;
-                                                                                     UNIT ;
-                                                                                     TRANSFER_TOKENS ;
-                                                                                     DUP 6 ;
-                                                                                     DIG 4 ;
-                                                                                     DUP 7 ;
-                                                                                     CAR ;
-                                                                                     ADD ;
-                                                                                     UPDATE 1 ;
-                                                                                     DIG 3 ;
-                                                                                     UPDATE 3 ;
-                                                                                     DIG 3 ;
-                                                                                     DIG 4 ;
-                                                                                     GET 26 ;
-                                                                                     ADD ;
-                                                                                     UPDATE 26 ;
-                                                                                     NIL operation ;
-                                                                                     DIG 2 ;
-                                                                                     CONS ;
-                                                                                     DIG 2 ;
-                                                                                     CONS ;
-                                                                                     PAIR } } }
+                                                                                LT ;
+                                                                                IF { PUSH nat 18 ; FAILWITH } {} ;
+                                                                                DUP ;
+                                                                                DUP 6 ;
+                                                                                CAR ;
+                                                                                SUB ;
+                                                                                ISNAT ;
+                                                                                IF_NONE { PUSH nat 19 ; FAILWITH } {} ;
+                                                                                PUSH mutez 1 ;
+                                                                                DIG 4 ;
+                                                                                MUL ;
+                                                                                PUSH mutez 1 ;
+                                                                                DIG 4 ;
+                                                                                MUL ;
+                                                                                DUP 6 ;
+                                                                                SWAP ;
+                                                                                DUP 7 ;
+                                                                                GET 3 ;
+                                                                                ADD ;
+                                                                                UPDATE 3 ;
+                                                                                DIG 2 ;
+                                                                                UPDATE 1 ;
+                                                                                SWAP ;
+                                                                                DIG 4 ;
+                                                                                GET 23 ;
+                                                                                ADD ;
+                                                                                UPDATE 23 ;
+                                                                                SWAP ;
+                                                                                DIG 2 ;
+                                                                                SELF_ADDRESS ;
+                                                                                DUP 4 ;
+                                                                                GET 17 ;
+                                                                                CONTRACT %transfer (pair address (pair address nat)) ;
+                                                                                IF_NONE { PUSH nat 0 ; FAILWITH } {} ;
+                                                                                PUSH mutez 0 ;
+                                                                                DIG 4 ;
+                                                                                DIG 4 ;
+                                                                                PAIR ;
+                                                                                DIG 3 ;
+                                                                                PAIR ;
+                                                                                TRANSFER_TOKENS ;
+                                                                                SWAP ;
+                                                                                NIL operation ;
+                                                                                DIG 2 ;
+                                                                                CONS ;
+                                                                                PAIR } }
                                                                          { PUSH nat 43 ; FAILWITH } } }
                                                                { IF_LEFT
-                                                                   { UNPAIR 3 ;
-                                                                     DUP 4 ;
+                                                                   { UNPAIR 5 ;
+                                                                     DUP 6 ;
                                                                      GET 11 ;
                                                                      IF { PUSH nat 2 ; FAILWITH }
                                                                         { PUSH nat 0 ;
-                                                                          DUP 5 ;
+                                                                          DUP 7 ;
                                                                           GET 5 ;
                                                                           COMPARE ;
                                                                           GT ;
                                                                           PUSH nat 0 ;
-                                                                          DUP 6 ;
+                                                                          DUP 8 ;
                                                                           CAR ;
                                                                           COMPARE ;
                                                                           GT ;
                                                                           PUSH mutez 0 ;
-                                                                          DUP 7 ;
+                                                                          DUP 9 ;
                                                                           GET 3 ;
                                                                           COMPARE ;
                                                                           GT ;
-                                                                          DUP 7 ;
+                                                                          DUP 9 ;
                                                                           GET 7 ;
                                                                           AND ;
                                                                           AND ;
                                                                           AND ;
-                                                                          IF { DIG 2 ;
+                                                                          IF { DIG 4 ;
+                                                                               NOW ;
+                                                                               COMPARE ;
+                                                                               GE ;
+                                                                               IF { PUSH nat 3 ; FAILWITH }
+                                                                                  { PUSH mutez 0 ;
+                                                                                    AMOUNT ;
+                                                                                    COMPARE ;
+                                                                                    GT ;
+                                                                                    IF { PUSH nat 10 ; FAILWITH }
+                                                                                       { DUP 5 ;
+                                                                                         GET 5 ;
+                                                                                         PUSH mutez 1 ;
+                                                                                         DUP 7 ;
+                                                                                         GET 3 ;
+                                                                                         EDIV ;
+                                                                                         IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                         DUP 4 ;
+                                                                                         MUL ;
+                                                                                         EDIV ;
+                                                                                         IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                         PUSH mutez 1 ;
+                                                                                         SWAP ;
+                                                                                         MUL ;
+                                                                                         DUP 6 ;
+                                                                                         GET 5 ;
+                                                                                         DUP 7 ;
+                                                                                         CAR ;
+                                                                                         DUP 5 ;
+                                                                                         MUL ;
+                                                                                         EDIV ;
+                                                                                         IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                         DIG 4 ;
+                                                                                         DUP 3 ;
+                                                                                         COMPARE ;
+                                                                                         LT ;
+                                                                                         IF { PUSH nat 11 ; FAILWITH }
+                                                                                            { DIG 4 ;
+                                                                                              DUP 2 ;
+                                                                                              COMPARE ;
+                                                                                              LT ;
+                                                                                              IF { PUSH nat 13 ; FAILWITH }
+                                                                                                 { DUP 4 ;
+                                                                                                   DUP 6 ;
+                                                                                                   GET 5 ;
+                                                                                                   SUB ;
+                                                                                                   ISNAT ;
+                                                                                                   IF_NONE { PUSH nat 14 ; FAILWITH } {} ;
+                                                                                                   DUP 2 ;
+                                                                                                   DUP 7 ;
+                                                                                                   CAR ;
+                                                                                                   SUB ;
+                                                                                                   ISNAT ;
+                                                                                                   IF_NONE { PUSH nat 15 ; FAILWITH } {} ;
+                                                                                                   PUSH mutez 1 ;
+                                                                                                   DUP 8 ;
+                                                                                                   GET 3 ;
+                                                                                                   EDIV ;
+                                                                                                   IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                                   PUSH mutez 1 ;
+                                                                                                   DUP 6 ;
+                                                                                                   EDIV ;
+                                                                                                   IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                                   SWAP ;
+                                                                                                   SUB ;
+                                                                                                   ISNAT ;
+                                                                                                   IF_NONE { PUSH nat 36 ; FAILWITH } {} ;
+                                                                                                   PUSH mutez 1 ;
+                                                                                                   SWAP ;
+                                                                                                   MUL ;
+                                                                                                   DIG 6 ;
+                                                                                                   PUSH int 0 ;
+                                                                                                   SUB ;
+                                                                                                   SENDER ;
+                                                                                                   DUP 9 ;
+                                                                                                   GET 19 ;
+                                                                                                   CONTRACT %mintOrBurn (pair (int %quantity) (address %target)) ;
+                                                                                                   IF_NONE { PUSH nat 12 ; FAILWITH } {} ;
+                                                                                                   PUSH mutez 0 ;
+                                                                                                   DIG 2 ;
+                                                                                                   DIG 3 ;
+                                                                                                   PAIR ;
+                                                                                                   TRANSFER_TOKENS ;
+                                                                                                   DIG 4 ;
+                                                                                                   DUP 7 ;
+                                                                                                   SELF_ADDRESS ;
+                                                                                                   DUP 10 ;
+                                                                                                   GET 17 ;
+                                                                                                   CONTRACT %transfer (pair address (pair address nat)) ;
+                                                                                                   IF_NONE { PUSH nat 0 ; FAILWITH } {} ;
+                                                                                                   PUSH mutez 0 ;
+                                                                                                   DIG 4 ;
+                                                                                                   DIG 4 ;
+                                                                                                   PAIR ;
+                                                                                                   DIG 3 ;
+                                                                                                   PAIR ;
+                                                                                                   TRANSFER_TOKENS ;
+                                                                                                   DIG 6 ;
+                                                                                                   CONTRACT unit ;
+                                                                                                   IF_NONE { PUSH nat 9 ; FAILWITH } {} ;
+                                                                                                   DIG 6 ;
+                                                                                                   UNIT ;
+                                                                                                   TRANSFER_TOKENS ;
+                                                                                                   DIG 6 ;
+                                                                                                   DIG 4 ;
+                                                                                                   UPDATE 3 ;
+                                                                                                   DIG 5 ;
+                                                                                                   UPDATE 5 ;
+                                                                                                   DIG 4 ;
+                                                                                                   UPDATE 1 ;
+                                                                                                   NIL operation ;
+                                                                                                   DIG 2 ;
+                                                                                                   CONS ;
+                                                                                                   DIG 2 ;
+                                                                                                   CONS ;
+                                                                                                   DIG 2 ;
+                                                                                                   CONS ;
+                                                                                                   PAIR } } } } }
+                                                                             { PUSH nat 43 ; FAILWITH } } }
+                                                                   { UNPAIR 4 ;
+                                                                     DUP 5 ;
+                                                                     GET 11 ;
+                                                                     IF { PUSH nat 2 ; FAILWITH }
+                                                                        { PUSH nat 0 ;
+                                                                          DUP 6 ;
+                                                                          GET 5 ;
+                                                                          COMPARE ;
+                                                                          GT ;
+                                                                          PUSH nat 0 ;
+                                                                          DUP 7 ;
+                                                                          CAR ;
+                                                                          COMPARE ;
+                                                                          GT ;
+                                                                          PUSH mutez 0 ;
+                                                                          DUP 8 ;
+                                                                          GET 3 ;
+                                                                          COMPARE ;
+                                                                          GT ;
+                                                                          DUP 8 ;
+                                                                          GET 7 ;
+                                                                          AND ;
+                                                                          AND ;
+                                                                          AND ;
+                                                                          IF { DIG 3 ;
                                                                                NOW ;
                                                                                COMPARE ;
                                                                                GE ;
                                                                                IF { PUSH nat 3 ; FAILWITH }
                                                                                   { PUSH mutez 1 ;
-                                                                                    DUP 4 ;
+                                                                                    DUP 5 ;
                                                                                     GET 3 ;
                                                                                     EDIV ;
                                                                                     IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
@@ -741,341 +975,82 @@
                                                                                     AMOUNT ;
                                                                                     EDIV ;
                                                                                     IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                                    PUSH nat 10000 ;
-                                                                                    DUP 6 ;
-                                                                                    GET 21 ;
+                                                                                    DUP 2 ;
+                                                                                    DUP 7 ;
+                                                                                    GET 5 ;
                                                                                     DUP 3 ;
                                                                                     MUL ;
                                                                                     EDIV ;
                                                                                     IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                                    DUP ;
                                                                                     DIG 2 ;
-                                                                                    SUB ;
-                                                                                    ISNAT ;
-                                                                                    IF_NONE { PUSH nat 34 ; FAILWITH } {} ;
-                                                                                    PUSH nat 997 ;
-                                                                                    DUP 2 ;
-                                                                                    MUL ;
-                                                                                    PUSH nat 1000 ;
-                                                                                    DIG 4 ;
-                                                                                    MUL ;
-                                                                                    ADD ;
-                                                                                    DUP 6 ;
+                                                                                    DUP 7 ;
                                                                                     CAR ;
-                                                                                    PUSH nat 997 ;
-                                                                                    DUP 4 ;
-                                                                                    MUL ;
+                                                                                    DIG 3 ;
                                                                                     MUL ;
                                                                                     EDIV ;
-                                                                                    IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                                    IF_NONE
+                                                                                      { PUSH string "DIV by 0" ; FAILWITH }
+                                                                                      { UNPAIR ; SWAP ; INT ; EQ ; IF {} { PUSH nat 1 ; ADD } } ;
                                                                                     DIG 4 ;
                                                                                     DUP 2 ;
                                                                                     COMPARE ;
-                                                                                    LT ;
-                                                                                    IF { PUSH nat 18 ; FAILWITH } {} ;
-                                                                                    DUP ;
-                                                                                    DUP 6 ;
-                                                                                    CAR ;
-                                                                                    SUB ;
-                                                                                    ISNAT ;
-                                                                                    IF_NONE { PUSH nat 19 ; FAILWITH } {} ;
-                                                                                    PUSH mutez 1 ;
-                                                                                    DIG 4 ;
-                                                                                    MUL ;
-                                                                                    PUSH mutez 1 ;
-                                                                                    DIG 4 ;
-                                                                                    MUL ;
-                                                                                    DUP 6 ;
-                                                                                    SWAP ;
-                                                                                    DUP 7 ;
-                                                                                    GET 3 ;
-                                                                                    ADD ;
-                                                                                    UPDATE 3 ;
-                                                                                    DIG 2 ;
-                                                                                    UPDATE 1 ;
-                                                                                    SWAP ;
-                                                                                    DIG 4 ;
-                                                                                    GET 25 ;
-                                                                                    ADD ;
-                                                                                    UPDATE 25 ;
-                                                                                    SWAP ;
-                                                                                    DIG 2 ;
-                                                                                    SELF_ADDRESS ;
-                                                                                    DUP 4 ;
-                                                                                    GET 17 ;
-                                                                                    CONTRACT %transfer (pair address (pair address nat)) ;
-                                                                                    IF_NONE { PUSH nat 0 ; FAILWITH } {} ;
-                                                                                    PUSH mutez 0 ;
-                                                                                    DIG 4 ;
-                                                                                    DIG 4 ;
-                                                                                    PAIR ;
-                                                                                    DIG 3 ;
-                                                                                    PAIR ;
-                                                                                    TRANSFER_TOKENS ;
-                                                                                    SWAP ;
-                                                                                    NIL operation ;
-                                                                                    DIG 2 ;
-                                                                                    CONS ;
-                                                                                    PAIR } }
-                                                                             { PUSH nat 43 ; FAILWITH } } }
-                                                                   { IF_LEFT
-                                                                       { UNPAIR 5 ;
-                                                                         DUP 6 ;
-                                                                         GET 11 ;
-                                                                         IF { PUSH nat 2 ; FAILWITH }
-                                                                            { PUSH nat 0 ;
-                                                                              DUP 7 ;
-                                                                              GET 5 ;
-                                                                              COMPARE ;
-                                                                              GT ;
-                                                                              PUSH nat 0 ;
-                                                                              DUP 8 ;
-                                                                              CAR ;
-                                                                              COMPARE ;
-                                                                              GT ;
-                                                                              PUSH mutez 0 ;
-                                                                              DUP 9 ;
-                                                                              GET 3 ;
-                                                                              COMPARE ;
-                                                                              GT ;
-                                                                              DUP 9 ;
-                                                                              GET 7 ;
-                                                                              AND ;
-                                                                              AND ;
-                                                                              AND ;
-                                                                              IF { DIG 4 ;
-                                                                                   NOW ;
-                                                                                   COMPARE ;
-                                                                                   GE ;
-                                                                                   IF { PUSH nat 3 ; FAILWITH }
-                                                                                      { PUSH mutez 0 ;
-                                                                                        AMOUNT ;
-                                                                                        COMPARE ;
-                                                                                        GT ;
-                                                                                        IF { PUSH nat 10 ; FAILWITH }
-                                                                                           { DUP 5 ;
-                                                                                             GET 5 ;
-                                                                                             PUSH mutez 1 ;
-                                                                                             DUP 7 ;
-                                                                                             GET 3 ;
-                                                                                             EDIV ;
-                                                                                             IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                                             DUP 4 ;
-                                                                                             MUL ;
-                                                                                             EDIV ;
-                                                                                             IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                                             PUSH mutez 1 ;
-                                                                                             SWAP ;
-                                                                                             MUL ;
-                                                                                             DUP 6 ;
-                                                                                             GET 5 ;
-                                                                                             DUP 7 ;
-                                                                                             CAR ;
-                                                                                             DUP 5 ;
-                                                                                             MUL ;
-                                                                                             EDIV ;
-                                                                                             IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                                             DIG 4 ;
-                                                                                             DUP 3 ;
-                                                                                             COMPARE ;
-                                                                                             LT ;
-                                                                                             IF { PUSH nat 11 ; FAILWITH }
-                                                                                                { DIG 4 ;
-                                                                                                  DUP 2 ;
-                                                                                                  COMPARE ;
-                                                                                                  LT ;
-                                                                                                  IF { PUSH nat 13 ; FAILWITH }
-                                                                                                     { DUP 4 ;
-                                                                                                       DUP 6 ;
-                                                                                                       GET 5 ;
-                                                                                                       SUB ;
-                                                                                                       ISNAT ;
-                                                                                                       IF_NONE { PUSH nat 14 ; FAILWITH } {} ;
-                                                                                                       DUP 2 ;
-                                                                                                       DUP 7 ;
-                                                                                                       CAR ;
-                                                                                                       SUB ;
-                                                                                                       ISNAT ;
-                                                                                                       IF_NONE { PUSH nat 15 ; FAILWITH } {} ;
-                                                                                                       PUSH mutez 1 ;
-                                                                                                       DUP 8 ;
-                                                                                                       GET 3 ;
-                                                                                                       EDIV ;
-                                                                                                       IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                                                       PUSH mutez 1 ;
-                                                                                                       DUP 6 ;
-                                                                                                       EDIV ;
-                                                                                                       IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                                                       SWAP ;
-                                                                                                       SUB ;
-                                                                                                       ISNAT ;
-                                                                                                       IF_NONE { PUSH nat 36 ; FAILWITH } {} ;
-                                                                                                       PUSH mutez 1 ;
-                                                                                                       SWAP ;
-                                                                                                       MUL ;
-                                                                                                       DIG 6 ;
-                                                                                                       PUSH int 0 ;
-                                                                                                       SUB ;
-                                                                                                       SENDER ;
-                                                                                                       DUP 9 ;
-                                                                                                       GET 19 ;
-                                                                                                       CONTRACT %mintOrBurn (pair (int %quantity) (address %target)) ;
-                                                                                                       IF_NONE { PUSH nat 12 ; FAILWITH } {} ;
-                                                                                                       PUSH mutez 0 ;
-                                                                                                       DIG 2 ;
-                                                                                                       DIG 3 ;
-                                                                                                       PAIR ;
-                                                                                                       TRANSFER_TOKENS ;
-                                                                                                       DIG 4 ;
-                                                                                                       DUP 7 ;
-                                                                                                       SELF_ADDRESS ;
-                                                                                                       DUP 10 ;
-                                                                                                       GET 17 ;
-                                                                                                       CONTRACT %transfer (pair address (pair address nat)) ;
-                                                                                                       IF_NONE { PUSH nat 0 ; FAILWITH } {} ;
-                                                                                                       PUSH mutez 0 ;
-                                                                                                       DIG 4 ;
-                                                                                                       DIG 4 ;
-                                                                                                       PAIR ;
-                                                                                                       DIG 3 ;
-                                                                                                       PAIR ;
-                                                                                                       TRANSFER_TOKENS ;
-                                                                                                       DIG 6 ;
-                                                                                                       CONTRACT unit ;
-                                                                                                       IF_NONE { PUSH nat 9 ; FAILWITH } {} ;
-                                                                                                       DIG 6 ;
-                                                                                                       UNIT ;
-                                                                                                       TRANSFER_TOKENS ;
-                                                                                                       DIG 6 ;
-                                                                                                       DIG 4 ;
-                                                                                                       UPDATE 3 ;
-                                                                                                       DIG 5 ;
-                                                                                                       UPDATE 5 ;
-                                                                                                       DIG 4 ;
-                                                                                                       UPDATE 1 ;
-                                                                                                       NIL operation ;
-                                                                                                       DIG 2 ;
-                                                                                                       CONS ;
-                                                                                                       DIG 2 ;
-                                                                                                       CONS ;
-                                                                                                       DIG 2 ;
-                                                                                                       CONS ;
-                                                                                                       PAIR } } } } }
-                                                                                 { PUSH nat 43 ; FAILWITH } } }
-                                                                       { UNPAIR 4 ;
-                                                                         DUP 5 ;
-                                                                         GET 11 ;
-                                                                         IF { PUSH nat 2 ; FAILWITH }
-                                                                            { PUSH nat 0 ;
-                                                                              DUP 6 ;
-                                                                              GET 5 ;
-                                                                              COMPARE ;
-                                                                              GT ;
-                                                                              PUSH nat 0 ;
-                                                                              DUP 7 ;
-                                                                              CAR ;
-                                                                              COMPARE ;
-                                                                              GT ;
-                                                                              PUSH mutez 0 ;
-                                                                              DUP 8 ;
-                                                                              GET 3 ;
-                                                                              COMPARE ;
-                                                                              GT ;
-                                                                              DUP 8 ;
-                                                                              GET 7 ;
-                                                                              AND ;
-                                                                              AND ;
-                                                                              AND ;
-                                                                              IF { DIG 3 ;
-                                                                                   NOW ;
-                                                                                   COMPARE ;
-                                                                                   GE ;
-                                                                                   IF { PUSH nat 3 ; FAILWITH }
-                                                                                      { PUSH mutez 1 ;
-                                                                                        DUP 5 ;
-                                                                                        GET 3 ;
-                                                                                        EDIV ;
-                                                                                        IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                                        PUSH mutez 1 ;
-                                                                                        AMOUNT ;
-                                                                                        EDIV ;
-                                                                                        IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                                        DUP 2 ;
-                                                                                        DUP 7 ;
-                                                                                        GET 5 ;
-                                                                                        DUP 3 ;
-                                                                                        MUL ;
-                                                                                        EDIV ;
-                                                                                        IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-                                                                                        DIG 2 ;
-                                                                                        DUP 7 ;
-                                                                                        CAR ;
-                                                                                        DIG 3 ;
-                                                                                        MUL ;
-                                                                                        EDIV ;
-                                                                                        IF_NONE
-                                                                                          { PUSH string "DIV by 0" ; FAILWITH }
-                                                                                          { UNPAIR ; SWAP ; INT ; EQ ; IF {} { PUSH nat 1 ; ADD } } ;
-                                                                                        DIG 4 ;
-                                                                                        DUP 2 ;
-                                                                                        COMPARE ;
-                                                                                        GT ;
-                                                                                        IF { PUSH nat 4 ; FAILWITH }
-                                                                                           { DIG 3 ;
-                                                                                             DUP 3 ;
-                                                                                             COMPARE ;
-                                                                                             LT ;
-                                                                                             IF { PUSH nat 5 ; FAILWITH }
-                                                                                                { DUP 4 ;
-                                                                                                  DUP 3 ;
-                                                                                                  DUP 6 ;
-                                                                                                  GET 5 ;
-                                                                                                  ADD ;
-                                                                                                  UPDATE 5 ;
-                                                                                                  DUP 2 ;
-                                                                                                  DUP 6 ;
-                                                                                                  CAR ;
-                                                                                                  ADD ;
-                                                                                                  UPDATE 1 ;
-                                                                                                  AMOUNT ;
-                                                                                                  DIG 5 ;
-                                                                                                  GET 3 ;
-                                                                                                  ADD ;
-                                                                                                  UPDATE 3 ;
-                                                                                                  SWAP ;
-                                                                                                  SELF_ADDRESS ;
-                                                                                                  SENDER ;
-                                                                                                  DUP 4 ;
-                                                                                                  GET 17 ;
-                                                                                                  CONTRACT %transfer (pair address (pair address nat)) ;
-                                                                                                  IF_NONE { PUSH nat 0 ; FAILWITH } {} ;
-                                                                                                  PUSH mutez 0 ;
-                                                                                                  DIG 4 ;
-                                                                                                  DIG 4 ;
-                                                                                                  PAIR ;
-                                                                                                  DIG 3 ;
-                                                                                                  PAIR ;
-                                                                                                  TRANSFER_TOKENS ;
-                                                                                                  DIG 2 ;
-                                                                                                  INT ;
-                                                                                                  DIG 3 ;
-                                                                                                  DUP 4 ;
-                                                                                                  GET 19 ;
-                                                                                                  CONTRACT %mintOrBurn (pair (int %quantity) (address %target)) ;
-                                                                                                  IF_NONE { PUSH nat 12 ; FAILWITH } {} ;
-                                                                                                  PUSH mutez 0 ;
-                                                                                                  DIG 2 ;
-                                                                                                  DIG 3 ;
-                                                                                                  PAIR ;
-                                                                                                  TRANSFER_TOKENS ;
-                                                                                                  DIG 2 ;
-                                                                                                  NIL operation ;
-                                                                                                  DIG 2 ;
-                                                                                                  CONS ;
-                                                                                                  DIG 2 ;
-                                                                                                  CONS ;
-                                                                                                  PAIR } } } }
-                                                                                 { PUSH nat 43 ; FAILWITH } } } } } } } } } } } } } } } } } } } ;
+                                                                                    GT ;
+                                                                                    IF { PUSH nat 4 ; FAILWITH }
+                                                                                       { DIG 3 ;
+                                                                                         DUP 3 ;
+                                                                                         COMPARE ;
+                                                                                         LT ;
+                                                                                         IF { PUSH nat 5 ; FAILWITH }
+                                                                                            { DUP 4 ;
+                                                                                              DUP 3 ;
+                                                                                              DUP 6 ;
+                                                                                              GET 5 ;
+                                                                                              ADD ;
+                                                                                              UPDATE 5 ;
+                                                                                              DUP 2 ;
+                                                                                              DUP 6 ;
+                                                                                              CAR ;
+                                                                                              ADD ;
+                                                                                              UPDATE 1 ;
+                                                                                              AMOUNT ;
+                                                                                              DIG 5 ;
+                                                                                              GET 3 ;
+                                                                                              ADD ;
+                                                                                              UPDATE 3 ;
+                                                                                              SWAP ;
+                                                                                              SELF_ADDRESS ;
+                                                                                              SENDER ;
+                                                                                              DUP 4 ;
+                                                                                              GET 17 ;
+                                                                                              CONTRACT %transfer (pair address (pair address nat)) ;
+                                                                                              IF_NONE { PUSH nat 0 ; FAILWITH } {} ;
+                                                                                              PUSH mutez 0 ;
+                                                                                              DIG 4 ;
+                                                                                              DIG 4 ;
+                                                                                              PAIR ;
+                                                                                              DIG 3 ;
+                                                                                              PAIR ;
+                                                                                              TRANSFER_TOKENS ;
+                                                                                              DIG 2 ;
+                                                                                              INT ;
+                                                                                              DIG 3 ;
+                                                                                              DUP 4 ;
+                                                                                              GET 19 ;
+                                                                                              CONTRACT %mintOrBurn (pair (int %quantity) (address %target)) ;
+                                                                                              IF_NONE { PUSH nat 12 ; FAILWITH } {} ;
+                                                                                              PUSH mutez 0 ;
+                                                                                              DIG 2 ;
+                                                                                              DIG 3 ;
+                                                                                              PAIR ;
+                                                                                              TRANSFER_TOKENS ;
+                                                                                              DIG 2 ;
+                                                                                              NIL operation ;
+                                                                                              DIG 2 ;
+                                                                                              CONS ;
+                                                                                              DIG 2 ;
+                                                                                              CONS ;
+                                                                                              PAIR } } } }
+                                                                             { PUSH nat 43 ; FAILWITH } } } } } } } } } } } } } } } } } } ;
   view "get_reserves"
        unit
        (pair nat nat)
@@ -1117,15 +1092,7 @@
   view "get_fee_bp"
        unit
        (pair nat (pair nat nat))
-       { CDR ;
-         DUP ;
-         GET 21 ;
-         PUSH nat 30 ;
-         ADD ;
-         SWAP ;
-         GET 21 ;
-         PUSH nat 30 ;
-         PAIR 3 } ;
+       { DROP ; PUSH nat 30 ; PUSH nat 5 ; PUSH nat 25 ; PAIR 3 } ;
   view "quote_tez_to_token"
        nat
        nat
@@ -1146,32 +1113,21 @@
          DUP 5 ;
          INT ;
          EQ ;
-         DUP 7 ;
+         DIG 6 ;
          GET 7 ;
          NOT ;
          OR ;
          OR ;
          OR ;
-         IF { DROP 4 ; PUSH nat 0 }
-            { PUSH nat 10000 ;
-              DIG 4 ;
-              GET 21 ;
-              DUP 5 ;
-              MUL ;
-              EDIV ;
-              IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-              DIG 3 ;
-              SUB ;
-              ISNAT ;
-              IF_NONE { PUSH nat 0 } {} ;
-              PUSH nat 997 ;
-              DUP 2 ;
+         IF { DROP 3 ; PUSH nat 0 }
+            { PUSH nat 997 ;
+              DUP 4 ;
               MUL ;
               PUSH nat 1000 ;
-              DIG 4 ;
+              DIG 3 ;
               MUL ;
               ADD ;
-              DIG 2 ;
+              SWAP ;
               PUSH nat 997 ;
               DIG 3 ;
               MUL ;
@@ -1198,32 +1154,21 @@
          DUP 5 ;
          INT ;
          EQ ;
-         DUP 7 ;
+         DIG 6 ;
          GET 7 ;
          NOT ;
          OR ;
          OR ;
          OR ;
-         IF { DROP 4 ; PUSH nat 0 }
-            { PUSH nat 10000 ;
-              DIG 4 ;
-              GET 21 ;
-              DUP 5 ;
-              MUL ;
-              EDIV ;
-              IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
-              DIG 3 ;
-              SUB ;
-              ISNAT ;
-              IF_NONE { PUSH nat 0 } {} ;
-              PUSH nat 997 ;
-              DUP 2 ;
+         IF { DROP 3 ; PUSH nat 0 }
+            { PUSH nat 997 ;
+              DUP 4 ;
               MUL ;
               PUSH nat 1000 ;
-              DIG 3 ;
+              DIG 2 ;
               MUL ;
               ADD ;
-              DIG 2 ;
+              SWAP ;
               PUSH nat 997 ;
               DIG 3 ;
               MUL ;

--- a/dex/contracts/dexter_mod.mligo
+++ b/dex/contracts/dexter_mod.mligo
@@ -49,6 +49,13 @@ module Dexter = struct
       deadline : timestamp ;
     }
 
+  type activate_pool =
+    [@layout:comb]
+    { expectedXtzPool : tez ;
+      expectedTokenPool : nat ;
+      expectedLqtTotal : nat ;
+    }
+
   #if FA2
   type update_token_pool_internal = ((address * nat) * nat) list
   #else
@@ -64,6 +71,8 @@ module Dexter = struct
     { tokenPool : nat ;
       xtzPool : tez ;
       lqtTotal : nat ;
+      active : bool ;
+      activationPending : bool ;
       selfIsUpdatingTokenPool : bool ;
       freezeBaker : bool ;
       manager : address ;
@@ -100,6 +109,11 @@ module Dexter = struct
     [@layout:comb]
     { quantity : int ;
       target : address }
+
+  type getTotalSupply =
+    [@layout:comb]
+    { request : unit ;
+      callback : nat contract }
 
   // =============================================================================
   // Error codes
@@ -152,6 +166,14 @@ module Dexter = struct
   [@inline] let error_NO_PROTOCOL_FEE_TO_CLAIM = 40n
   [@inline] let error_ONLY_MANAGER_CAN_SET_PROTOCOL_FEE_RECIPIENT = 41n
   [@inline] let error_ACCUMULATED_FEE_EXCEEDS_TOKEN_POOL = 42n
+  [@inline] let error_POOL_NOT_ACTIVE = 43n
+  [@inline] let error_POOL_ALREADY_ACTIVE = 44n
+  [@inline] let error_ONLY_MANAGER_CAN_INITIALIZE_POOL = 45n
+  [@inline] let error_LQT_ADDRESS_NOT_CONFIGURED = 46n
+  [@inline] let error_INVALID_INITIAL_RESERVES = 47n
+  [@inline] let error_LQT_CONTRACT_MUST_HAVE_A_GET_TOTAL_SUPPLY_ENTRYPOINT = 48n
+  [@inline] let error_INVALID_ACTIVATION_CALLBACK = 49n
+  [@inline] let error_LQT_TOTAL_MISMATCH = 50n
 
   // =============================================================================
   // Functions
@@ -205,16 +227,21 @@ module Dexter = struct
   let compute_protocol_fee (amount_nat : nat) (fee_bp : nat) : nat =
       (amount_nat * fee_bp) / 10000n
 
+  [@inline]
+  let pool_is_ready (storage : storage) : bool =
+      storage.active
+      && storage.xtzPool > 0mutez
+      && storage.tokenPool > 0n
+      && storage.lqtTotal > 0n
+
   // =============================================================================
   // Entrypoint Functions
   // =============================================================================
 
-  // We assume the contract is originated with at least one liquidity
-  // provider set up already, so lqtTotal, xtzPool and tokenPool will
-  // always be positive after the initial setup, unless all liquidity is
-  // removed, at which point the contract is considered dead and stops working
-  // properly. (To prevent this, at least one address should keep at least a
-  // small amount of liquidity in the contract forever.)
+  // Modified pools originate inactive. The manager seeds the reserves and
+  // activates the pool only after the expected reserves and the LQT contract's
+  // actual total supply have been verified. Each user-funds entrypoint also
+  // checks the lifecycle and positive reserves so an emptied pool fails closed.
 
   [@entry]
   let addLiquidity (param : add_liquidity) (storage: storage) : result =
@@ -225,6 +252,8 @@ module Dexter = struct
 
       if storage.selfIsUpdatingTokenPool then
           (failwith error_SELF_IS_UPDATING_TOKEN_POOL_MUST_BE_FALSE : result)
+      else if not (pool_is_ready storage) then
+          (failwith error_POOL_NOT_ACTIVE : result)
       else if Tezos.get_now () >= deadline then
           (failwith error_THE_CURRENT_TIME_MUST_BE_LESS_THAN_THE_DEADLINE : result)
       else
@@ -261,6 +290,8 @@ module Dexter = struct
 
       if storage.selfIsUpdatingTokenPool then
         (failwith error_SELF_IS_UPDATING_TOKEN_POOL_MUST_BE_FALSE : result)
+      else if not (pool_is_ready storage) then
+        (failwith error_POOL_NOT_ACTIVE : result)
       else if Tezos.get_now () >= deadline then
         (failwith error_THE_CURRENT_TIME_MUST_BE_LESS_THAN_THE_DEADLINE : result)    
       else if Tezos.get_amount () > 0mutez then
@@ -309,6 +340,8 @@ module Dexter = struct
 
       if storage.selfIsUpdatingTokenPool then
           (failwith error_SELF_IS_UPDATING_TOKEN_POOL_MUST_BE_FALSE : result)
+      else if not (pool_is_ready storage) then
+          (failwith error_POOL_NOT_ACTIVE : result)
       else if Tezos.get_now () >= deadline then
           (failwith error_THE_CURRENT_TIME_MUST_BE_LESS_THAN_THE_DEADLINE : result)    
       else begin
@@ -356,6 +389,8 @@ module Dexter = struct
 
       if storage.selfIsUpdatingTokenPool then
           (failwith error_SELF_IS_UPDATING_TOKEN_POOL_MUST_BE_FALSE : result)
+      else if not (pool_is_ready storage) then
+          (failwith error_POOL_NOT_ACTIVE : result)
       else if Tezos.get_now () >= deadline then
           (failwith error_THE_CURRENT_TIME_MUST_BE_LESS_THAN_THE_DEADLINE : result)    
       else if Tezos.get_amount () > 0mutez then
@@ -407,6 +442,8 @@ module Dexter = struct
       // update xtzPool
       if (storage.selfIsUpdatingTokenPool) then
           (failwith error_SELF_IS_UPDATING_TOKEN_POOL_MUST_BE_FALSE: result)
+      else if not storage.active && Tezos.get_sender () <> storage.manager then
+          (failwith error_ONLY_MANAGER_CAN_INITIALIZE_POOL : result)
       else 
           let storage = {storage with xtzPool = storage.xtzPool + Tezos.get_amount () } in
           (([] : operation list), storage)
@@ -461,6 +498,8 @@ module Dexter = struct
         (failwith error_AMOUNT_MUST_BE_ZERO : result)
       else if storage.selfIsUpdatingTokenPool then
         (failwith error_UNEXPECTED_REENTRANCE_IN_UPDATE_TOKEN_POOL : result)
+      else if not storage.active && Tezos.get_sender () <> storage.manager then
+        (failwith error_ONLY_MANAGER_CAN_INITIALIZE_POOL : result)
       else
         let self_addr = Tezos.get_self_address () in
         let cfmm_update_token_pool_internal : update_token_pool_internal contract = 
@@ -490,12 +529,15 @@ module Dexter = struct
         (failwith error_AMOUNT_MUST_BE_ZERO : result)
       else 
   #if FA2
-          // we trust the FA2 to provide the expected balance. there are no BFS
-          // shenanigans to worry about unless the token contract misbehaves
           let token_pool =
-            match List.head token_pool with
-                None -> (failwith error_INVALID_FA2_BALANCE_RESPONSE : nat)
-                | Some ((_addr, _token_id), balance) -> balance in
+            match token_pool with
+              [((owner, token_id), balance)] ->
+                if
+                  owner = Tezos.get_self_address ()
+                  && token_id = storage.tokenId
+                then balance
+                else (failwith error_INVALID_FA2_BALANCE_RESPONSE : nat)
+            | _ -> (failwith error_INVALID_FA2_BALANCE_RESPONSE : nat) in
   #endif
           // Subtract accumulated token fee from the real balance to get the true pool size.
           // The contract holds tokenPool + accumulated_protocol_fee_token tokens in total,
@@ -521,6 +563,8 @@ module Dexter = struct
     
       if storage.selfIsUpdatingTokenPool then
         (failwith error_SELF_IS_UPDATING_TOKEN_POOL_MUST_BE_FALSE : result)
+      else if not (pool_is_ready storage) then
+        (failwith error_POOL_NOT_ACTIVE : result)
       else if Tezos.get_amount () > 0mutez then
         (failwith error_AMOUNT_MUST_BE_ZERO : result)
       else if Tezos.get_now () >= deadline then
@@ -553,6 +597,80 @@ module Dexter = struct
               xtz_bought
               outputDexterContract_contract in
           ([op1; op2] , storage)
+
+    [@entry]
+    let activate (param : activate_pool) (storage : storage) : result =
+        if storage.selfIsUpdatingTokenPool then
+            (failwith error_SELF_IS_UPDATING_TOKEN_POOL_MUST_BE_FALSE : result)
+        else if Tezos.get_amount () > 0mutez then
+            (failwith error_AMOUNT_MUST_BE_ZERO : result)
+        else if Tezos.get_sender () <> storage.manager then
+            (failwith error_ONLY_MANAGER_CAN_INITIALIZE_POOL : result)
+        else if storage.active or storage.activationPending then
+            (failwith error_POOL_ALREADY_ACTIVE : result)
+        else if storage.lqtAddress = ("tz1Ke2h7sDdakHJQh8WX4Z372du1KChsksyU" : address) then
+            (failwith error_LQT_ADDRESS_NOT_CONFIGURED : result)
+        else if
+            param.expectedXtzPool = 0mutez
+            or param.expectedTokenPool = 0n
+            or param.expectedLqtTotal = 0n
+            or storage.xtzPool <> param.expectedXtzPool
+            or storage.tokenPool <> param.expectedTokenPool
+            or storage.lqtTotal <> param.expectedLqtTotal
+            or Tezos.get_balance () <> param.expectedXtzPool
+        then
+            (failwith error_INVALID_INITIAL_RESERVES : result)
+        else
+            let self_addr = Tezos.get_self_address () in
+            let activate_internal : nat contract =
+                match
+                  (Tezos.get_entrypoint_opt
+                    "%activateInternal"
+                    self_addr
+                    : nat contract option)
+                with
+                | None ->
+                    (failwith "Cannot get activateInternal entrypoint" : nat contract)
+                | Some contract -> contract in
+            let lqt_get_total_supply : getTotalSupply contract =
+                match
+                  (Tezos.get_entrypoint_opt
+                    "%getTotalSupply"
+                    storage.lqtAddress
+                    : getTotalSupply contract option)
+                with
+                | None ->
+                    (failwith
+                      error_LQT_CONTRACT_MUST_HAVE_A_GET_TOTAL_SUPPLY_ENTRYPOINT
+                      : getTotalSupply contract)
+                | Some contract -> contract in
+            let op =
+                Tezos.transaction
+                  {request = (); callback = activate_internal}
+                  0mutez
+                  lqt_get_total_supply in
+            ([op], {storage with activationPending = true})
+
+    [@entry]
+    let activateInternal (actual_lqt_total : nat) (storage : storage) : result =
+        if
+          not storage.activationPending
+          or Tezos.get_sender () <> storage.lqtAddress
+        then
+            (failwith error_INVALID_ACTIVATION_CALLBACK : result)
+        else if Tezos.get_amount () > 0mutez then
+            (failwith error_AMOUNT_MUST_BE_ZERO : result)
+        else if actual_lqt_total <> storage.lqtTotal then
+            (failwith error_LQT_TOTAL_MISMATCH : result)
+        else if
+          storage.xtzPool = 0mutez
+          or storage.tokenPool = 0n
+          or storage.lqtTotal = 0n
+        then
+            (failwith error_INVALID_INITIAL_RESERVES : result)
+        else
+            (([] : operation list),
+             {storage with active = true; activationPending = false})
 
     [@entry]
     let setProtocolFee (new_fee_bp : nat) (storage : storage) : result =
@@ -626,6 +744,10 @@ module Dexter = struct
       storage.lqtTotal
 
   [@view]
+  let is_active (_ : unit) (storage : storage) : bool =
+      pool_is_ready storage
+
+  [@view]
   let get_fee_bp (_ : unit) (storage : storage) : (nat * nat * nat) =
       (30n, storage.protocol_fee_bp, 30n + storage.protocol_fee_bp)
 
@@ -633,7 +755,7 @@ module Dexter = struct
   let quote_tez_to_token (tez_in : nat) (storage : storage) : nat =
       let a : nat = mutez_to_natural storage.xtzPool in
       let b : nat = storage.tokenPool in
-      if tez_in = 0n or a = 0n or b = 0n then
+      if not storage.active or tez_in = 0n or a = 0n or b = 0n then
           0n
       else
         // Deduct protocol fee from tez_in before quoting so the returned
@@ -648,7 +770,7 @@ module Dexter = struct
   let quote_token_to_tez (token_in : nat) (storage : storage) : nat =
       let a : nat = mutez_to_natural storage.xtzPool in
       let b : nat = storage.tokenPool in
-      if token_in = 0n or a = 0n or b = 0n then
+      if not storage.active or token_in = 0n or a = 0n or b = 0n then
           0n
       else
         let fee : nat = compute_protocol_fee token_in storage.protocol_fee_bp in
@@ -672,12 +794,14 @@ module Dexter = struct
   { tokenPool = 0n ;
     xtzPool = 0tz ;
     lqtTotal = build.lqtTotal ;
+    active = false ;
+    activationPending = false ;
     selfIsUpdatingTokenPool = false ;
     freezeBaker = false ;
     manager = build.manager ;
     tokenAddress = build.tokenAddress ;
     #if FA2
-    tokenId = 0n ;
+    tokenId = build.tokenId ;
     #endif
     lqtAddress = ("tz1Ke2h7sDdakHJQh8WX4Z372du1KChsksyU" : address) ;
     protocol_fee_bp = build.protocol_fee_bp ;

--- a/dex/contracts/dexter_mod.mligo
+++ b/dex/contracts/dexter_mod.mligo
@@ -246,9 +246,11 @@ module Dexter = struct
   // =============================================================================
 
   // Modified pools originate inactive. The manager seeds the reserves and
-  // activates the pool only after the expected reserves and the LQT contract's
-  // actual total supply have been verified. Each user-funds entrypoint also
-  // checks the lifecycle and positive reserves so an emptied pool fails closed.
+  // activates the pool only after the expected XTZ/LQT reserves, the minimum
+  // token seed, and the LQT contract's actual total supply have been verified.
+  // Any tokens donated before synchronization remain in the pool for LPs and
+  // cannot prevent activation. Each user-funds entrypoint also checks the
+  // lifecycle and positive reserves so an emptied pool fails closed.
 
   [@entry]
   let addLiquidity (param : add_liquidity) (storage: storage) : result =
@@ -625,7 +627,10 @@ module Dexter = struct
             or param.expectedTokenPool = 0n
             or param.expectedLqtTotal = 0n
             or storage.xtzPool <> param.expectedXtzPool
-            or storage.tokenPool <> param.expectedTokenPool
+            (* Token contracts can transfer directly to this address while the
+               pool is inactive. Treat the configured token seed as a minimum
+               so donated excess benefits LPs instead of blocking activation. *)
+            or storage.tokenPool < param.expectedTokenPool
             or storage.lqtTotal <> param.expectedLqtTotal
             or Tezos.get_balance () <> param.expectedXtzPool
         then

--- a/dex/contracts/dexter_mod.mligo
+++ b/dex/contracts/dexter_mod.mligo
@@ -81,7 +81,6 @@ module Dexter = struct
       tokenId : nat ;
   #endif
       lqtAddress : address ;
-      protocol_fee_bp : nat ;           // fee in basis points (1 bp = 0.01%).
       protocol_fee_recipient : address ; // address authorised to claim the accumulated fee
       accumulated_protocol_fee_xtz : tez ;  // total XTZ fee accumulated since last claim
       accumulated_protocol_fee_token : nat ; // total token fee accumulated since last claim
@@ -160,8 +159,8 @@ module Dexter = struct
   [@inline] let error_PROTOCOL_FEE_EXCEEDS_AMOUNT = 34n
   [@inline] let error_PROTOCOL_FEE_EXCEEDS_XTZ_BOUGHT = 35n
   [@inline] let error_XTZ_POOL_UNDERFLOW = 36n
-  [@inline] let error_ONLY_MANAGER_CAN_SET_PROTOCOL_FEE = 37n
-  [@inline] let error_PROTOCOL_FEE_TOO_HIGH = 38n
+  (* 37n *)
+  (* 38n *)
   [@inline] let error_ONLY_RECIPIENT_CAN_CLAIM_PROTOCOL_FEE = 39n
   [@inline] let error_NO_PROTOCOL_FEE_TO_CLAIM = 40n
   [@inline] let error_ONLY_MANAGER_CAN_SET_PROTOCOL_FEE_RECIPIENT = 41n
@@ -223,9 +222,17 @@ module Dexter = struct
       | Some c -> c in
       Tezos.transaction () amount_ to_contract
 
+  // A swap pays exactly 30 bp in total: 25 bp remains in the pool for LPs and
+  // 5 bp is accounted separately for the protocol recipient. These constants
+  // are intentionally not stored and there is no fee-setting entrypoint.
+  [@inline] let lp_fee_bp : nat = 25n
+  [@inline] let protocol_fee_bp : nat = 5n
+  [@inline] let total_fee_bp : nat = 30n
+  [@inline] let swap_fee_numerator : nat = 997n
+
   [@inline]
-  let compute_protocol_fee (amount_nat : nat) (fee_bp : nat) : nat =
-      (amount_nat * fee_bp) / 10000n
+  let compute_protocol_fee (amount_nat : nat) : nat =
+      (amount_nat * protocol_fee_bp) / 10000n
 
   [@inline]
   let pool_is_ready (storage : storage) : bool =
@@ -350,13 +357,15 @@ module Dexter = struct
           let xtzPool = mutez_to_natural storage.xtzPool in
           let nat_amount = mutez_to_natural (Tezos.get_amount ()) in
 
-          let protocol_fee = compute_protocol_fee nat_amount storage.protocol_fee_bp in
-          let net_amount : nat = match is_nat (nat_amount - protocol_fee) with
+          let protocol_fee = compute_protocol_fee nat_amount in
+          let pool_amount : nat = match is_nat (nat_amount - protocol_fee) with
               | None -> (failwith error_PROTOCOL_FEE_EXCEEDS_AMOUNT : nat)
               | Some n -> n in
 
           let tokens_bought = 
-              (let bought = (net_amount * 997n * storage.tokenPool) / (xtzPool * 1000n + (net_amount * 997n)) in
+              // Price the gross input at the full 30 bp swap fee. The 5 bp
+              // protocol share is removed only from reserve accounting below.
+              (let bought = (nat_amount * swap_fee_numerator * storage.tokenPool) / (xtzPool * 1000n + (nat_amount * swap_fee_numerator)) in
               if bought < minTokensBought then
                   (failwith error_TOKENS_BOUGHT_MUST_BE_GREATER_THAN_OR_EQUAL_TO_MIN_TOKENS_BOUGHT : nat)
               else
@@ -366,12 +375,13 @@ module Dexter = struct
               | None -> (failwith error_TOKEN_POOL_MINUS_TOKENS_BOUGHT_IS_NEGATIVE : nat)
               | Some difference -> difference) in
 
-          // Only the net amount enters the xtzPool; fee sits in accumulated_protocol_fee
+          // Gross XTZ enters the contract. The tracked pool receives gross less
+          // the 5 bp protocol liability, leaving the other 25 bp with LPs.
           let fee_tez : tez = natural_to_mutez protocol_fee in
-          let net_tez : tez = natural_to_mutez net_amount in
+          let pool_tez : tez = natural_to_mutez pool_amount in
           // update xtzPool
           let storage = { storage with
-              xtzPool = storage.xtzPool + net_tez ;
+              xtzPool = storage.xtzPool + pool_tez ;
               tokenPool = new_tokenPool ;
               accumulated_protocol_fee_xtz = storage.accumulated_protocol_fee_xtz + fee_tez } in
           // send tokens_withdrawn to to address
@@ -398,13 +408,13 @@ module Dexter = struct
       else
           // we don't check that tokenPool > 0, because that is impossible
           // unless all liquidity has been removed
-          let protocol_fee = compute_protocol_fee tokensSold storage.protocol_fee_bp in
-          let net_tokens_sold : nat = match is_nat (tokensSold - protocol_fee) with
+          let protocol_fee = compute_protocol_fee tokensSold in
+          let pool_tokens_sold : nat = match is_nat (tokensSold - protocol_fee) with
               | None -> (failwith error_PROTOCOL_FEE_EXCEEDS_AMOUNT : nat)
               | Some n -> n in
           
           let xtz_bought = 
-              let bought = natural_to_mutez (((net_tokens_sold * 997n * (mutez_to_natural storage.xtzPool)) / (storage.tokenPool * 1000n + (net_tokens_sold * 997n)))) in
+              let bought = natural_to_mutez (((tokensSold * swap_fee_numerator * (mutez_to_natural storage.xtzPool)) / (storage.tokenPool * 1000n + (tokensSold * swap_fee_numerator)))) in
                   if bought < minXtzBought then (failwith error_XTZ_BOUGHT_MUST_BE_GREATER_THAN_OR_EQUAL_TO_MIN_XTZ_BOUGHT : tez) else bought in
 
           let xtz_pool_nat = mutez_to_natural storage.xtzPool in
@@ -416,7 +426,7 @@ module Dexter = struct
 
           let op_token = token_transfer storage (Tezos.get_sender ()) (Tezos.get_self_address ()) tokensSold in
           let op_tez = xtz_transfer to_ xtz_bought in
-          let storage = {storage with tokenPool = storage.tokenPool + net_tokens_sold ;
+          let storage = {storage with tokenPool = storage.tokenPool + pool_tokens_sold ;
                                       xtzPool = new_xtzPool ;
                                       accumulated_protocol_fee_token = storage.accumulated_protocol_fee_token + protocol_fee} in
           ([op_token ; op_tez], storage)
@@ -571,12 +581,12 @@ module Dexter = struct
         (failwith error_THE_CURRENT_TIME_MUST_BE_LESS_THAN_THE_DEADLINE : result)
       else 
           // we don't check that tokenPool > 0, because that is impossible unless all liquidity has been removed
-          let protocol_fee = compute_protocol_fee tokensSold storage.protocol_fee_bp in
-          let net_tokens_sold : nat = match is_nat (tokensSold - protocol_fee) with
+          let protocol_fee = compute_protocol_fee tokensSold in
+          let pool_tokens_sold : nat = match is_nat (tokensSold - protocol_fee) with
               | None -> (failwith error_PROTOCOL_FEE_EXCEEDS_AMOUNT : nat)
               | Some n -> n in
           let xtz_bought_nat =
-              (net_tokens_sold * 997n * (mutez_to_natural storage.xtzPool)) / (storage.tokenPool * 1000n + (net_tokens_sold * 997n)) in
+              (tokensSold * swap_fee_numerator * (mutez_to_natural storage.xtzPool)) / (storage.tokenPool * 1000n + (tokensSold * swap_fee_numerator)) in
 
           let xtz_pool_nat = mutez_to_natural storage.xtzPool in
           let new_xtz_pool_nat = match is_nat (xtz_pool_nat - xtz_bought_nat) with
@@ -586,7 +596,7 @@ module Dexter = struct
           let xtz_bought = natural_to_mutez xtz_bought_nat in
 
           let storage = {storage with
-              tokenPool = storage.tokenPool + net_tokens_sold ;
+              tokenPool = storage.tokenPool + pool_tokens_sold ;
               xtzPool = new_xtzPool ;
               accumulated_protocol_fee_token = storage.accumulated_protocol_fee_token + protocol_fee } in
           
@@ -673,20 +683,6 @@ module Dexter = struct
              {storage with active = true; activationPending = false})
 
     [@entry]
-    let setProtocolFee (new_fee_bp : nat) (storage : storage) : result =
-        if storage.selfIsUpdatingTokenPool then
-            (failwith error_SELF_IS_UPDATING_TOKEN_POOL_MUST_BE_FALSE : result)
-        else if Tezos.get_amount () > 0mutez then
-            (failwith error_AMOUNT_MUST_BE_ZERO : result)
-        else if Tezos.get_sender () <> storage.manager then
-            (failwith error_ONLY_MANAGER_CAN_SET_PROTOCOL_FEE : result)
-        else if new_fee_bp > 1000n then
-            // Hard cap at 10% (1000 bp) to prevent accidental misconfigurations
-            (failwith error_PROTOCOL_FEE_TOO_HIGH : result)
-        else
-            (([] : operation list), {storage with protocol_fee_bp = new_fee_bp})
-
-    [@entry]
     let setProtocolFeeRecipient (new_recipient : address) (storage : storage) : result =
         if storage.selfIsUpdatingTokenPool then
             (failwith error_SELF_IS_UPDATING_TOKEN_POOL_MUST_BE_FALSE : result)
@@ -748,8 +744,8 @@ module Dexter = struct
       pool_is_ready storage
 
   [@view]
-  let get_fee_bp (_ : unit) (storage : storage) : (nat * nat * nat) =
-      (30n, storage.protocol_fee_bp, 30n + storage.protocol_fee_bp)
+  let get_fee_bp (_ : unit) (_storage : storage) : (nat * nat * nat) =
+      (lp_fee_bp, protocol_fee_bp, total_fee_bp)
 
   [@view]
   let quote_tez_to_token (tez_in : nat) (storage : storage) : nat =
@@ -758,13 +754,7 @@ module Dexter = struct
       if not storage.active or tez_in = 0n or a = 0n or b = 0n then
           0n
       else
-        // Deduct protocol fee from tez_in before quoting so the returned
-        // value matches what the user will actually receive
-        let fee : nat = compute_protocol_fee tez_in storage.protocol_fee_bp in
-        let net_tez_in : nat = match is_nat (tez_in - fee) with
-            | None -> 0n
-            | Some n -> n in
-        (net_tez_in * 997n * b) / (a * 1000n + net_tez_in * 997n)
+        (tez_in * swap_fee_numerator * b) / (a * 1000n + tez_in * swap_fee_numerator)
 
   [@view]
   let quote_token_to_tez (token_in : nat) (storage : storage) : nat =
@@ -773,11 +763,7 @@ module Dexter = struct
       if not storage.active or token_in = 0n or a = 0n or b = 0n then
           0n
       else
-        let fee : nat = compute_protocol_fee token_in storage.protocol_fee_bp in
-        let net_token_in : nat = match is_nat (token_in - fee) with
-            | None -> 0n
-            | Some n -> n in
-        (net_token_in * 997n * a) / (b * 1000n + net_token_in * 997n)
+        (token_in * swap_fee_numerator * a) / (b * 1000n + token_in * swap_fee_numerator)
 
   type build_storage =
   { lqtTotal : nat;
@@ -786,7 +772,6 @@ module Dexter = struct
 #if FA2
     tokenId : nat;
 #endif
-    protocol_fee_bp : nat ;
     protocol_fee_recipient : address ;
   }
 
@@ -804,7 +789,6 @@ module Dexter = struct
     tokenId = build.tokenId ;
     #endif
     lqtAddress = ("tz1Ke2h7sDdakHJQh8WX4Z372du1KChsksyU" : address) ;
-    protocol_fee_bp = build.protocol_fee_bp ;
     protocol_fee_recipient = build.protocol_fee_recipient ;
     accumulated_protocol_fee_xtz = 0mutez ;
     accumulated_protocol_fee_token = 0n ;

--- a/dex/contracts/helpers/dexter_mod_fa2.mligo
+++ b/dex/contracts/helpers/dexter_mod_fa2.mligo
@@ -1,0 +1,2 @@
+#define FA2
+#include "../dexter_mod.mligo"

--- a/dex/scripts/.env.example
+++ b/dex/scripts/.env.example
@@ -1,5 +1,4 @@
-# Address of the token to be traded on the DEX 
-# Note: Script is configured to work with FA1.2 tokens only.
+# Address of the FA1.2 or FA2 token to be traded on the DEX.
 TOKEN_ADDRESS=
 
 # This are optional values. If not set, TzKT (Ghostnet/Mainnet) endpoint will be used by default.
@@ -10,6 +9,7 @@ MAINNET_RPC=
 TESTNET_PRIVATE_KEY=
 MAINNET_PRIVATE_KEY=
 
+# Exact base-10 integers only; decimal points and exponent notation are rejected.
 # In MUTEZ. So for example, to seed 20 XTZ, set SEED_XTZ=20000000
 SEED_XTZ=
 # In TOKENS (with decimals). So for example, for a token with 6 decimals, to seed 10 tokens, set SEED_TOKEN=10000000
@@ -31,7 +31,8 @@ TOKEN_STANDARD=
 TOKEN_ID=
 # The type of the DEX pool to be deployed. Can be either "mod" or "base". "mod" is a version modified with protocol fee, while "base" is a basic version without protocol fee.
 POOL_TYPE=
-# Protocol fee in basis points (1% = 100 basis points). Only applicable for "mod" pool type.
+# Protocol fee in basis points (1% = 100 basis points), from 0 through 1000.
+# Only applicable for "mod" pool type.
 PROTOCOL_FEE_BP=
 # Address that will receive protocol fees. Only applicable for "mod" pool type.
 PROTOCOL_FEE_RECIPIENT=

--- a/dex/scripts/.env.example
+++ b/dex/scripts/.env.example
@@ -15,9 +15,10 @@ SEED_XTZ=
 # In TOKENS (with decimals). So for example, for a token with 6 decimals, to seed 10 tokens, set SEED_TOKEN=10000000
 SEED_TOKEN=
 
-# Address of the manager account. 
-# Will be set as admin of the DEX contract + initial liquidity tokens will be minted to this address
-# Should be set to PRIVATE_KEY owner address to complete the setup after deployment, otherwise the process will fail after deployment.
+# Final DEX manager. This may be an implicit account or a contract such as a
+# multisig. The deployment signer temporarily manages the inactive setup, then
+# the atomic initialization batch transfers management here. Initial LQT is
+# minted here. For modified pools this is also the initial protocol fee recipient.
 MANAGER=
 
 # Should be in format ipfs://Qmb94zFKazBKxuYk4QyTWmgiVP3zXLkGjNDDTq3DShEs8E
@@ -31,8 +32,5 @@ TOKEN_STANDARD=
 TOKEN_ID=
 # The type of the DEX pool to be deployed. Can be either "mod" or "base". "mod" is a version modified with protocol fee, while "base" is a basic version without protocol fee.
 POOL_TYPE=
-# Protocol fee in basis points (1% = 100 basis points), from 0 through 1000.
-# Only applicable for "mod" pool type.
-PROTOCOL_FEE_BP=
-# Address that will receive protocol fees. Only applicable for "mod" pool type.
-PROTOCOL_FEE_RECIPIENT=
+# Modified pools use an immutable 30 bp total swap fee: 25 bp for LPs and
+# 5 bp accumulated for the MANAGER address as protocol fee recipient.

--- a/dex/scripts/package.json
+++ b/dex/scripts/package.json
@@ -4,7 +4,9 @@
     "type": "module",
     "scripts": {
         "deploy:testnet": "tsx src/deploy.ts --network=testnet",
-        "deploy:mainnet": "tsx src/deploy.ts --network=mainnet"
+        "deploy:mainnet": "tsx src/deploy.ts --network=mainnet",
+        "test": "tsx --test src/*.test.ts",
+        "typecheck": "tsc --noEmit"
     },
     "keywords": [],
     "author": "",
@@ -15,6 +17,7 @@
         "@taquito/michelson-encoder": "^23.1.0",
         "@taquito/signer": "^23.0.3",
         "@taquito/taquito": "^23.0.3",
+        "@taquito/utils": "^23.1.0",
         "bn.js": "^5.2.2",
         "dotenv": "^17.2.3"
     },

--- a/dex/scripts/src/amounts.test.ts
+++ b/dex/scripts/src/amounts.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+    calculateInitialLqt,
+    formatMutez,
+    integerSquareRoot,
+    parseNat,
+    toSafeNumber,
+} from "./amounts.js";
+
+test("integerSquareRoot floors exact arbitrary-precision values", () => {
+    assert.equal(integerSquareRoot(0n), 0n);
+    assert.equal(integerSquareRoot(1n), 1n);
+    assert.equal(integerSquareRoot(15n), 3n);
+    assert.equal(integerSquareRoot(16n), 4n);
+    assert.equal(
+        integerSquareRoot(1234567890123456789012345678901234567890n),
+        35136418288201442531n
+    );
+});
+
+test("calculateInitialLqt remains exact above Number.MAX_SAFE_INTEGER", () => {
+    assert.equal(
+        calculateInitialLqt("1000000000000000000", "250000000000000000"),
+        "500000000000000000"
+    );
+});
+
+test("parseNat rejects partial, signed, fractional, and exponential inputs", () => {
+    for (const value of ["12abc", "-1", "+1", "1.5", "1e6", "01", ""]) {
+        assert.throws(() => parseNat(value, "VALUE"));
+    }
+    assert.equal(parseNat(" 123 ", "VALUE"), "123");
+});
+
+test("toSafeNumber rejects values that Taquito cannot accept exactly", () => {
+    assert.equal(toSafeNumber("9007199254740991", "VALUE"), Number.MAX_SAFE_INTEGER);
+    assert.throws(() => toSafeNumber("9007199254740992", "VALUE"));
+});
+
+test("formatMutez uses integer formatting", () => {
+    assert.equal(formatMutez("20000001"), "20.000001");
+});

--- a/dex/scripts/src/amounts.ts
+++ b/dex/scripts/src/amounts.ts
@@ -1,0 +1,50 @@
+const NAT_PATTERN = /^(0|[1-9][0-9]*)$/;
+
+export function parseNat(value: string, name: string): string {
+    const normalized = value.trim();
+    if (!NAT_PATTERN.test(normalized)) {
+        throw new Error(`${name} must be a non-negative base-10 integer`);
+    }
+    return BigInt(normalized).toString();
+}
+
+export function toSafeNumber(value: string, name: string): number {
+    const parsed = BigInt(parseNat(value, name));
+    if (parsed > BigInt(Number.MAX_SAFE_INTEGER)) {
+        throw new Error(
+            `${name} exceeds the exact integer range accepted by the Taquito amount API`
+        );
+    }
+    return Number(parsed);
+}
+
+export function integerSquareRoot(value: bigint): bigint {
+    if (value < 0n) {
+        throw new Error("Cannot calculate the square root of a negative integer");
+    }
+    if (value < 2n) {
+        return value;
+    }
+
+    let estimate = 1n << (BigInt(value.toString(2).length) + 1n >> 1n);
+    while (true) {
+        const next = (estimate + value / estimate) >> 1n;
+        if (next >= estimate) {
+            return estimate;
+        }
+        estimate = next;
+    }
+}
+
+export function calculateInitialLqt(xtz: string, token: string): string {
+    const product = BigInt(parseNat(xtz, "SEED_XTZ"))
+        * BigInt(parseNat(token, "SEED_TOKEN"));
+    return integerSquareRoot(product).toString();
+}
+
+export function formatMutez(value: string): string {
+    const mutez = BigInt(parseNat(value, "mutez value"));
+    const whole = mutez / 1_000_000n;
+    const fraction = (mutez % 1_000_000n).toString().padStart(6, "0");
+    return `${whole}.${fraction}`;
+}

--- a/dex/scripts/src/config.ts
+++ b/dex/scripts/src/config.ts
@@ -1,5 +1,12 @@
 import dotenv from "dotenv";
 import type { NetworkName } from "./types.ts";
+import { parseNat } from "./amounts.js";
+import {
+    ValidationResult,
+    validateAddress,
+    validateContractAddress,
+    validateKeyHash,
+} from "@taquito/utils";
 
 dotenv.config();
 
@@ -10,8 +17,8 @@ interface NetworkConfig {
 }
 
 interface SeedAmount {
-    xtz: number;
-    token: number;
+    xtz: string;
+    token: string;
 }
 
 interface Config {
@@ -21,7 +28,7 @@ interface Config {
     tokenStandard: string; // e.g. "FA1.2" or "FA2"
     metadata_uri: string;
     token_metadata_uri: string;
-    tokenId: number; // Only for FA2
+    tokenId: string; // Only for FA2
     poolType: "base" | "mod", // "base" for no fee functionality, "mod" for fee functionality
     protocol_fee_bp?: number; // Protocol fee in basis points
     protocol_fee_recipient?: string; // Address to receive protocol fees
@@ -40,15 +47,19 @@ export const networks: Record<NetworkName, NetworkConfig> = {
     },
 };
 
-const poolType = getRequiredEnv("POOL_TYPE") as "base" | "mod";
+const poolTypeValue = getRequiredEnv("POOL_TYPE");
+if (poolTypeValue !== "base" && poolTypeValue !== "mod") {
+    throw new Error(`Invalid POOL_TYPE: ${poolTypeValue}. Use 'base' or 'mod'.`);
+}
+const poolType: "base" | "mod" = poolTypeValue;
 
 const config: Config = {
     tokenAddress: getRequiredEnv("TOKEN_ADDRESS"),
-    tokenId: getRequiredIntEnv("TOKEN_ID"),
+    tokenId: getRequiredNatEnv("TOKEN_ID"),
     tokenStandard: getRequiredEnv("TOKEN_STANDARD"),
     seedAmount: {
-        xtz: getRequiredIntEnv("SEED_XTZ"),
-        token: getRequiredIntEnv("SEED_TOKEN"),
+        xtz: getRequiredNatEnv("SEED_XTZ"),
+        token: getRequiredNatEnv("SEED_TOKEN"),
     },
     manager: getRequiredEnv("MANAGER"),
     metadata_uri: getRequiredEnv("METADATA_URI"),
@@ -63,8 +74,8 @@ const config: Config = {
 export interface FullConfig extends NetworkConfig, Config {
     privateKey: string;
     seedAmount: {
-        xtz: number;
-        token: number;
+        xtz: string;
+        token: string;
     };
 }
 
@@ -81,12 +92,28 @@ export function getConfig(networkName: NetworkName): FullConfig {
         );
     }
 
-    if (config.seedAmount.xtz === 0 || config.seedAmount.token === 0) {
+    if (config.seedAmount.xtz === "0" || config.seedAmount.token === "0") {
         throw new Error(`Seed amounts not configured properly. Set SEED_XTZ and SEED_TOKEN in .env file.`);
     }
 
     if (config.tokenStandard !== "FA1.2" && config.tokenStandard !== "FA2") {
         throw new Error(`Invalid token standard: ${config.tokenStandard}. Use 'FA1.2' or 'FA2'.`);
+    }
+
+    if (config.poolType === "mod" && config.protocol_fee_bp! > 1000) {
+        throw new Error("PROTOCOL_FEE_BP cannot exceed the contract cap of 1000 bp");
+    }
+
+    requireValidAddress(
+        validateContractAddress(config.tokenAddress),
+        "TOKEN_ADDRESS"
+    );
+    requireValidAddress(validateKeyHash(config.manager), "MANAGER");
+    if (config.protocol_fee_recipient) {
+        requireValidAddress(
+            validateAddress(config.protocol_fee_recipient),
+            "PROTOCOL_FEE_RECIPIENT"
+        );
     }
 
     return {
@@ -114,9 +141,22 @@ function getRequiredIntEnv(key: string, defaultValue?: number): number {
         if (defaultValue !== undefined) return defaultValue;
         throw new Error(`Required environment variable ${key} is not set`);
     }
-    const num = parseInt(value, 10);
-    if (isNaN(num)) {
-        throw new Error(`Environment variable ${key} must be a number, got: ${value}`);
+    if (!/^(0|[1-9][0-9]*)$/.test(value.trim())) {
+        throw new Error(`Environment variable ${key} must be a non-negative integer`);
+    }
+    const num = Number(value);
+    if (!Number.isSafeInteger(num)) {
+        throw new Error(`Environment variable ${key} exceeds JavaScript's safe integer range`);
     }
     return num;
+}
+
+function getRequiredNatEnv(key: string): string {
+    return parseNat(getRequiredEnv(key), key);
+}
+
+function requireValidAddress(result: ValidationResult, name: string): void {
+    if (result !== ValidationResult.VALID) {
+        throw new Error(`${name} is not a valid Tezos address`);
+    }
 }

--- a/dex/scripts/src/config.ts
+++ b/dex/scripts/src/config.ts
@@ -5,7 +5,6 @@ import {
     ValidationResult,
     validateAddress,
     validateContractAddress,
-    validateKeyHash,
 } from "@taquito/utils";
 
 dotenv.config();
@@ -30,8 +29,6 @@ interface Config {
     token_metadata_uri: string;
     tokenId: string; // Only for FA2
     poolType: "base" | "mod", // "base" for no fee functionality, "mod" for fee functionality
-    protocol_fee_bp?: number; // Protocol fee in basis points
-    protocol_fee_recipient?: string; // Address to receive protocol fees
 }
 
 export const networks: Record<NetworkName, NetworkConfig> = {
@@ -65,10 +62,6 @@ const config: Config = {
     metadata_uri: getRequiredEnv("METADATA_URI"),
     token_metadata_uri: getRequiredEnv("TOKEN_METADATA_URI"),
     poolType,
-    ...(poolType === "mod" && {
-        protocol_fee_bp: getRequiredIntEnv("PROTOCOL_FEE_BP"),
-        protocol_fee_recipient: getRequiredEnv("PROTOCOL_FEE_RECIPIENT"),
-    }),
 };
 
 export interface FullConfig extends NetworkConfig, Config {
@@ -100,21 +93,11 @@ export function getConfig(networkName: NetworkName): FullConfig {
         throw new Error(`Invalid token standard: ${config.tokenStandard}. Use 'FA1.2' or 'FA2'.`);
     }
 
-    if (config.poolType === "mod" && config.protocol_fee_bp! > 1000) {
-        throw new Error("PROTOCOL_FEE_BP cannot exceed the contract cap of 1000 bp");
-    }
-
     requireValidAddress(
         validateContractAddress(config.tokenAddress),
         "TOKEN_ADDRESS"
     );
-    requireValidAddress(validateKeyHash(config.manager), "MANAGER");
-    if (config.protocol_fee_recipient) {
-        requireValidAddress(
-            validateAddress(config.protocol_fee_recipient),
-            "PROTOCOL_FEE_RECIPIENT"
-        );
-    }
+    requireValidAddress(validateAddress(config.manager), "MANAGER");
 
     return {
         ...networkConfig,
@@ -133,22 +116,6 @@ function getRequiredEnv(key: string): string {
         throw new Error(`Required environment variable ${key} is not set or empty`);
     }
     return value;
-}
-
-function getRequiredIntEnv(key: string, defaultValue?: number): number {
-    const value = process.env[key];
-    if (!value || value.trim() === "") {
-        if (defaultValue !== undefined) return defaultValue;
-        throw new Error(`Required environment variable ${key} is not set`);
-    }
-    if (!/^(0|[1-9][0-9]*)$/.test(value.trim())) {
-        throw new Error(`Environment variable ${key} must be a non-negative integer`);
-    }
-    const num = Number(value);
-    if (!Number.isSafeInteger(num)) {
-        throw new Error(`Environment variable ${key} exceeds JavaScript's safe integer range`);
-    }
-    return num;
 }
 
 function getRequiredNatEnv(key: string): string {

--- a/dex/scripts/src/deploy.ts
+++ b/dex/scripts/src/deploy.ts
@@ -26,6 +26,7 @@ import {
     toSafeNumber,
 } from "./amounts.js";
 import { appendInitializationCalls } from "./initialization.js";
+import { verifyAtLeast, verifyEqual } from "./verification.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -308,14 +309,6 @@ function toNatString(value: unknown, field: string): string {
     return BigInt((value as { toString(): string }).toString()).toString();
 }
 
-function verifyEqual(actual: string, expected: string, field: string): void {
-    if (actual !== expected) {
-        throw new Error(
-            `Deployment verification failed for ${field}: expected ${expected}, got ${actual}`
-        );
-    }
-}
-
 async function verifyDeployment(
     tezos: TezosToolkit,
     dexAddress: string,
@@ -333,7 +326,12 @@ async function verifyDeployment(
     );
 
     verifyEqual(toNatString(dexStorage.xtzPool, "DEX xtzPool"), config.seedAmount.xtz, "DEX xtzPool");
-    verifyEqual(toNatString(dexStorage.tokenPool, "DEX tokenPool"), config.seedAmount.token, "DEX tokenPool");
+    const dexTokenPool = toNatString(dexStorage.tokenPool, "DEX tokenPool");
+    if (config.poolType === "mod") {
+        verifyAtLeast(dexTokenPool, config.seedAmount.token, "DEX tokenPool");
+    } else {
+        verifyEqual(dexTokenPool, config.seedAmount.token, "DEX tokenPool");
+    }
     verifyEqual(toNatString(dexStorage.lqtTotal, "DEX lqtTotal"), expectedLqtTotal, "DEX lqtTotal");
     verifyEqual(
         toNatString(lqtStorage.total_supply, "LQT total_supply"),
@@ -376,7 +374,11 @@ async function verifyDeployment(
         config.tokenStandard,
         config.tokenId
     );
-    verifyEqual(dexTokenBalance.toString(), config.seedAmount.token, "DEX token balance");
+    if (config.poolType === "mod") {
+        verifyAtLeast(dexTokenBalance.toString(), dexTokenPool, "DEX token balance");
+    } else {
+        verifyEqual(dexTokenBalance.toString(), config.seedAmount.token, "DEX token balance");
+    }
 
     console.log("✓ On-chain addresses, reserves, balances, supply, and activation verified");
 }

--- a/dex/scripts/src/deploy.ts
+++ b/dex/scripts/src/deploy.ts
@@ -20,6 +20,11 @@ import {
 import { Parser } from "@taquito/michel-codec";
 import { MichelsonMap, Schema } from "@taquito/michelson-encoder";
 import { getTokenBalance, prepareTokenTransfer } from "./util.js";
+import {
+    calculateInitialLqt,
+    formatMutez,
+    toSafeNumber,
+} from "./amounts.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -48,7 +53,10 @@ async function deployLQT(tezos: TezosToolkit, dexAddress: string, config: FullCo
     const parser = new Parser();
     const parsedMichelson = parser.parseScript(lqtCode);
 
-    let lqtTotal = Math.floor(Math.sqrt(+config.seedAmount.xtz * +config.seedAmount.token));
+    const lqtTotal = calculateInitialLqt(
+        config.seedAmount.xtz,
+        config.seedAmount.token
+    );
 
     let metadata: MichelsonMap<string, string> = new MichelsonMap();
     metadata.set("", Buffer.from(config.metadata_uri!).toString("hex"));
@@ -58,7 +66,7 @@ async function deployLQT(tezos: TezosToolkit, dexAddress: string, config: FullCo
     token_info.set("", Buffer.from(config.token_metadata_uri!).toString("hex"));
     token_metadata.set(0, { token_id: 0, token_info });
 
-    let tokens: MichelsonMap<string, number> = new MichelsonMap();
+    let tokens: MichelsonMap<string, string> = new MichelsonMap();
     tokens.set(config.manager, lqtTotal);
 
     const storageSchema = new Schema(lqtStorageType);
@@ -95,7 +103,10 @@ async function deployDEX(tezos: TezosToolkit, config: FullConfig): Promise<strin
     const parser = new Parser();
     const parsedMichelson = parser.parseScript(dexCode);
 
-    const lqtTotal = Math.floor(Math.sqrt(+config.seedAmount.xtz * +config.seedAmount.token));
+    const lqtTotal = calculateInitialLqt(
+        config.seedAmount.xtz,
+        config.seedAmount.token
+    );
 
     const storageSchema = new Schema(
         config.poolType === "mod"
@@ -103,9 +114,13 @@ async function deployDEX(tezos: TezosToolkit, config: FullConfig): Promise<strin
             : (config.tokenStandard === "FA2" ? dexStorageTypeFA2 : dexStorageType)
     );
     const dexStorage: DexStorage = {
-        tokenPool: 0,
-        xtzPool: 0,
+        tokenPool: "0",
+        xtzPool: "0",
         lqtTotal,
+        ...(config.poolType === "mod" && {
+            active: false,
+            activationPending: false,
+        }),
         selfIsUpdatingTokenPool: false,
         freezeBaker: false,
         manager: config.manager,
@@ -116,8 +131,8 @@ async function deployDEX(tezos: TezosToolkit, config: FullConfig): Promise<strin
         ...(config.poolType === "mod" && {
             protocol_fee_bp: config.protocol_fee_bp!,
             protocol_fee_recipient: config.protocol_fee_recipient!,
-            accumulated_protocol_fee_xtz: 0,
-            accumulated_protocol_fee_token: 0,
+            accumulated_protocol_fee_xtz: "0",
+            accumulated_protocol_fee_token: "0",
         }),
     };
     const michelsonData = storageSchema.Encode(dexStorage);
@@ -134,18 +149,18 @@ async function deployDEX(tezos: TezosToolkit, config: FullConfig): Promise<strin
     return contract.address;
 }
 
-async function setLQTAddress(tezos: TezosToolkit, dexAddress: string, lqtAddress: string): Promise<void> {
-    console.log("\nSetting LQT address in DEX...");
-
-    const dex = await tezos.contract.at(dexAddress);
-    const op = await dex.methodsObject.setLqtAddress(lqtAddress).send();
-
-    console.log(`SetLqtAddress operation: ${op.hash}`);
-    await op.confirmation(1);
-    console.log("✓ LQT address set");
-}
-
-function saveDeploymentInfo(network: NetworkName, dexAddress: string, lqtAddress: string, tokenAddress: string): void {
+function saveDeploymentInfo(
+    network: NetworkName,
+    dexAddress: string,
+    lqtAddress: string,
+    tokenAddress: string,
+    initializationOperation: string,
+    config: FullConfig
+): void {
+    const lqtTotal = calculateInitialLqt(
+        config.seedAmount.xtz,
+        config.seedAmount.token
+    );
     const deploymentInfo = {
         network: network,
         timestamp: new Date().toISOString(),
@@ -153,6 +168,17 @@ function saveDeploymentInfo(network: NetworkName, dexAddress: string, lqtAddress
             dex: dexAddress,
             lqt: lqtAddress,
             token: tokenAddress,
+        },
+        initializationOperation,
+        configuration: {
+            manager: config.manager,
+            tokenStandard: config.tokenStandard,
+            tokenId: config.tokenId,
+            poolType: config.poolType,
+            seedAmount: config.seedAmount,
+            lqtTotal,
+            protocolFeeBp: config.protocol_fee_bp,
+            protocolFeeRecipient: config.protocol_fee_recipient,
         },
     };
 
@@ -176,15 +202,16 @@ async function checkBalance(config: FullConfig, tezos: TezosToolkit): Promise<vo
     const pkh = await tezos.signer.publicKeyHash();
     const balance = await tezos.tz.getBalance(pkh);
 
-    const seedXtz = config.seedAmount.xtz;
-    const seedToken = config.seedAmount.token;
+    const seedXtz = BigInt(config.seedAmount.xtz);
+    const seedToken = BigInt(config.seedAmount.token);
+    const balanceMutez = BigInt(balance.toString());
 
     // Check if balance is sufficient (seed amount + 2 XTZ buffer for fees)
-    const requiredBalance = seedXtz + 2_000_000;
-    if (balance.toNumber() < requiredBalance) {
+    const requiredBalance = seedXtz + 2_000_000n;
+    if (balanceMutez < requiredBalance) {
         throw new Error(
-            `Insufficient XTZ balance (${balance.toNumber()} XTZ). ` +
-            `Required: ${requiredBalance} XTZ. ` +
+            `Insufficient XTZ balance (${balanceMutez} mutez). ` +
+            `Required: ${requiredBalance} mutez. ` +
             `Please fund the account ${pkh} on ${config.name} network.`
         );
     }
@@ -207,56 +234,156 @@ async function checkBalance(config: FullConfig, tezos: TezosToolkit): Promise<vo
     }
 
     console.log(`Balance check passed:`);
-    console.log(`  XTZ: ${balance.toNumber() / 1_000_000} / ${requiredBalance / 1_000_000} required`);
+    console.log(
+        `  XTZ: ${formatMutez(balanceMutez.toString())} / ` +
+        `${formatMutez(requiredBalance.toString())} required`
+    );
     console.log(`  Tokens: ${tokenBalance} / ${seedToken} required`);
 }
 
-async function updateXtzPool(tezos: TezosToolkit, dex_address: string, config: FullConfig) {
-    console.log("\nUpdating XTZ pool...");
-    console.log(`Sending ${config.seedAmount.xtz} XTZ to DEX at ${dex_address}`);
-
-    const contract = await tezos.contract.at(dex_address);
-    const op = await contract.methodsObject.default().send({
-        amount: +config.seedAmount.xtz,
-        mutez: true,
-    });
-
-    console.log(`XTZ pool update operation: ${op.hash}`);
-    await op.confirmation(1);
-    console.log("✓ XTZ pool updated successfully");
-}
-
-async function updateTokenPool(tezos: TezosToolkit, dex_address: string, config: FullConfig) {
-    console.log("\nUpdating Token pool...");
+async function initializePool(
+    tezos: TezosToolkit,
+    dexAddress: string,
+    lqtAddress: string,
+    config: FullConfig
+): Promise<string> {
+    console.log("\nInitializing pool atomically...");
     const managerAddress = await tezos.signer.publicKeyHash();
-    console.log(`Transferring ${config.seedAmount.token} tokens from ${managerAddress} to DEX`);
 
-    const dex_contract = await tezos.contract.at(dex_address);
-    const token_contract = await tezos.contract.at(config.tokenAddress);
+    if (managerAddress !== config.manager) {
+        throw new Error(
+            `The deployment signer (${managerAddress}) must match MANAGER (${config.manager}) ` +
+            "to initialize the pool."
+        );
+    }
+
+    const dexContract = await tezos.contract.at(dexAddress);
+    const tokenContract = await tezos.contract.at(config.tokenAddress);
 
     const transferParams = prepareTokenTransfer(config.tokenStandard, {
         from: managerAddress,
-        to: dex_address,
+        to: dexAddress,
         amount: config.seedAmount.token,
         tokenId: config.tokenStandard === "FA2" ? config.tokenId : undefined,
     });
 
-    // First transfer token to DEX contract
-    const transferOp = await token_contract.methodsObject
-        .transfer(transferParams.transfer)
-        .send();
+    let batch = tezos.contract
+        .batch()
+        .withContractCall(dexContract.methodsObject.setLqtAddress(lqtAddress))
+        .withContractCall(dexContract.methodsObject.default(), {
+            amount: toSafeNumber(config.seedAmount.xtz, "SEED_XTZ"),
+            mutez: true,
+        })
+        .withContractCall(tokenContract.methodsObject.transfer(transferParams.transfer))
+        .withContractCall(dexContract.methodsObject.updateTokenPool());
 
-    console.log(`Token transfer operation: ${transferOp.hash}`);
-    await transferOp.confirmation(1);
-    console.log("✓ Tokens transferred to DEX");
+    if (config.poolType === "mod") {
+        const lqtTotal = calculateInitialLqt(
+            config.seedAmount.xtz,
+            config.seedAmount.token
+        );
+        batch = batch.withContractCall(
+            dexContract.methodsObject.activate({
+                expectedXtzPool: config.seedAmount.xtz,
+                expectedTokenPool: config.seedAmount.token,
+                expectedLqtTotal: lqtTotal,
+            })
+        );
+    }
 
-    // Then update token pool in DEX
-    console.log("Calling updateTokenPool on DEX...");
-    const updateOp = await dex_contract.methodsObject.updateTokenPool().send();
+    const op = await batch.send();
+    console.log(`Pool initialization operation: ${op.hash}`);
+    await op.confirmation(1);
+    console.log(
+        config.poolType === "mod"
+            ? "✓ Pool funded, reserves synchronized, and activated"
+            : "✓ Pool funded and reserves synchronized"
+    );
+    return op.hash;
+}
 
-    console.log(`Token pool update operation: ${updateOp.hash}`);
-    await updateOp.confirmation(1);
-    console.log("✓ Token pool updated successfully");
+function toNatString(value: unknown, field: string): string {
+    if (
+        value === null
+        || value === undefined
+        || typeof (value as { toString?: unknown }).toString !== "function"
+    ) {
+        throw new Error(`Missing numeric field ${field} during deployment verification`);
+    }
+    return BigInt((value as { toString(): string }).toString()).toString();
+}
+
+function verifyEqual(actual: string, expected: string, field: string): void {
+    if (actual !== expected) {
+        throw new Error(
+            `Deployment verification failed for ${field}: expected ${expected}, got ${actual}`
+        );
+    }
+}
+
+async function verifyDeployment(
+    tezos: TezosToolkit,
+    dexAddress: string,
+    lqtAddress: string,
+    config: FullConfig
+): Promise<void> {
+    console.log("\nVerifying initialized on-chain state...");
+    const dexContract = await tezos.contract.at(dexAddress);
+    const lqtContract = await tezos.contract.at(lqtAddress);
+    const dexStorage: any = await dexContract.storage();
+    const lqtStorage: any = await lqtContract.storage();
+    const expectedLqtTotal = calculateInitialLqt(
+        config.seedAmount.xtz,
+        config.seedAmount.token
+    );
+
+    verifyEqual(toNatString(dexStorage.xtzPool, "DEX xtzPool"), config.seedAmount.xtz, "DEX xtzPool");
+    verifyEqual(toNatString(dexStorage.tokenPool, "DEX tokenPool"), config.seedAmount.token, "DEX tokenPool");
+    verifyEqual(toNatString(dexStorage.lqtTotal, "DEX lqtTotal"), expectedLqtTotal, "DEX lqtTotal");
+    verifyEqual(
+        toNatString(lqtStorage.total_supply, "LQT total_supply"),
+        expectedLqtTotal,
+        "LQT total_supply"
+    );
+
+    if (dexStorage.manager !== config.manager) {
+        throw new Error("Deployment verification failed for DEX manager");
+    }
+    if (dexStorage.tokenAddress !== config.tokenAddress) {
+        throw new Error("Deployment verification failed for DEX token address");
+    }
+    if (dexStorage.lqtAddress !== lqtAddress) {
+        throw new Error("Deployment verification failed for DEX LQT address");
+    }
+    if (lqtStorage.admin !== dexAddress) {
+        throw new Error("Deployment verification failed for LQT administrator");
+    }
+    if (
+        config.tokenStandard === "FA2"
+        && toNatString(dexStorage.tokenId, "DEX tokenId") !== config.tokenId
+    ) {
+        throw new Error("Deployment verification failed for DEX token ID");
+    }
+    if (
+        config.poolType === "mod"
+        && (dexStorage.active !== true || dexStorage.activationPending !== false)
+    ) {
+        throw new Error("Deployment verification failed for pool activation state");
+    }
+
+    const dexXtzBalance = await tezos.tz.getBalance(dexAddress);
+    verifyEqual(dexXtzBalance.toString(), config.seedAmount.xtz, "DEX XTZ balance");
+
+    const dexTokenBalance = await getTokenBalance(
+        tezos,
+        config.tokenAddress,
+        dexAddress,
+        config.tokenStandard,
+        config.tokenId
+    );
+    verifyEqual(dexTokenBalance.toString(), config.seedAmount.token, "DEX token balance");
+
+    console.log("✓ On-chain addresses, reserves, balances, supply, and activation verified");
 }
 
 async function main(): Promise<void> {
@@ -277,7 +404,12 @@ async function main(): Promise<void> {
 
     await checkBalance(config, tezos);
 
-    const managerAddress = config.manager || pkh;
+    const managerAddress = config.manager;
+    if (managerAddress !== pkh) {
+        throw new Error(
+            `MANAGER (${managerAddress}) must match the deployment signer (${pkh}).`
+        );
+    }
 
     console.log(`Token: ${config.tokenAddress}`);
     console.log(`Manager: ${managerAddress}`);
@@ -293,12 +425,17 @@ async function main(): Promise<void> {
         const dexAddress = await deployDEX(tezos, config);
         const lqtAddress = await deployLQT(tezos, dexAddress, config);
         await new Promise((resolve) => setTimeout(resolve, 5000));
-        await setLQTAddress(tezos, dexAddress, lqtAddress);
-        await new Promise((resolve) => setTimeout(resolve, 5000));
-        await updateXtzPool(tezos, dexAddress, config);
-        await new Promise((resolve) => setTimeout(resolve, 5000));
-        await updateTokenPool(tezos, dexAddress, config);
-        saveDeploymentInfo(networkName, dexAddress, lqtAddress, config.tokenAddress);
+        const initializationOperation =
+            await initializePool(tezos, dexAddress, lqtAddress, config);
+        await verifyDeployment(tezos, dexAddress, lqtAddress, config);
+        saveDeploymentInfo(
+            networkName,
+            dexAddress,
+            lqtAddress,
+            config.tokenAddress,
+            initializationOperation,
+            config
+        );
 
         console.log("\nDeployment complete");
         console.log(`DEX: ${dexAddress}`);

--- a/dex/scripts/src/deploy.ts
+++ b/dex/scripts/src/deploy.ts
@@ -25,6 +25,7 @@ import {
     formatMutez,
     toSafeNumber,
 } from "./amounts.js";
+import { appendInitializationCalls } from "./initialization.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -92,7 +93,11 @@ async function deployLQT(tezos: TezosToolkit, dexAddress: string, config: FullCo
     return contract.address;
 }
 
-async function deployDEX(tezos: TezosToolkit, config: FullConfig): Promise<string> {
+async function deployDEX(
+    tezos: TezosToolkit,
+    config: FullConfig,
+    deploymentManager: string
+): Promise<string> {
     console.log("\nDeploying DEX contract...");
 
     const contractFile =
@@ -123,14 +128,15 @@ async function deployDEX(tezos: TezosToolkit, config: FullConfig): Promise<strin
         }),
         selfIsUpdatingTokenPool: false,
         freezeBaker: false,
-        manager: config.manager,
+        // The signer manages only the inactive initialization window. The
+        // initialization batch transfers management to config.manager.
+        manager: deploymentManager,
         tokenAddress: config.tokenAddress,
         lqtAddress: "tz1Ke2h7sDdakHJQh8WX4Z372du1KChsksyU",
         tokenId: config.tokenStandard === "FA2" ? config.tokenId : undefined,
 
         ...(config.poolType === "mod" && {
-            protocol_fee_bp: config.protocol_fee_bp!,
-            protocol_fee_recipient: config.protocol_fee_recipient!,
+            protocol_fee_recipient: config.manager,
             accumulated_protocol_fee_xtz: "0",
             accumulated_protocol_fee_token: "0",
         }),
@@ -155,6 +161,7 @@ function saveDeploymentInfo(
     lqtAddress: string,
     tokenAddress: string,
     initializationOperation: string,
+    deploymentManager: string,
     config: FullConfig
 ): void {
     const lqtTotal = calculateInitialLqt(
@@ -172,13 +179,16 @@ function saveDeploymentInfo(
         initializationOperation,
         configuration: {
             manager: config.manager,
+            deploymentManager,
             tokenStandard: config.tokenStandard,
             tokenId: config.tokenId,
             poolType: config.poolType,
             seedAmount: config.seedAmount,
             lqtTotal,
-            protocolFeeBp: config.protocol_fee_bp,
-            protocolFeeRecipient: config.protocol_fee_recipient,
+            lpFeeBp: config.poolType === "mod" ? 25 : undefined,
+            protocolFeeBp: config.poolType === "mod" ? 5 : undefined,
+            totalFeeBp: config.poolType === "mod" ? 30 : undefined,
+            protocolFeeRecipient: config.poolType === "mod" ? config.manager : undefined,
         },
     };
 
@@ -250,13 +260,6 @@ async function initializePool(
     console.log("\nInitializing pool atomically...");
     const managerAddress = await tezos.signer.publicKeyHash();
 
-    if (managerAddress !== config.manager) {
-        throw new Error(
-            `The deployment signer (${managerAddress}) must match MANAGER (${config.manager}) ` +
-            "to initialize the pool."
-        );
-    }
-
     const dexContract = await tezos.contract.at(dexAddress);
     const tokenContract = await tezos.contract.at(config.tokenAddress);
 
@@ -267,37 +270,29 @@ async function initializePool(
         tokenId: config.tokenStandard === "FA2" ? config.tokenId : undefined,
     });
 
-    let batch = tezos.contract
-        .batch()
-        .withContractCall(dexContract.methodsObject.setLqtAddress(lqtAddress))
-        .withContractCall(dexContract.methodsObject.default(), {
-            amount: toSafeNumber(config.seedAmount.xtz, "SEED_XTZ"),
-            mutez: true,
-        })
-        .withContractCall(tokenContract.methodsObject.transfer(transferParams.transfer))
-        .withContractCall(dexContract.methodsObject.updateTokenPool());
-
-    if (config.poolType === "mod") {
-        const lqtTotal = calculateInitialLqt(
+    const batch = appendInitializationCalls({
+        batch: tezos.contract.batch(),
+        dexContract,
+        tokenContract,
+        tokenTransfer: transferParams.transfer,
+        lqtAddress,
+        seedXtz: toSafeNumber(config.seedAmount.xtz, "SEED_XTZ"),
+        seedToken: config.seedAmount.token,
+        lqtTotal: calculateInitialLqt(
             config.seedAmount.xtz,
             config.seedAmount.token
-        );
-        batch = batch.withContractCall(
-            dexContract.methodsObject.activate({
-                expectedXtzPool: config.seedAmount.xtz,
-                expectedTokenPool: config.seedAmount.token,
-                expectedLqtTotal: lqtTotal,
-            })
-        );
-    }
+        ),
+        poolType: config.poolType,
+        finalManager: config.manager,
+    });
 
     const op = await batch.send();
     console.log(`Pool initialization operation: ${op.hash}`);
     await op.confirmation(1);
     console.log(
         config.poolType === "mod"
-            ? "✓ Pool funded, reserves synchronized, and activated"
-            : "✓ Pool funded and reserves synchronized"
+            ? "✓ Pool funded, activated, and transferred to final manager"
+            : "✓ Pool funded and transferred to final manager"
     );
     return op.hash;
 }
@@ -404,15 +399,9 @@ async function main(): Promise<void> {
 
     await checkBalance(config, tezos);
 
-    const managerAddress = config.manager;
-    if (managerAddress !== pkh) {
-        throw new Error(
-            `MANAGER (${managerAddress}) must match the deployment signer (${pkh}).`
-        );
-    }
-
     console.log(`Token: ${config.tokenAddress}`);
-    console.log(`Manager: ${managerAddress}`);
+    console.log(`Temporary deployment manager: ${pkh}`);
+    console.log(`Final manager and fee recipient: ${config.manager}`);
     console.log(`Seed XTZ: ${config.seedAmount.xtz} mutez`);
     console.log(`Seed Tokens: ${config.seedAmount.token} tokens`);
 
@@ -422,7 +411,7 @@ async function main(): Promise<void> {
     }
 
     try {
-        const dexAddress = await deployDEX(tezos, config);
+        const dexAddress = await deployDEX(tezos, config, pkh);
         const lqtAddress = await deployLQT(tezos, dexAddress, config);
         await new Promise((resolve) => setTimeout(resolve, 5000));
         const initializationOperation =
@@ -434,6 +423,7 @@ async function main(): Promise<void> {
             lqtAddress,
             config.tokenAddress,
             initializationOperation,
+            pkh,
             config
         );
 

--- a/dex/scripts/src/initialization.test.ts
+++ b/dex/scripts/src/initialization.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { appendInitializationCalls, type BatchLike } from "./initialization.js";
+
+function methodRecorder(calls: Array<{ method: string; value?: unknown }>) {
+    return new Proxy({}, {
+        get: (_target, method: string) => (value?: unknown) => {
+            calls.push({ method, value });
+            return method;
+        },
+    }) as Record<string, (...args: any[]) => unknown>;
+}
+
+test("modified initialization hands management off only after activation", () => {
+    const methodCalls: Array<{ method: string; value?: unknown }> = [];
+    const batchCalls: unknown[] = [];
+    const batch: BatchLike = {
+        withContractCall(call: unknown) {
+            batchCalls.push(call);
+            return this;
+        },
+    };
+
+    appendInitializationCalls({
+        batch,
+        dexContract: { methodsObject: methodRecorder(methodCalls) },
+        tokenContract: { methodsObject: methodRecorder(methodCalls) },
+        tokenTransfer: { transfer: "seed" },
+        lqtAddress: "KT1-lqt",
+        seedXtz: 20_000_000,
+        seedToken: "10000000",
+        lqtTotal: "14142135",
+        poolType: "mod",
+        finalManager: "KT1-multisig",
+    });
+
+    assert.deepEqual(
+        methodCalls.map(({ method }) => method),
+        ["setLqtAddress", "default", "transfer", "updateTokenPool", "activate", "setManager"]
+    );
+    assert.equal(methodCalls.at(-1)?.value, "KT1-multisig");
+    assert.deepEqual(methodCalls.at(-2)?.value, {
+        expectedXtzPool: "20000000",
+        expectedTokenPool: "10000000",
+        expectedLqtTotal: "14142135",
+    });
+    assert.deepEqual(batchCalls, [
+        "setLqtAddress",
+        "default",
+        "transfer",
+        "updateTokenPool",
+        "activate",
+        "setManager",
+    ]);
+});
+
+test("base initialization also ends with the final manager handoff", () => {
+    const methodCalls: Array<{ method: string; value?: unknown }> = [];
+    const batch: BatchLike = {
+        withContractCall() {
+            return this;
+        },
+    };
+
+    appendInitializationCalls({
+        batch,
+        dexContract: { methodsObject: methodRecorder(methodCalls) },
+        tokenContract: { methodsObject: methodRecorder(methodCalls) },
+        tokenTransfer: [],
+        lqtAddress: "KT1-lqt",
+        seedXtz: 1,
+        seedToken: "1",
+        lqtTotal: "1",
+        poolType: "base",
+        finalManager: "KT1-multisig",
+    });
+
+    assert.deepEqual(
+        methodCalls.map(({ method }) => method),
+        ["setLqtAddress", "default", "transfer", "updateTokenPool", "setManager"]
+    );
+});

--- a/dex/scripts/src/initialization.ts
+++ b/dex/scripts/src/initialization.ts
@@ -49,6 +49,8 @@ export function appendInitializationCalls<TBatch extends BatchLike>({
         next = next.withContractCall(
             dexContract.methodsObject.activate({
                 expectedXtzPool: seedXtz.toString(),
+                // The contract treats this as the minimum configured seed.
+                // Any tokens donated before updateTokenPool remain in the pool.
                 expectedTokenPool: seedToken,
                 expectedLqtTotal: lqtTotal,
             })

--- a/dex/scripts/src/initialization.ts
+++ b/dex/scripts/src/initialization.ts
@@ -1,0 +1,61 @@
+export interface BatchLike {
+    withContractCall(call: unknown, options?: { amount: number; mutez: true }): BatchLike;
+}
+
+interface ContractLike {
+    methodsObject: Record<string, (...args: any[]) => unknown>;
+}
+
+interface InitializationCalls<TBatch extends BatchLike> {
+    batch: TBatch;
+    dexContract: ContractLike;
+    tokenContract: ContractLike;
+    tokenTransfer: unknown;
+    lqtAddress: string;
+    seedXtz: number;
+    seedToken: string;
+    lqtTotal: string;
+    poolType: "base" | "mod";
+    finalManager: string;
+}
+
+/**
+ * Appends the complete initialization sequence. The final manager handoff is
+ * deliberately last, keeping the deployment signer in control only until all
+ * reserve and activation checks have succeeded in the same operation group.
+ */
+export function appendInitializationCalls<TBatch extends BatchLike>({
+    batch,
+    dexContract,
+    tokenContract,
+    tokenTransfer,
+    lqtAddress,
+    seedXtz,
+    seedToken,
+    lqtTotal,
+    poolType,
+    finalManager,
+}: InitializationCalls<TBatch>): TBatch {
+    let next = batch
+        .withContractCall(dexContract.methodsObject.setLqtAddress(lqtAddress))
+        .withContractCall(dexContract.methodsObject.default(), {
+            amount: seedXtz,
+            mutez: true,
+        })
+        .withContractCall(tokenContract.methodsObject.transfer(tokenTransfer))
+        .withContractCall(dexContract.methodsObject.updateTokenPool());
+
+    if (poolType === "mod") {
+        next = next.withContractCall(
+            dexContract.methodsObject.activate({
+                expectedXtzPool: seedXtz.toString(),
+                expectedTokenPool: seedToken,
+                expectedLqtTotal: lqtTotal,
+            })
+        );
+    }
+
+    return next.withContractCall(
+        dexContract.methodsObject.setManager(finalManager)
+    ) as TBatch;
+}

--- a/dex/scripts/src/schema.test.ts
+++ b/dex/scripts/src/schema.test.ts
@@ -49,7 +49,6 @@ test("deployment schemas preserve arbitrary-precision storage integers", () => {
         tokenAddress: token,
         tokenId: exactTokenId,
         lqtAddress: manager,
-        protocol_fee_bp: 5,
         protocol_fee_recipient: manager,
         accumulated_protocol_fee_xtz: "0",
         accumulated_protocol_fee_token: "0",

--- a/dex/scripts/src/schema.test.ts
+++ b/dex/scripts/src/schema.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+import { Parser } from "@taquito/michel-codec";
+import { MichelsonMap, Schema } from "@taquito/michelson-encoder";
+import {
+    dexStorageTypeFA2Mod,
+    dexStorageTypeMod,
+    lqtStorageType,
+} from "./types.js";
+
+const parser = new Parser();
+
+function compiledStorageType(filename: string): object {
+    const source = fs.readFileSync(
+        new URL(`../../compiled_contracts/${filename}`, import.meta.url),
+        "utf8"
+    );
+    const script = parser.parseScript(source);
+    const storage = script?.find(
+        (expression) => "prim" in expression && expression.prim === "storage"
+    );
+    if (!storage || !("args" in storage) || !storage.args?.[0]) {
+        throw new Error(`Compiled contract ${filename} has no storage type`);
+    }
+    return JSON.parse(JSON.stringify(storage.args[0])) as object;
+}
+
+test("deployment schemas match the compiled modified contracts", () => {
+    assert.deepEqual(compiledStorageType("pool_mod.tz"), dexStorageTypeMod);
+    assert.deepEqual(compiledStorageType("pool_fa2_mod.tz"), dexStorageTypeFA2Mod);
+});
+
+test("deployment schemas preserve arbitrary-precision storage integers", () => {
+    const manager = "tz1Ke2h7sDdakHJQh8WX4Z372du1KChsksyU";
+    const token = "KT1RJ6PbjHpwc3M5rw5s2Nbmefwbuwbdxton";
+    const exactLqtTotal = "500000000000000000";
+    const exactTokenId = "9007199254740993";
+
+    const dexStorage = new Schema(dexStorageTypeFA2Mod).Encode({
+        tokenPool: "0",
+        xtzPool: "0",
+        lqtTotal: exactLqtTotal,
+        active: false,
+        activationPending: false,
+        selfIsUpdatingTokenPool: false,
+        freezeBaker: false,
+        manager,
+        tokenAddress: token,
+        tokenId: exactTokenId,
+        lqtAddress: manager,
+        protocol_fee_bp: 5,
+        protocol_fee_recipient: manager,
+        accumulated_protocol_fee_xtz: "0",
+        accumulated_protocol_fee_token: "0",
+    });
+
+    const tokens = new MichelsonMap<string, string>();
+    tokens.set(manager, exactLqtTotal);
+    const lqtStorage = new Schema(lqtStorageType).Encode({
+        tokens,
+        allowances: new MichelsonMap(),
+        admin: token,
+        total_supply: exactLqtTotal,
+        metadata: new MichelsonMap(),
+        token_metadata: new MichelsonMap(),
+    });
+
+    const encoded = JSON.stringify([dexStorage, lqtStorage]);
+    assert.match(encoded, new RegExp(exactLqtTotal));
+    assert.match(encoded, new RegExp(exactTokenId));
+});

--- a/dex/scripts/src/types.ts
+++ b/dex/scripts/src/types.ts
@@ -19,15 +19,21 @@ export interface DeploymentInfo {
 }
 
 export interface DexStorage {
-  tokenPool: number;
-  xtzPool: number;
-  lqtTotal: number;
+  tokenPool: string;
+  xtzPool: string;
+  lqtTotal: string;
+  active?: boolean; // Modified pools only
+  activationPending?: boolean; // Modified pools only
   tokenAddress: string;
   lqtAddress: string;
   selfIsUpdatingTokenPool: boolean;
   freezeBaker: boolean;
   manager: string;
-  tokenId?: number; // Only for FA2
+  tokenId?: string; // Only for FA2
+  protocol_fee_bp?: number; // Modified pools only
+  protocol_fee_recipient?: string; // Modified pools only
+  accumulated_protocol_fee_xtz?: string; // Modified pools only
+  accumulated_protocol_fee_token?: string; // Modified pools only
 }
 
 export type TokenInfo = MichelsonMap<string, string>; // Map<string, bytes>
@@ -40,10 +46,10 @@ export interface TokenMetadataValue {
 export type TokenMetadata = MichelsonMap<number, TokenMetadataValue>;
 
 export interface LqtStorage {
-  tokens: MichelsonMap<string, number>;
+  tokens: MichelsonMap<string, string>;
   allowances: MichelsonMap<string, MichelsonMap<string, number>>;
   admin: string;
-  total_supply: number;
+  total_supply: string;
   metadata: MichelsonMap<string, string>;
   token_metadata: TokenMetadata;
 }
@@ -53,8 +59,8 @@ export type NetworkName = "testnet" | "mainnet";
 export type TransferParams = {
   from: string;
   to: string;
-  amount: number;
-  tokenId?: number; // For FA2 tokens
+  amount: string;
+  tokenId?: string; // For FA2 tokens
 };
 
 
@@ -199,36 +205,48 @@ export const dexStorageTypeMod = {
             {
               prim: 'pair',
               args: [
-                { prim: 'bool', annots: ['%selfIsUpdatingTokenPool'] },
+                { prim: 'bool', annots: ['%active'] },
                 {
                   prim: 'pair',
                   args: [
-                    { prim: 'bool', annots: ['%freezeBaker'] },
+                    { prim: 'bool', annots: ['%activationPending'] },
                     {
                       prim: 'pair',
                       args: [
-                        { prim: 'address', annots: ['%manager'] },
+                        { prim: 'bool', annots: ['%selfIsUpdatingTokenPool'] },
                         {
                           prim: 'pair',
                           args: [
-                            { prim: 'address', annots: ['%tokenAddress'] },
+                            { prim: 'bool', annots: ['%freezeBaker'] },
                             {
                               prim: 'pair',
                               args: [
-                                { prim: 'address', annots: ['%lqtAddress'] },
+                                { prim: 'address', annots: ['%manager'] },
                                 {
                                   prim: 'pair',
                                   args: [
-                                    { prim: 'nat', annots: ['%protocol_fee_bp'] },
+                                    { prim: 'address', annots: ['%tokenAddress'] },
                                     {
                                       prim: 'pair',
                                       args: [
-                                        { prim: 'address', annots: ['%protocol_fee_recipient'] },
+                                        { prim: 'address', annots: ['%lqtAddress'] },
                                         {
                                           prim: 'pair',
                                           args: [
-                                            { prim: 'mutez', annots: ['%accumulated_protocol_fee_xtz'] },
-                                            { prim: 'nat', annots: ['%accumulated_protocol_fee_token'] }
+                                            { prim: 'nat', annots: ['%protocol_fee_bp'] },
+                                            {
+                                              prim: 'pair',
+                                              args: [
+                                                { prim: 'address', annots: ['%protocol_fee_recipient'] },
+                                                {
+                                                  prim: 'pair',
+                                                  args: [
+                                                    { prim: 'mutez', annots: ['%accumulated_protocol_fee_xtz'] },
+                                                    { prim: 'nat', annots: ['%accumulated_protocol_fee_token'] }
+                                                  ]
+                                                }
+                                              ]
+                                            }
                                           ]
                                         }
                                       ]
@@ -267,40 +285,52 @@ export const dexStorageTypeFA2Mod = {
             {
               prim: 'pair',
               args: [
-                { prim: 'bool', annots: ['%selfIsUpdatingTokenPool'] },
+                { prim: 'bool', annots: ['%active'] },
                 {
                   prim: 'pair',
                   args: [
-                    { prim: 'bool', annots: ['%freezeBaker'] },
+                    { prim: 'bool', annots: ['%activationPending'] },
                     {
                       prim: 'pair',
                       args: [
-                        { prim: 'address', annots: ['%manager'] },
+                        { prim: 'bool', annots: ['%selfIsUpdatingTokenPool'] },
                         {
                           prim: 'pair',
                           args: [
-                            { prim: 'address', annots: ['%tokenAddress'] },
+                            { prim: 'bool', annots: ['%freezeBaker'] },
                             {
                               prim: 'pair',
                               args: [
-                                { prim: 'nat', annots: ['%tokenId'] },
+                                { prim: 'address', annots: ['%manager'] },
                                 {
                                   prim: 'pair',
                                   args: [
-                                    { prim: 'address', annots: ['%lqtAddress'] },
+                                    { prim: 'address', annots: ['%tokenAddress'] },
                                     {
                                       prim: 'pair',
                                       args: [
-                                        { prim: 'nat', annots: ['%protocol_fee_bp'] },
+                                        { prim: 'nat', annots: ['%tokenId'] },
                                         {
                                           prim: 'pair',
                                           args: [
-                                            { prim: 'address', annots: ['%protocol_fee_recipient'] },
+                                            { prim: 'address', annots: ['%lqtAddress'] },
                                             {
                                               prim: 'pair',
                                               args: [
-                                                { prim: 'mutez', annots: ['%accumulated_protocol_fee_xtz'] },
-                                                { prim: 'nat', annots: ['%accumulated_protocol_fee_token'] }
+                                                { prim: 'nat', annots: ['%protocol_fee_bp'] },
+                                                {
+                                                  prim: 'pair',
+                                                  args: [
+                                                    { prim: 'address', annots: ['%protocol_fee_recipient'] },
+                                                    {
+                                                      prim: 'pair',
+                                                      args: [
+                                                        { prim: 'mutez', annots: ['%accumulated_protocol_fee_xtz'] },
+                                                        { prim: 'nat', annots: ['%accumulated_protocol_fee_token'] }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
                                               ]
                                             }
                                           ]

--- a/dex/scripts/src/types.ts
+++ b/dex/scripts/src/types.ts
@@ -30,7 +30,6 @@ export interface DexStorage {
   freezeBaker: boolean;
   manager: string;
   tokenId?: string; // Only for FA2
-  protocol_fee_bp?: number; // Modified pools only
   protocol_fee_recipient?: string; // Modified pools only
   accumulated_protocol_fee_xtz?: string; // Modified pools only
   accumulated_protocol_fee_token?: string; // Modified pools only
@@ -233,18 +232,12 @@ export const dexStorageTypeMod = {
                                         {
                                           prim: 'pair',
                                           args: [
-                                            { prim: 'nat', annots: ['%protocol_fee_bp'] },
+                                            { prim: 'address', annots: ['%protocol_fee_recipient'] },
                                             {
                                               prim: 'pair',
                                               args: [
-                                                { prim: 'address', annots: ['%protocol_fee_recipient'] },
-                                                {
-                                                  prim: 'pair',
-                                                  args: [
-                                                    { prim: 'mutez', annots: ['%accumulated_protocol_fee_xtz'] },
-                                                    { prim: 'nat', annots: ['%accumulated_protocol_fee_token'] }
-                                                  ]
-                                                }
+                                                { prim: 'mutez', annots: ['%accumulated_protocol_fee_xtz'] },
+                                                { prim: 'nat', annots: ['%accumulated_protocol_fee_token'] }
                                               ]
                                             }
                                           ]
@@ -317,18 +310,12 @@ export const dexStorageTypeFA2Mod = {
                                             {
                                               prim: 'pair',
                                               args: [
-                                                { prim: 'nat', annots: ['%protocol_fee_bp'] },
+                                                { prim: 'address', annots: ['%protocol_fee_recipient'] },
                                                 {
                                                   prim: 'pair',
                                                   args: [
-                                                    { prim: 'address', annots: ['%protocol_fee_recipient'] },
-                                                    {
-                                                      prim: 'pair',
-                                                      args: [
-                                                        { prim: 'mutez', annots: ['%accumulated_protocol_fee_xtz'] },
-                                                        { prim: 'nat', annots: ['%accumulated_protocol_fee_token'] }
-                                                      ]
-                                                    }
+                                                    { prim: 'mutez', annots: ['%accumulated_protocol_fee_xtz'] },
+                                                    { prim: 'nat', annots: ['%accumulated_protocol_fee_token'] }
                                                   ]
                                                 }
                                               ]

--- a/dex/scripts/src/util.ts
+++ b/dex/scripts/src/util.ts
@@ -35,18 +35,19 @@ export async function getTokenBalance(
     tokenAddress: string,
     owner: string,
     tokenStandard: string,
-    tokenId: number = 0
-): Promise<number> {
+    tokenId: string = "0"
+): Promise<bigint> {
     const contract = await tezos.contract.at(tokenAddress);
     const storage: any = await contract.storage();
 
     if (tokenStandard.toUpperCase() === 'FA2') {
         const key = { owner, token_id: tokenId };
         const balance = await storage.ledger.get(key);
-        return balance?.toNumber() ?? 0;
+        return BigInt(balance?.toString() ?? "0");
     }
 
     // FA1.2
     const balance = await storage.ledger.get(owner);
-    return balance.balance ?? 0;
+    const value = balance?.balance ?? balance ?? 0;
+    return BigInt(value.toString());
 }

--- a/dex/scripts/src/verification.test.ts
+++ b/dex/scripts/src/verification.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { verifyAtLeast, verifyEqual } from "./verification.js";
+
+test("verifyEqual rejects a mismatched exact reserve", () => {
+    assert.throws(
+        () => verifyEqual("1000001", "1000000", "DEX tokenPool"),
+        /expected 1000000, got 1000001/
+    );
+});
+
+test("verifyAtLeast accepts an exact seed and donated excess", () => {
+    assert.doesNotThrow(() => verifyAtLeast("1000000", "1000000", "DEX tokenPool"));
+    assert.doesNotThrow(() => verifyAtLeast("1000001", "1000000", "DEX tokenPool"));
+});
+
+test("verifyAtLeast rejects an underfunded reserve", () => {
+    assert.throws(
+        () => verifyAtLeast("999999", "1000000", "DEX tokenPool"),
+        /expected at least 1000000, got 999999/
+    );
+});

--- a/dex/scripts/src/verification.ts
+++ b/dex/scripts/src/verification.ts
@@ -1,0 +1,15 @@
+export function verifyEqual(actual: string, expected: string, field: string): void {
+    if (actual !== expected) {
+        throw new Error(
+            `Deployment verification failed for ${field}: expected ${expected}, got ${actual}`
+        );
+    }
+}
+
+export function verifyAtLeast(actual: string, minimum: string, field: string): void {
+    if (BigInt(actual) < BigInt(minimum)) {
+        throw new Error(
+            `Deployment verification failed for ${field}: expected at least ${minimum}, got ${actual}`
+        );
+    }
+}

--- a/dex/tests/dexter_mod.test.mligo
+++ b/dex/tests/dexter_mod.test.mligo
@@ -204,7 +204,8 @@ let test_remove_liquidity_error_amount =
 (* XTZ to Token tests                                                        *)
 (*****************************************************************************)
 
-(* With zero fee results must be identical to original Dexter *)
+(* A 1 tez swap is priced at 30 bp total. Of the gross input, 500 mutez
+   (5 bp) accrues to the protocol and the remaining 25 bp stays with LPs. *)
 let test_xtz_to_token =
   let test_name = "test_xtz_to_token" in
   let (dex_orig, lqt_orig, tok_orig) = Util.setup_full_dex () in
@@ -217,11 +218,10 @@ let test_xtz_to_token =
   let _ : nat =
     Test.Typed_address.transfer_exn dex_orig.taddr (XtzToToken swap_param) 1tez in
   begin
-    Util.assert_dex_state dex_orig.taddr test_name 2tez 500752n 1000000n;
+    Util.assert_dex_state dex_orig.taddr test_name 1999500mutez 500752n 1000000n;
     Util.assert_token_balance tok_orig.taddr test_name (Util.src ()) 1000499248n;
     Util.assert_token_balance lqt_orig.taddr test_name (Util.src ()) 1000000n;
-    // No XTZ fee accumulated when fee_bp = 0
-    Util.assert_accumulated_fee_xtz dex_orig.taddr test_name 0mutez
+    Util.assert_accumulated_fee_xtz dex_orig.taddr test_name 500mutez
   end
 
 let test_xtz_to_token_error_deadline =
@@ -273,13 +273,10 @@ let test_xtz_to_token_error_updating_pool =
     DexterMod.Dexter.error_SELF_IS_UPDATING_TOKEN_POOL_MUST_BE_FALSE
     result
 
-(* With fee: only net XTZ enters the pool, fee is accumulated in XTZ
-   fee_bp = 50 (0.5%), amount = 1 tez = 1_000_000 mutez
-   protocol_fee = floor(1_000_000 * 50 / 10_000) = 5_000 mutez
-*)
+(* The protocol share is not charged on top of the 30 bp curve fee. *)
 let test_xtz_to_token_with_fee =
   let test_name = "test_xtz_to_token_with_fee" in
-  let (dex_orig, _, _) = Util.setup_full_dex_with_fee 50n in
+  let (dex_orig, _, _) = Util.setup_full_dex () in
   let swap_param : DexterMod.Dexter.xtz_to_token =
     {
      to_ = Util.src ();
@@ -289,20 +286,18 @@ let test_xtz_to_token_with_fee =
   let _ : nat =
     Test.Typed_address.transfer_exn dex_orig.taddr (XtzToToken swap_param) 1tez in
   begin
-    Util.assert_dex_state dex_orig.taddr test_name 1995000mutez 502005n 1000000n;
-    Util.assert_accumulated_fee_xtz dex_orig.taddr test_name 5000mutez
+    Util.assert_dex_state dex_orig.taddr test_name 1999500mutez 500752n 1000000n;
+    Util.assert_accumulated_fee_xtz dex_orig.taddr test_name 500mutez
   end
 
-(* minTokensBought is checked against the post-fee (net) amount *)
+(* minTokensBought is checked against the exact 30 bp quote. *)
 let test_xtz_to_token_min_tokens_checked_after_fee =
   let test_name = "test_xtz_to_token_min_tokens_checked_after_fee" in
-  let (dex_orig, _, _) = Util.setup_full_dex_with_fee 50n in
+  let (dex_orig, _, _) = Util.setup_full_dex () in
   let swap_param : DexterMod.Dexter.xtz_to_token =
     {
      to_ = Util.src ();
-     // Without fee would get 499_248; with 0.5% fee on input gets ~498_002,
-     // so requesting 499_248 must fail
-     minTokensBought = 499248n;
+     minTokensBought = 499249n;
      deadline = Util.future
     } in
   let result =
@@ -316,7 +311,8 @@ let test_xtz_to_token_min_tokens_checked_after_fee =
 (* Token to XTZ tests                                                        *)
 (*****************************************************************************)
 
-(* With zero fee results must be identical to original Dexter *)
+(* A 500,000 token swap is priced at 30 bp total and records 250 tokens
+   (5 bp) for the protocol. *)
 let test_token_to_xtz =
   let test_name = "test_token_to_xtz" in
   let (dex_orig, lqt_orig, tok_orig) = Util.setup_full_dex () in
@@ -330,12 +326,11 @@ let test_token_to_xtz =
   let _ : nat =
     Test.Typed_address.transfer_exn dex_orig.taddr (TokenToXtz swap_param) 0tez in
   begin
-    Util.assert_dex_state dex_orig.taddr test_name 667335mutez 1500000n 1000000n;
+    Util.assert_dex_state dex_orig.taddr test_name 667335mutez 1499750n 1000000n;
     Util.assert_token_balance tok_orig.taddr test_name (Util.src ()) 999500000n;
     Util.assert_token_balance lqt_orig.taddr test_name (Util.src ()) 1000000n;
-    // No fees accumulated when fee_bp = 0
     Util.assert_accumulated_fee_xtz dex_orig.taddr test_name 0mutez;
-    Util.assert_accumulated_fee_token dex_orig.taddr test_name 0n
+    Util.assert_accumulated_fee_token dex_orig.taddr test_name 250n
   end
 
 let test_token_to_xtz_error_deadline =
@@ -404,14 +399,11 @@ let test_token_to_xtz_error_updating_pool =
     DexterMod.Dexter.error_SELF_IS_UPDATING_TOKEN_POOL_MUST_BE_FALSE
     result
 
-(* With fee: protocol fee is taken in tokens before AMM
-   fee_bp = 100 (1%), tokensSold = 500_000
-   protocol_fee_token = floor(500_000 * 100 / 10_000) = 5_000 tokens
-   net_tokens_sold    = 495_000
-*)
+(* The 5 bp protocol allocation is removed from reserve accounting after the
+   gross input has been priced at the full 30 bp. *)
 let test_token_to_xtz_with_fee =
   let test_name = "test_token_to_xtz_with_fee" in
-  let (dex_orig, _, _) = Util.setup_full_dex_with_fee 100n in
+  let (dex_orig, _, _) = Util.setup_full_dex () in
   let swap_param : DexterMod.Dexter.token_to_xtz =
     {
      to_ = Util.src ();
@@ -422,23 +414,21 @@ let test_token_to_xtz_with_fee =
   let _ : nat =
     Test.Typed_address.transfer_exn dex_orig.taddr (TokenToXtz swap_param) 0tez in
   begin
-    // xtzPool decreases by xtz_bought, tokenPool increases by net_tokens_sold only
-    Util.assert_dex_state dex_orig.taddr test_name 669562mutez 1495000n 1000000n;
+    Util.assert_dex_state dex_orig.taddr test_name 667335mutez 1499750n 1000000n;
     // No XTZ fee - fee is collected in tokens
     Util.assert_accumulated_fee_xtz dex_orig.taddr test_name 0mutez;
-    // Token fee = 1% of 500_000 = 5_000 tokens
-    Util.assert_accumulated_fee_token dex_orig.taddr test_name 5000n
+    Util.assert_accumulated_fee_token dex_orig.taddr test_name 250n
   end
 
-(* minXtzBought is checked against the post-fee (net) XTZ amount *)
+(* minXtzBought is checked against the exact 30 bp quote. *)
 let test_token_to_xtz_min_xtz_checked_after_fee =
   let test_name = "test_token_to_xtz_min_xtz_checked_after_fee" in
-  let (dex_orig, _, _) = Util.setup_full_dex_with_fee 100n in
+  let (dex_orig, _, _) = Util.setup_full_dex () in
   let swap_param : DexterMod.Dexter.token_to_xtz =
     {
      to_ = Util.src ();
      tokensSold = 500000n;
-     minXtzBought = 332665mutez;
+     minXtzBought = 332666mutez;
      deadline = Util.future
     } in
   let result =
@@ -615,7 +605,7 @@ let test_token_to_token =
   let swap_param : DexterMod.Dexter.token_to_token =
     {
      outputDexterContract = Test.Typed_address.to_address dex_orig.taddr;
-     minTokensBought = 497997n;
+     minTokensBought = 497914n;
      to_ = Util.src ();
      tokensSold = 500000n;
      deadline = Util.future
@@ -623,9 +613,11 @@ let test_token_to_token =
   let _ : nat =
     Test.Typed_address.transfer_exn dex_orig.taddr (TokenToToken swap_param) 0tez in
   begin
-    Util.assert_dex_state dex_orig.taddr test_name 1tez 1002003n 1000000n;
-    Util.assert_token_balance tok_orig.taddr test_name (Util.src ()) 999997997n;
-    Util.assert_token_balance lqt_orig.taddr test_name (Util.src ()) 1000000n
+    Util.assert_dex_state dex_orig.taddr test_name 999834mutez 1001836n 1000000n;
+    Util.assert_token_balance tok_orig.taddr test_name (Util.src ()) 999997914n;
+    Util.assert_token_balance lqt_orig.taddr test_name (Util.src ()) 1000000n;
+    Util.assert_accumulated_fee_xtz dex_orig.taddr test_name 166mutez;
+    Util.assert_accumulated_fee_token dex_orig.taddr test_name 250n
   end
 
 let test_token_to_token_error_amount =
@@ -660,68 +652,6 @@ let test_token_to_token_error_deadline =
   Util.assert_error
     test_name
     DexterMod.Dexter.error_THE_CURRENT_TIME_MUST_BE_LESS_THAN_THE_DEADLINE
-    result
-
-(*****************************************************************************)
-(* setProtocolFee tests                                                      *)
-(*****************************************************************************)
-let test_set_protocol_fee =
-  let (dex_orig, _, _) = Util.setup_full_dex () in
-  let param : nat = 50n in
-  let _ : nat =
-    Test.Typed_address.transfer_exn dex_orig.taddr (SetProtocolFee param) 0tez in
-  let storage = Test.Typed_address.get_storage dex_orig.taddr in
-  Assert.assert (storage.protocol_fee_bp = 50n)
-
-let test_set_protocol_fee_zero =
-  let (dex_orig, _, _) = Util.setup_full_dex_with_fee 50n in
-  let param : nat = 0n in
-  let _ : nat =
-    Test.Typed_address.transfer_exn dex_orig.taddr (SetProtocolFee param) 0tez in
-  let storage = Test.Typed_address.get_storage dex_orig.taddr in
-  Assert.assert (storage.protocol_fee_bp = 0n)
-
-let test_set_protocol_fee_max =
-  let (dex_orig, _, _) = Util.setup_full_dex () in
-  let param : nat = 1000n in
-  let _ : nat =
-    Test.Typed_address.transfer_exn dex_orig.taddr (SetProtocolFee param) 0tez in
-  let storage = Test.Typed_address.get_storage dex_orig.taddr in
-  Assert.assert (storage.protocol_fee_bp = 1000n)
-
-let test_set_protocol_fee_error_not_manager =
-  let test_name = "test_set_protocol_fee_error_not_manager" in
-  let (dex_orig, _, _) = Util.setup_full_dex () in
-  let () = Test.State.set_source (Util.other ()) in
-  let param : nat = 50n in
-  let result = Test.Typed_address.transfer dex_orig.taddr (SetProtocolFee param) 0tez in
-  Util.assert_error
-    test_name
-    DexterMod.Dexter.error_ONLY_MANAGER_CAN_SET_PROTOCOL_FEE
-    result
-
-let test_set_protocol_fee_error_amount =
-  let test_name = "test_set_protocol_fee_error_amount" in
-  let (dex_orig, _, _) = Util.setup_full_dex () in
-  let param : nat = 50n in
-  let result = Test.Typed_address.transfer dex_orig.taddr (SetProtocolFee param) 1tez in
-  Util.assert_error test_name DexterMod.Dexter.error_AMOUNT_MUST_BE_ZERO result
-
-let test_set_protocol_fee_error_too_high =
-  let test_name = "test_set_protocol_fee_error_too_high" in
-  let (dex_orig, _, _) = Util.setup_full_dex () in
-  let param : nat = 1001n in
-  let result = Test.Typed_address.transfer dex_orig.taddr (SetProtocolFee param) 0tez in
-  Util.assert_error test_name DexterMod.Dexter.error_PROTOCOL_FEE_TOO_HIGH result
-
-let test_set_protocol_fee_error_updating_pool =
-  let test_name = "test_set_protocol_fee_error_updating_pool" in
-  let (dex_orig, _, _) = Util.setup_dex_with_updating_pool () in
-  let param : nat = 50n in
-  let result = Test.Typed_address.transfer dex_orig.taddr (SetProtocolFee param) 0tez in
-  Util.assert_error
-    test_name
-    DexterMod.Dexter.error_SELF_IS_UPDATING_TOKEN_POOL_MUST_BE_FALSE
     result
 
 (*****************************************************************************)
@@ -770,16 +700,15 @@ let test_set_protocol_fee_recipient_error_updating_pool =
 (* claimProtocolFeeXtz tests                                                 *)
 (*****************************************************************************)
 
-(* Basic XTZ fee claim after xtzToToken swap
-   fee_bp = 50 (0.5%), swap 1 tez → fee = 5_000 mutez *)
+(* Basic XTZ fee claim after xtzToToken swap: 5 bp of 1 tez = 500 mutez. *)
 let test_claim_protocol_fee_xtz =
   let test_name = "test_claim_protocol_fee_xtz" in
-  let (dex_orig, _, _) = Util.setup_full_dex_with_fee 50n in
+  let (dex_orig, _, _) = Util.setup_full_dex () in
   let swap_param : DexterMod.Dexter.xtz_to_token =
     { to_ = Util.src (); minTokensBought = 1n; deadline = Util.future } in
   let _ : nat =
     Test.Typed_address.transfer_exn dex_orig.taddr (XtzToToken swap_param) 1tez in
-  let () = Util.assert_accumulated_fee_xtz dex_orig.taddr test_name 5000mutez in
+  let () = Util.assert_accumulated_fee_xtz dex_orig.taddr test_name 500mutez in
   let balance_before = Test.Typed_address.get_balance dex_orig.taddr in
   let _ : nat =
     Test.Typed_address.transfer_exn dex_orig.taddr (ClaimProtocolFeeXtz ()) 0tez in
@@ -787,22 +716,22 @@ let test_claim_protocol_fee_xtz =
   let balance_after = Test.Typed_address.get_balance dex_orig.taddr in
   begin
     Assert.assert (storage.accumulated_protocol_fee_xtz = 0mutez);
-    Assert.assert (balance_before = balance_after + 5000mutez)
+    Assert.assert (balance_before = balance_after + 500mutez)
   end
 
 (* XTZ fee accumulates correctly over multiple swaps *)
 let test_claim_protocol_fee_xtz_multiple_swaps =
   let test_name = "test_claim_protocol_fee_xtz_multiple_swaps" in
-  let (dex_orig, _, _) = Util.setup_full_dex_with_fee 50n in
+  let (dex_orig, _, _) = Util.setup_full_dex () in
   let xtz_swap : DexterMod.Dexter.xtz_to_token =
     { to_ = Util.src (); minTokensBought = 1n; deadline = Util.future } in
-  // First swap: 1 tez — fee = floor(1_000_000 * 50 / 10_000) = 5_000 mutez
+  // First swap: floor(1_000_000 * 5 / 10_000) = 500 mutez
   let _ : nat =
     Test.Typed_address.transfer_exn dex_orig.taddr (XtzToToken xtz_swap) 1tez in
-  // Second swap: 500_000 mutez — fee = floor(500_000 * 50 / 10_000) = 2_500 mutez
+  // Second swap: floor(500_000 * 5 / 10_000) = 250 mutez
   let _ : nat =
     Test.Typed_address.transfer_exn dex_orig.taddr (XtzToToken xtz_swap) 500000mutez in
-  let () = Util.assert_accumulated_fee_xtz dex_orig.taddr test_name 7500mutez in
+  let () = Util.assert_accumulated_fee_xtz dex_orig.taddr test_name 750mutez in
   let _ : nat =
     Test.Typed_address.transfer_exn dex_orig.taddr (ClaimProtocolFeeXtz ()) 0tez in
   let storage = Test.Typed_address.get_storage dex_orig.taddr in
@@ -811,7 +740,7 @@ let test_claim_protocol_fee_xtz_multiple_swaps =
 (* Only the designated recipient can claim XTZ fee *)
 let test_claim_protocol_fee_xtz_error_not_recipient =
   let test_name = "test_claim_protocol_fee_xtz_error_not_recipient" in
-  let (dex_orig, _, _) = Util.setup_full_dex_with_fee 50n in
+  let (dex_orig, _, _) = Util.setup_full_dex () in
   let swap_param : DexterMod.Dexter.xtz_to_token =
     { to_ = Util.src (); minTokensBought = 1n; deadline = Util.future } in
   let _ : nat =
@@ -826,14 +755,14 @@ let test_claim_protocol_fee_xtz_error_not_recipient =
 (* Cannot claim XTZ fee when nothing has been accumulated *)
 let test_claim_protocol_fee_xtz_error_nothing_to_claim =
   let test_name = "test_claim_protocol_fee_xtz_error_nothing_to_claim" in
-  let (dex_orig, _, _) = Util.setup_full_dex () in // fee_bp = 0
+  let (dex_orig, _, _) = Util.setup_full_dex () in
   let result = Test.Typed_address.transfer dex_orig.taddr (ClaimProtocolFeeXtz ()) 0tez in
   Util.assert_error test_name DexterMod.Dexter.error_NO_PROTOCOL_FEE_TO_CLAIM result
 
 (* Cannot send XTZ when claiming *)
 let test_claim_protocol_fee_xtz_error_amount =
   let test_name = "test_claim_protocol_fee_xtz_error_amount" in
-  let (dex_orig, _, _) = Util.setup_full_dex_with_fee 50n in
+  let (dex_orig, _, _) = Util.setup_full_dex () in
   let swap_param : DexterMod.Dexter.xtz_to_token =
     { to_ = Util.src (); minTokensBought = 1n; deadline = Util.future } in
   let _ : nat =
@@ -844,7 +773,7 @@ let test_claim_protocol_fee_xtz_error_amount =
 (* Double claim: second attempt must fail after first succeeds *)
 let test_claim_protocol_fee_xtz_double_claim =
   let test_name = "test_claim_protocol_fee_xtz_double_claim" in
-  let (dex_orig, _, _) = Util.setup_full_dex_with_fee 50n in
+  let (dex_orig, _, _) = Util.setup_full_dex () in
   let swap_param : DexterMod.Dexter.xtz_to_token =
     { to_ = Util.src (); minTokensBought = 1n; deadline = Util.future } in
   let _ : nat =
@@ -867,7 +796,7 @@ let test_claim_protocol_fee_xtz_error_updating_pool =
 (* Changing recipient takes effect immediately for XTZ fee *)
 let test_claim_xtz_fee_after_recipient_change =
   let test_name = "test_claim_xtz_fee_after_recipient_change" in
-  let (dex_orig, _, _) = Util.setup_full_dex_with_fee 50n in
+  let (dex_orig, _, _) = Util.setup_full_dex () in
   let swap_param : DexterMod.Dexter.xtz_to_token =
     { to_ = Util.src (); minTokensBought = 1n; deadline = Util.future } in
   let _ : nat =
@@ -894,50 +823,47 @@ let test_claim_xtz_fee_after_recipient_change =
 (* claimProtocolFeeToken tests                                               *)
 (*****************************************************************************)
 
-(* Basic token fee claim after tokenToXtz swap
-   fee_bp = 100 (1%), tokensSold = 500_000 → fee = 5_000 tokens *)
+(* Basic token fee claim: 5 bp of 500,000 tokens = 250 tokens. *)
 let test_claim_protocol_fee_token =
   let test_name = "test_claim_protocol_fee_token" in
-  let (dex_orig, _, tok_orig) = Util.setup_full_dex_with_fee 100n in
+  let (dex_orig, _, tok_orig) = Util.setup_full_dex () in
   let swap_param : DexterMod.Dexter.token_to_xtz =
     { to_ = Util.src (); tokensSold = 500000n; minXtzBought = 1mutez; deadline = Util.future } in
   let _ : nat =
     Test.Typed_address.transfer_exn dex_orig.taddr (TokenToXtz swap_param) 0tez in
-  let () = Util.assert_accumulated_fee_token dex_orig.taddr test_name 5000n in
+  let () = Util.assert_accumulated_fee_token dex_orig.taddr test_name 250n in
   let _ : nat =
     Test.Typed_address.transfer_exn dex_orig.taddr (ClaimProtocolFeeToken ()) 0tez in
   let storage = Test.Typed_address.get_storage dex_orig.taddr in
   begin
     Assert.assert (storage.accumulated_protocol_fee_token = 0n) ; 
-    // Recipient receives 5_000 tokens back as fee
-    Util.assert_token_balance tok_orig.taddr test_name (Util.src ()) 999505000n
+    Util.assert_token_balance tok_orig.taddr test_name (Util.src ()) 999500250n
   end
 
 (* Token fee accumulates correctly over multiple swaps *)
 let test_claim_protocol_fee_token_multiple_swaps =
   let test_name = "test_claim_protocol_fee_token_multiple_swaps" in
-  let (dex_orig, _, tok_orig) = Util.setup_full_dex_with_fee 100n in
+  let (dex_orig, _, tok_orig) = Util.setup_full_dex () in
   let swap_param : DexterMod.Dexter.token_to_xtz =
     { to_ = Util.src (); tokensSold = 500000n; minXtzBought = 1mutez; deadline = Util.future } in
-  // First swap: fee = floor(500_000 * 100 / 10_000) = 5_000 tokens
+  // First swap: fee = floor(500_000 * 5 / 10_000) = 250 tokens
   let _ : nat =
     Test.Typed_address.transfer_exn dex_orig.taddr (TokenToXtz swap_param) 0tez in
-  // Second swap: fee = floor(500_000 * 100 / 10_000) = 5_000 tokens
+  // Second swap: fee = 250 tokens
   let _ : nat =
     Test.Typed_address.transfer_exn dex_orig.taddr (TokenToXtz swap_param) 0tez in
-  let () = Util.assert_accumulated_fee_token dex_orig.taddr test_name 10000n in
+  let () = Util.assert_accumulated_fee_token dex_orig.taddr test_name 500n in
   let _ : nat =
     Test.Typed_address.transfer_exn dex_orig.taddr (ClaimProtocolFeeToken ()) 0tez in
   let storage = Test.Typed_address.get_storage dex_orig.taddr in
   begin
     Assert.assert (storage.accumulated_protocol_fee_token = 0n) ;
-    // Recipient receives 10_000 tokens back as accumulated fee
-    Util.assert_token_balance tok_orig.taddr test_name (Util.src ()) 999010000n
+    Util.assert_token_balance tok_orig.taddr test_name (Util.src ()) 999000500n
   end
 (* Only the designated recipient can claim token fee *)
 let test_claim_protocol_fee_token_error_not_recipient =
   let test_name = "test_claim_protocol_fee_token_error_not_recipient" in
-  let (dex_orig, _, _) = Util.setup_full_dex_with_fee 100n in
+  let (dex_orig, _, _) = Util.setup_full_dex () in
   let swap_param : DexterMod.Dexter.token_to_xtz =
     { to_ = Util.src (); tokensSold = 500000n; minXtzBought = 1mutez; deadline = Util.future } in
   let _ : nat =
@@ -952,14 +878,14 @@ let test_claim_protocol_fee_token_error_not_recipient =
 (* Cannot claim token fee when nothing has been accumulated *)
 let test_claim_protocol_fee_token_error_nothing_to_claim =
   let test_name = "test_claim_protocol_fee_token_error_nothing_to_claim" in
-  let (dex_orig, _, _) = Util.setup_full_dex () in // fee_bp = 0
+  let (dex_orig, _, _) = Util.setup_full_dex () in
   let result = Test.Typed_address.transfer dex_orig.taddr (ClaimProtocolFeeToken ()) 0tez in
   Util.assert_error test_name DexterMod.Dexter.error_NO_PROTOCOL_FEE_TO_CLAIM result
 
 (* Cannot send XTZ when claiming token fee *)
 let test_claim_protocol_fee_token_error_amount =
   let test_name = "test_claim_protocol_fee_token_error_amount" in
-  let (dex_orig, _, _) = Util.setup_full_dex_with_fee 100n in
+  let (dex_orig, _, _) = Util.setup_full_dex () in
   let swap_param : DexterMod.Dexter.token_to_xtz =
     { to_ = Util.src (); tokensSold = 500000n; minXtzBought = 1mutez; deadline = Util.future } in
   let _ : nat =
@@ -970,7 +896,7 @@ let test_claim_protocol_fee_token_error_amount =
 (* Double claim: second attempt must fail after first succeeds *)
 let test_claim_protocol_fee_token_double_claim =
   let test_name = "test_claim_protocol_fee_token_double_claim" in
-  let (dex_orig, _, _) = Util.setup_full_dex_with_fee 100n in
+  let (dex_orig, _, _) = Util.setup_full_dex () in
   let swap_param : DexterMod.Dexter.token_to_xtz =
     { to_ = Util.src (); tokensSold = 500000n; minXtzBought = 1mutez; deadline = Util.future } in
   let _ : nat =
@@ -993,7 +919,7 @@ let test_claim_protocol_fee_token_error_updating_pool =
 (* Changing recipient takes effect immediately for token fee *)
 let test_claim_token_fee_after_recipient_change =
   let test_name = "test_claim_token_fee_after_recipient_change" in
-  let (dex_orig, _, _) = Util.setup_full_dex_with_fee 100n in
+  let (dex_orig, _, _) = Util.setup_full_dex () in
   let swap_param : DexterMod.Dexter.token_to_xtz =
     { to_ = Util.src (); tokensSold = 500000n; minXtzBought = 1mutez; deadline = Util.future } in
   let _ : nat =
@@ -1048,22 +974,9 @@ let test_view_get_fee_bp =
     None -> failwith "get_fee_bp view failed"
   | Some (lp_fee, protocol_fee, total_fee) ->
       begin
-        Assert.assert (lp_fee = 30n);
-        Assert.assert (protocol_fee = 0n);
-        Assert.assert (total_fee = 30n + 0n)
-      end
-
-let test_view_get_fee_bp_with_fee =
-  let (dex_orig, _, _) = Util.setup_full_dex_with_fee 50n in
-  let dex_address = Test.Typed_address.to_address dex_orig.taddr in
-  let view_result : (nat * nat * nat) option = Tezos.View.call "get_fee_bp" () dex_address in
-  match view_result with
-    None -> failwith "get_fee_bp with fee view failed"
-  | Some (lp_fee, protocol_fee, total_fee) ->
-      begin
-        Assert.assert (lp_fee = 30n);
-        Assert.assert (protocol_fee = 50n);
-        Assert.assert (total_fee = 30n + 50n)
+        Assert.assert (lp_fee = 25n);
+        Assert.assert (protocol_fee = 5n);
+        Assert.assert (total_fee = 30n)
       end
 
 let test_view_quote_tez_to_token =
@@ -1076,14 +989,13 @@ let test_view_quote_tez_to_token =
   | Some tokens_out -> Assert.assert (tokens_out = 499248n)
 
 let test_view_quote_tez_to_token_with_fee =
-  let (dex_orig, _, _) = Util.setup_full_dex_with_fee 50n in
+  let (dex_orig, _, _) = Util.setup_full_dex () in
   let dex_address = Test.Typed_address.to_address dex_orig.taddr in
   let view_result : nat option =
     Tezos.View.call "quote_tez_to_token" 1000000n dex_address in
   match view_result with
     None -> failwith "quote_tez_to_token view failed"
-  | Some tokens_out ->
-      Assert.assert (tokens_out < 499248n)
+  | Some tokens_out -> Assert.assert (tokens_out = 499248n)
 
 let test_view_quote_tez_to_token_zero =
   let (dex_orig, _, _) = Util.setup_full_dex () in
@@ -1104,14 +1016,13 @@ let test_view_quote_token_to_tez =
   | Some xtz_out -> Assert.assert (xtz_out = 332665n)
 
 let test_view_quote_token_to_tez_with_fee =
-  let (dex_orig, _, _) = Util.setup_full_dex_with_fee 100n in
+  let (dex_orig, _, _) = Util.setup_full_dex () in
   let dex_address = Test.Typed_address.to_address dex_orig.taddr in
   let view_result : nat option =
     Tezos.View.call "quote_token_to_tez" 500000n dex_address in
   match view_result with
     None -> failwith "quote_token_to_tez view failed"
-  | Some xtz_out ->
-      Assert.assert (xtz_out < 332665n)
+  | Some xtz_out -> Assert.assert (xtz_out = 332665n)
 
 let test_view_quote_token_to_tez_zero =
   let (dex_orig, _, _) = Util.setup_full_dex () in

--- a/dex/tests/dexter_mod.test.mligo
+++ b/dex/tests/dexter_mod.test.mligo
@@ -18,6 +18,43 @@ let test_setup =
     Util.assert_token_balance lqt_orig.taddr test_name (Util.src ()) 1000000n
   end
 
+let test_activation_accepts_donated_token_excess =
+  let test_name = "test_activation_accepts_donated_token_excess" in
+  let () = Util.clean () in
+  let () = Test.State.set_source (Util.src ()) in
+  let tok_orig = Util.deploy_token 1001000001n (Util.src ()) in
+  let tok_addr = Test.Typed_address.to_address tok_orig.taddr in
+  let dex_orig =
+    Util.deploy_dex 1000000n (Util.src ()) tok_addr 0tez (Util.src ()) in
+  let dex_addr = Test.Typed_address.to_address dex_orig.taddr in
+  let lqt_orig = Util.deploy_lqt 1000000n (Util.src ()) dex_addr in
+  let transfer_param : LQT.LQT.transfer =
+    {
+     address_from = Util.src ();
+     address_to = dex_addr;
+     value = 1000001n;
+    } in
+  let _ : nat =
+    Test.Typed_address.transfer_exn
+      dex_orig.taddr
+      (SetLqtAddress (Test.Typed_address.to_address lqt_orig.taddr))
+      0tez in
+  let _ : nat =
+    Test.Typed_address.transfer_exn dex_orig.taddr (Default_ ()) 1tez in
+  let _ : nat =
+    Test.Typed_address.transfer_exn tok_orig.taddr (Transfer transfer_param) 0tez in
+  let _ : nat =
+    Test.Typed_address.transfer_exn dex_orig.taddr (UpdateTokenPool ()) 0tez in
+  let () = Util.activate_dex dex_orig.taddr 1tez 1000000n 1000000n in
+  let storage : DexterMod.Dexter.storage =
+    Test.Typed_address.get_storage dex_orig.taddr in
+  if
+    not storage.active
+    or storage.activationPending
+    or storage.tokenPool <> 1000001n
+  then failwith (test_name ^ ": donated excess did not remain in the pool")
+  else ()
+
 (*****************************************************************************)
 (* Add liquidity tests                                                       *)
 (*****************************************************************************)

--- a/dex/tests/dexter_mod_fa2.test.mligo
+++ b/dex/tests/dexter_mod_fa2.test.mligo
@@ -1,0 +1,670 @@
+#include "../contracts/helpers/dexter_mod_fa2.mligo"
+#import "../contracts/helpers/fa2_token.mligo" "FA2"
+#import "../contracts/lqt_fa12.mligo" "LQT"
+
+module Test = Test.Next
+
+module Tezos = Tezos.Next
+
+module MalformedFA2 = struct
+  type response_mode =
+    WrongOwner
+  | WrongTokenId
+  | ExtraResult
+  | EmptyResult
+
+  type storage =
+    {
+     responseMode : response_mode;
+     balance : nat;
+     wrongOwner : address;
+    }
+
+  type result = operation list * storage
+
+  [@entry]
+  let balance_of (param : FA2.balance_of) (storage : storage) : result =
+    let request =
+      match List.head param.requests with
+        None -> (failwith "Missing request" : FA2.request)
+      | Some request -> request in
+    let valid_response : FA2.callback =
+      {
+       request = request;
+       balance = storage.balance;
+      } in
+    let responses : FA2.callback list =
+      match storage.responseMode with
+        WrongOwner ->
+          [
+            {
+             request = {request with owner = storage.wrongOwner};
+             balance = storage.balance;
+            }
+          ]
+      | WrongTokenId ->
+          [
+            {
+             request = {request with token_id = request.token_id + 1n};
+             balance = storage.balance;
+            }
+          ]
+      | ExtraResult -> [valid_response; valid_response]
+      | EmptyResult -> [] in
+    ([Tezos.Operation.transaction responses 0tez param.callback], storage)
+
+  [@entry]
+  let transfer (_ : unit) (storage : storage) : result =
+    (([] : operation list), storage)
+end
+
+let src () = Test.Account.address 1n
+
+let other () = Test.Account.address 0n
+
+let future = ("1970-01-01T00:10:12Z" : timestamp)
+
+let clean () =
+  Test.State.reset 3n [10000000000tez; 10000000000tez; 10000000000tez]
+
+let deploy_fa2_token (initial_balance : nat) (token_id : nat) =
+  let storage : FA2.storage = FA2.make_storage (src ()) initial_balance token_id in
+  Test.Originate.contract (contract_of FA2) storage 0tez
+
+let deploy_lqt
+    (lqt_amount : nat)
+    (owner : address)
+    (admin : address) =
+  let lqt_storage : LQT.LQT.storage =
+    {
+     tokens = (Big_map.literal [(owner, lqt_amount)] : LQT.LQT.tokens);
+     allowances = (Big_map.empty : LQT.LQT.allowances);
+     admin = admin;
+     total_supply = lqt_amount;
+     metadata = (Big_map.empty : (string, bytes) big_map);
+     token_metadata =
+       (Big_map.literal
+          [
+            (0n,
+             {
+              token_id = 0n;
+              token_info = (Map.empty : (string, bytes) map)
+             })
+          ]
+        : (nat, LQT.LQT.token_metadata_value) big_map)
+    } in
+  Test.Originate.contract (contract_of LQT.LQT) lqt_storage 0tez
+
+let deploy_dex
+    (token_address : address)
+    (token_id : nat)
+    (protocol_fee_bp : nat)
+    (protocol_fee_recipient : address) =
+  let dex_storage =
+    Dexter.build_storage
+      {
+       lqtTotal = 1000000n;
+       manager = src ();
+       tokenAddress = token_address;
+       tokenId = token_id;
+       protocol_fee_bp = protocol_fee_bp;
+       protocol_fee_recipient = protocol_fee_recipient;
+      } in
+  Test.Originate.contract (contract_of Dexter) dex_storage 0tez
+
+let activate_dex (dex_taddr) =
+  let activate_param : Dexter.activate_pool =
+    {
+     expectedXtzPool = 1tez;
+     expectedTokenPool = 1000000n;
+     expectedLqtTotal = 1000000n;
+    } in
+  let activate_entrypoint : Dexter.activate_pool contract =
+    Test.Typed_address.get_entrypoint "activate" dex_taddr in
+  let _ : nat =
+    Test.Contract.transfer_exn activate_entrypoint activate_param 0tez in
+  ()
+
+let prepare_full_dex
+    (protocol_fee_bp : nat)
+    (lqt_total_supply : nat)
+    (token_id : nat) =
+  let () = clean () in
+  let () = Test.State.set_source (src ()) in
+  let tok_orig = deploy_fa2_token 1001000000n token_id in
+  let tok_addr = Test.Typed_address.to_address tok_orig.taddr in
+  let dex_orig = deploy_dex tok_addr token_id protocol_fee_bp (other ()) in
+  let dex_addr = Test.Typed_address.to_address dex_orig.taddr in
+  let lqt_orig = deploy_lqt lqt_total_supply (src ()) dex_addr in
+  let lqt_addr = Test.Typed_address.to_address lqt_orig.taddr in
+  let operator_param : FA2.update_operators =
+    [
+      Add_operator
+        {
+         owner = src ();
+         operator = dex_addr;
+         token_id = token_id;
+        }
+    ] in
+  let _ : nat =
+    Test.Typed_address.transfer_exn
+      tok_orig.taddr
+      (Update_operators operator_param)
+      0tez in
+  let _ : nat =
+    Test.Typed_address.transfer_exn
+      dex_orig.taddr
+      (SetLqtAddress lqt_addr)
+      0tez in
+  let _ : nat =
+    Test.Typed_address.transfer_exn dex_orig.taddr (Default_ ()) 1tez in
+  let transfer_param : FA2.transfer =
+    [
+      {
+       from_ = src ();
+       txs =
+         [
+           {
+            to_ = dex_addr;
+            token_id = token_id;
+            amount = 1000000n;
+           }
+         ];
+      }
+    ] in
+  let _ : nat =
+    Test.Typed_address.transfer_exn
+      tok_orig.taddr
+      (Transfer transfer_param)
+      0tez in
+  let _ : nat =
+    Test.Typed_address.transfer_exn dex_orig.taddr (UpdateTokenPool ()) 0tez in
+  (dex_orig, lqt_orig, tok_orig)
+
+let setup_full_dex (protocol_fee_bp : nat) =
+  let (dex_orig, lqt_orig, tok_orig) =
+    prepare_full_dex protocol_fee_bp 1000000n 0n in
+  let () = activate_dex dex_orig.taddr in
+  (dex_orig, lqt_orig, tok_orig)
+
+let assert_error
+    (test_name : string)
+    (error_code : nat)
+    (result : test_exec_result) =
+  match result with
+    Success _ -> failwith (test_name ^ ": expected error, got success")
+  | Fail e ->
+      (match e with
+         Rejected (err, _) ->
+           let expected = Test.Michelson.eval error_code in
+           if Test.Compare.eq err expected
+           then ()
+           else failwith (test_name ^ ": wrong error code")
+       | _ -> failwith (test_name ^ ": unexpected error type"))
+
+let fa2_balance (tok_taddr) (owner : address) =
+  let storage : FA2.storage = Test.Typed_address.get_storage tok_taddr in
+  match Big_map.find_opt owner storage.ledger with
+    None -> 0n
+  | Some balance -> balance
+
+let test_modified_fa2_pool_is_inactive_by_default =
+  let test_name = "test_modified_fa2_pool_is_inactive_by_default" in
+  let () = clean () in
+  let () = Test.State.set_source (src ()) in
+  let tok_orig = deploy_fa2_token 1000000n 0n in
+  let dex_orig =
+    deploy_dex
+      (Test.Typed_address.to_address tok_orig.taddr)
+      0n
+      0n
+      (other ()) in
+  let storage : Dexter.storage =
+    Test.Typed_address.get_storage dex_orig.taddr in
+  let () =
+    if storage.active or storage.activationPending
+    then failwith (test_name ^ ": pool should originate inactive")
+    else () in
+  let dex_address = Test.Typed_address.to_address dex_orig.taddr in
+  let active_view : bool option =
+    Tezos.View.call "is_active" () dex_address in
+  let quote_view : nat option =
+    Tezos.View.call "quote_tez_to_token" 1000000n dex_address in
+  let () =
+    match active_view with
+      Some false -> ()
+    | _ -> failwith (test_name ^ ": is_active should be false") in
+  let () =
+    match quote_view with
+      Some quote ->
+        if quote = 0n
+        then ()
+        else failwith (test_name ^ ": inactive quote should be zero")
+    | None -> failwith (test_name ^ ": inactive quote view failed") in
+  let swap_param : Dexter.xtz_to_token =
+    {
+     to_ = src ();
+     minTokensBought = 0n;
+     deadline = future;
+    } in
+  let result =
+    Test.Typed_address.transfer
+      dex_orig.taddr
+      (XtzToToken swap_param)
+      1tez in
+  let () =
+    assert_error test_name Dexter.error_POOL_NOT_ACTIVE result in
+  let token_swap_param : Dexter.token_to_xtz =
+    {
+     to_ = src ();
+     tokensSold = 1000n;
+     minXtzBought = 0tez;
+     deadline = future;
+    } in
+  let token_result =
+    Test.Typed_address.transfer
+      dex_orig.taddr
+      (TokenToXtz token_swap_param)
+      0tez in
+  assert_error test_name Dexter.error_POOL_NOT_ACTIVE token_result
+
+let test_modified_fa2_only_manager_can_seed_inactive_pool =
+  let test_name = "test_modified_fa2_only_manager_can_seed_inactive_pool" in
+  let () = clean () in
+  let () = Test.State.set_source (src ()) in
+  let tok_orig = deploy_fa2_token 1000000n 0n in
+  let dex_orig =
+    deploy_dex
+      (Test.Typed_address.to_address tok_orig.taddr)
+      0n
+      0n
+      (other ()) in
+  let () = Test.State.set_source (other ()) in
+  let result =
+    Test.Typed_address.transfer dex_orig.taddr (Default_ ()) 1tez in
+  assert_error
+    test_name
+    Dexter.error_ONLY_MANAGER_CAN_INITIALIZE_POOL
+    result
+
+let test_modified_fa2_activation_rejects_unexpected_reserves =
+  let test_name = "test_modified_fa2_activation_rejects_unexpected_reserves" in
+  let (dex_orig, _, _) = prepare_full_dex 0n 1000000n 0n in
+  let activate_param : Dexter.activate_pool =
+    {
+     expectedXtzPool = 1tez;
+     expectedTokenPool = 999999n;
+     expectedLqtTotal = 1000000n;
+    } in
+  let activate_entrypoint : Dexter.activate_pool contract =
+    Test.Typed_address.get_entrypoint "activate" dex_orig.taddr in
+  let result =
+    Test.Contract.transfer activate_entrypoint activate_param 0tez in
+  let () =
+    assert_error test_name Dexter.error_INVALID_INITIAL_RESERVES result in
+  let storage : Dexter.storage =
+    Test.Typed_address.get_storage dex_orig.taddr in
+  if storage.active or storage.activationPending
+  then failwith (test_name ^ ": failed activation changed lifecycle state")
+  else ()
+
+let test_modified_fa2_activation_verifies_lqt_total_supply =
+  let test_name = "test_modified_fa2_activation_verifies_lqt_total_supply" in
+  let (dex_orig, _, _) = prepare_full_dex 0n 1000001n 0n in
+  let activate_param : Dexter.activate_pool =
+    {
+     expectedXtzPool = 1tez;
+     expectedTokenPool = 1000000n;
+     expectedLqtTotal = 1000000n;
+    } in
+  let activate_entrypoint : Dexter.activate_pool contract =
+    Test.Typed_address.get_entrypoint "activate" dex_orig.taddr in
+  let result =
+    Test.Contract.transfer activate_entrypoint activate_param 0tez in
+  let () =
+    assert_error test_name Dexter.error_LQT_TOTAL_MISMATCH result in
+  let storage : Dexter.storage =
+    Test.Typed_address.get_storage dex_orig.taddr in
+  if storage.active or storage.activationPending
+  then failwith (test_name ^ ": callback failure was not atomic")
+  else ()
+
+let test_modified_fa2_activation =
+  let test_name = "test_modified_fa2_activation" in
+  let (dex_orig, _, _) = setup_full_dex 0n in
+  let storage : Dexter.storage =
+    Test.Typed_address.get_storage dex_orig.taddr in
+  if
+    not storage.active
+    or storage.activationPending
+    or storage.xtzPool <> 1tez
+    or storage.tokenPool <> 1000000n
+    or storage.lqtTotal <> 1000000n
+  then failwith (test_name ^ ": activation state mismatch")
+  else ()
+
+let assert_malformed_fa2_response_rejected
+    (test_name : string)
+    (response_mode : MalformedFA2.response_mode) =
+  let () = clean () in
+  let () = Test.State.set_source (src ()) in
+  let token_storage : MalformedFA2.storage =
+    {
+     responseMode = response_mode;
+     balance = 1000000n;
+     wrongOwner = other ();
+    } in
+  let tok_orig =
+    Test.Originate.contract
+      (contract_of MalformedFA2)
+      token_storage
+      0tez in
+  let dex_orig =
+    deploy_dex
+      (Test.Typed_address.to_address tok_orig.taddr)
+      0n
+      0n
+      (other ()) in
+  let result =
+    Test.Typed_address.transfer
+      dex_orig.taddr
+      (UpdateTokenPool ())
+      0tez in
+  let () =
+    assert_error
+      test_name
+      Dexter.error_INVALID_FA2_BALANCE_RESPONSE
+      result in
+  let dex_storage : Dexter.storage =
+    Test.Typed_address.get_storage dex_orig.taddr in
+  if dex_storage.selfIsUpdatingTokenPool
+  then failwith (test_name ^ ": failed callback did not backtrack")
+  else ()
+
+let test_modified_fa2_rejects_wrong_callback_owner =
+  assert_malformed_fa2_response_rejected
+    "test_modified_fa2_rejects_wrong_callback_owner"
+    WrongOwner
+
+let test_modified_fa2_rejects_wrong_callback_token_id =
+  assert_malformed_fa2_response_rejected
+    "test_modified_fa2_rejects_wrong_callback_token_id"
+    WrongTokenId
+
+let test_modified_fa2_rejects_extra_callback_result =
+  assert_malformed_fa2_response_rejected
+    "test_modified_fa2_rejects_extra_callback_result"
+    ExtraResult
+
+let test_modified_fa2_rejects_empty_callback_result =
+  assert_malformed_fa2_response_rejected
+    "test_modified_fa2_rejects_empty_callback_result"
+    EmptyResult
+
+let test_modified_fa2_nonzero_token_id_lifecycle =
+  let test_name = "test_modified_fa2_nonzero_token_id_lifecycle" in
+  let (dex_orig, _, _) = prepare_full_dex 0n 1000000n 7n in
+  let () = activate_dex dex_orig.taddr in
+  let storage : Dexter.storage =
+    Test.Typed_address.get_storage dex_orig.taddr in
+  if storage.tokenId <> 7n or not storage.active
+  then failwith (test_name ^ ": nonzero token ID was not preserved")
+  else ()
+
+let test_modified_fa2_cannot_activate_twice =
+  let test_name = "test_modified_fa2_cannot_activate_twice" in
+  let (dex_orig, _, _) = setup_full_dex 0n in
+  let activate_param : Dexter.activate_pool =
+    {
+     expectedXtzPool = 1tez;
+     expectedTokenPool = 1000000n;
+     expectedLqtTotal = 1000000n;
+    } in
+  let activate_entrypoint : Dexter.activate_pool contract =
+    Test.Typed_address.get_entrypoint "activate" dex_orig.taddr in
+  let result =
+    Test.Contract.transfer activate_entrypoint activate_param 0tez in
+  assert_error test_name Dexter.error_POOL_ALREADY_ACTIVE result
+
+let test_modified_fa2_empty_pool_stays_fail_closed =
+  let test_name = "test_modified_fa2_empty_pool_stays_fail_closed" in
+  let (dex_orig, _, _) = setup_full_dex 0n in
+  let remove_param : Dexter.remove_liquidity =
+    {
+     to_ = src ();
+     lqtBurned = 1000000n;
+     minXtzWithdrawn = 1tez;
+     minTokensWithdrawn = 1000000n;
+     deadline = future;
+    } in
+  let _ : nat =
+    Test.Typed_address.transfer_exn
+      dex_orig.taddr
+      (RemoveLiquidity remove_param)
+      0tez in
+  let storage : Dexter.storage =
+    Test.Typed_address.get_storage dex_orig.taddr in
+  let () =
+    if
+      storage.xtzPool <> 0tez
+      or storage.tokenPool <> 0n
+      or storage.lqtTotal <> 0n
+    then failwith (test_name ^ ": pool was not emptied")
+    else () in
+  let swap_param : Dexter.xtz_to_token =
+    {
+     to_ = src ();
+     minTokensBought = 0n;
+     deadline = future;
+    } in
+  let result =
+    Test.Typed_address.transfer
+      dex_orig.taddr
+      (XtzToToken swap_param)
+      1tez in
+  assert_error test_name Dexter.error_POOL_NOT_ACTIVE result
+
+let test_modified_fa2_one_sided_active_states_fail_closed =
+  let test_name = "test_modified_fa2_one_sided_active_states_fail_closed" in
+  let () = clean () in
+  let () = Test.State.set_source (src ()) in
+  let tok_orig = deploy_fa2_token 1000000n 0n in
+  let base_storage =
+    Dexter.build_storage
+      {
+       lqtTotal = 1000000n;
+       manager = src ();
+       tokenAddress = Test.Typed_address.to_address tok_orig.taddr;
+       tokenId = 0n;
+       protocol_fee_bp = 0n;
+       protocol_fee_recipient = other ();
+      } in
+  let xtz_only_storage =
+    {
+     base_storage with
+     active = true;
+     xtzPool = 100tez;
+    } in
+  let xtz_only_orig =
+    Test.Originate.contract
+      (contract_of Dexter)
+      xtz_only_storage
+      100tez in
+  let token_swap_param : Dexter.token_to_xtz =
+    {
+     to_ = src ();
+     tokensSold = 1000n;
+     minXtzBought = 0tez;
+     deadline = future;
+    } in
+  let xtz_only_result =
+    Test.Typed_address.transfer
+      xtz_only_orig.taddr
+      (TokenToXtz token_swap_param)
+      0tez in
+  let () =
+    assert_error
+      test_name
+      Dexter.error_POOL_NOT_ACTIVE
+      xtz_only_result in
+  let token_only_storage =
+    {
+     base_storage with
+     active = true;
+     tokenPool = 1000000n;
+    } in
+  let token_only_orig =
+    Test.Originate.contract
+      (contract_of Dexter)
+      token_only_storage
+      0tez in
+  let xtz_swap_param : Dexter.xtz_to_token =
+    {
+     to_ = src ();
+     minTokensBought = 0n;
+     deadline = future;
+    } in
+  let token_only_result =
+    Test.Typed_address.transfer
+      token_only_orig.taddr
+      (XtzToToken xtz_swap_param)
+      1tez in
+  assert_error
+    test_name
+    Dexter.error_POOL_NOT_ACTIVE
+    token_only_result
+
+let test_modified_fa2_xtz_fee_claim_preserves_lp_reserve =
+  let test_name = "test_modified_fa2_xtz_fee_claim_preserves_lp_reserve" in
+  let (dex_orig, _, _) = setup_full_dex 100n in
+  let swap_param : Dexter.xtz_to_token =
+    {
+     to_ = src ();
+     minTokensBought = 0n;
+     deadline = future;
+    } in
+  let _ : nat =
+    Test.Typed_address.transfer_exn
+      dex_orig.taddr
+      (XtzToToken swap_param)
+      1tez in
+  let storage_after_swap : Dexter.storage =
+    Test.Typed_address.get_storage dex_orig.taddr in
+  let () =
+    if
+      storage_after_swap.xtzPool <> 1990000mutez
+      or storage_after_swap.accumulated_protocol_fee_xtz <> 10000mutez
+    then failwith (test_name ^ ": XTZ fee accounting mismatch")
+    else () in
+  let () = Test.State.set_source (other ()) in
+  let _ : nat =
+    Test.Typed_address.transfer_exn
+      dex_orig.taddr
+      (ClaimProtocolFeeXtz ())
+      0tez in
+  let storage_after_claim : Dexter.storage =
+    Test.Typed_address.get_storage dex_orig.taddr in
+  if
+    storage_after_claim.xtzPool <> storage_after_swap.xtzPool
+    or storage_after_claim.accumulated_protocol_fee_xtz <> 0mutez
+  then failwith (test_name ^ ": XTZ claim changed the LP reserve")
+  else ()
+
+let test_modified_fa2_token_fee_survives_resynchronization =
+  let test_name = "test_modified_fa2_token_fee_survives_resynchronization" in
+  let (dex_orig, _, tok_orig) = setup_full_dex 100n in
+  let swap_param : Dexter.token_to_xtz =
+    {
+     to_ = src ();
+     tokensSold = 1000000n;
+     minXtzBought = 0tez;
+     deadline = future;
+    } in
+  let _ : nat =
+    Test.Typed_address.transfer_exn
+      dex_orig.taddr
+      (TokenToXtz swap_param)
+      0tez in
+  let storage_after_swap : Dexter.storage =
+    Test.Typed_address.get_storage dex_orig.taddr in
+  let () =
+    if
+      storage_after_swap.tokenPool <> 1990000n
+      or storage_after_swap.accumulated_protocol_fee_token <> 10000n
+    then failwith (test_name ^ ": fee accounting mismatch after swap")
+    else () in
+  let _ : nat =
+    Test.Typed_address.transfer_exn
+      dex_orig.taddr
+      (UpdateTokenPool ())
+      0tez in
+  let storage_after_update : Dexter.storage =
+    Test.Typed_address.get_storage dex_orig.taddr in
+  let () =
+    if
+      storage_after_update.tokenPool <> 1990000n
+      or storage_after_update.accumulated_protocol_fee_token <> 10000n
+    then failwith (test_name ^ ": fee accounting changed during synchronization")
+    else () in
+  let () = Test.State.set_source (other ()) in
+  let _ : nat =
+    Test.Typed_address.transfer_exn
+      dex_orig.taddr
+      (ClaimProtocolFeeToken ())
+      0tez in
+  let storage_after_claim : Dexter.storage =
+    Test.Typed_address.get_storage dex_orig.taddr in
+  if
+    storage_after_claim.accumulated_protocol_fee_token <> 0n
+    or fa2_balance tok_orig.taddr (other ()) <> 10000n
+  then failwith (test_name ^ ": fee claim mismatch")
+  else ()
+
+let test_modified_fa2_liquidity_lifecycle_after_activation =
+  let test_name = "test_modified_fa2_liquidity_lifecycle_after_activation" in
+  let (dex_orig, lqt_orig, _) = setup_full_dex 0n in
+  let add_param : Dexter.add_liquidity =
+    {
+     owner = src ();
+     minLqtMinted = 1000000n;
+     maxTokensDeposited = 1000000n;
+     deadline = future;
+    } in
+  let _ : nat =
+    Test.Typed_address.transfer_exn
+      dex_orig.taddr
+      (AddLiquidity add_param)
+      1tez in
+  let storage_after_add : Dexter.storage =
+    Test.Typed_address.get_storage dex_orig.taddr in
+  let () =
+    if
+      storage_after_add.xtzPool <> 2tez
+      or storage_after_add.tokenPool <> 2000000n
+      or storage_after_add.lqtTotal <> 2000000n
+    then failwith (test_name ^ ": add-liquidity state mismatch")
+    else () in
+  let remove_param : Dexter.remove_liquidity =
+    {
+     to_ = src ();
+     lqtBurned = 500000n;
+     minXtzWithdrawn = 500000mutez;
+     minTokensWithdrawn = 500000n;
+     deadline = future;
+    } in
+  let _ : nat =
+    Test.Typed_address.transfer_exn
+      dex_orig.taddr
+      (RemoveLiquidity remove_param)
+      0tez in
+  let storage_after_remove : Dexter.storage =
+    Test.Typed_address.get_storage dex_orig.taddr in
+  let lqt_storage : LQT.LQT.storage =
+    Test.Typed_address.get_storage lqt_orig.taddr in
+  if
+    storage_after_remove.xtzPool <> 1500000mutez
+    or storage_after_remove.tokenPool <> 1500000n
+    or storage_after_remove.lqtTotal <> 1500000n
+    or lqt_storage.total_supply <> 1500000n
+  then failwith (test_name ^ ": remove-liquidity state mismatch")
+  else ()

--- a/dex/tests/dexter_mod_fa2.test.mligo
+++ b/dex/tests/dexter_mod_fa2.test.mligo
@@ -98,7 +98,6 @@ let deploy_lqt
 let deploy_dex
     (token_address : address)
     (token_id : nat)
-    (protocol_fee_bp : nat)
     (protocol_fee_recipient : address) =
   let dex_storage =
     Dexter.build_storage
@@ -107,7 +106,6 @@ let deploy_dex
        manager = src ();
        tokenAddress = token_address;
        tokenId = token_id;
-       protocol_fee_bp = protocol_fee_bp;
        protocol_fee_recipient = protocol_fee_recipient;
       } in
   Test.Originate.contract (contract_of Dexter) dex_storage 0tez
@@ -126,14 +124,13 @@ let activate_dex (dex_taddr) =
   ()
 
 let prepare_full_dex
-    (protocol_fee_bp : nat)
     (lqt_total_supply : nat)
     (token_id : nat) =
   let () = clean () in
   let () = Test.State.set_source (src ()) in
   let tok_orig = deploy_fa2_token 1001000000n token_id in
   let tok_addr = Test.Typed_address.to_address tok_orig.taddr in
-  let dex_orig = deploy_dex tok_addr token_id protocol_fee_bp (other ()) in
+  let dex_orig = deploy_dex tok_addr token_id (other ()) in
   let dex_addr = Test.Typed_address.to_address dex_orig.taddr in
   let lqt_orig = deploy_lqt lqt_total_supply (src ()) dex_addr in
   let lqt_addr = Test.Typed_address.to_address lqt_orig.taddr in
@@ -181,9 +178,9 @@ let prepare_full_dex
     Test.Typed_address.transfer_exn dex_orig.taddr (UpdateTokenPool ()) 0tez in
   (dex_orig, lqt_orig, tok_orig)
 
-let setup_full_dex (protocol_fee_bp : nat) =
+let setup_full_dex () =
   let (dex_orig, lqt_orig, tok_orig) =
-    prepare_full_dex protocol_fee_bp 1000000n 0n in
+    prepare_full_dex 1000000n 0n in
   let () = activate_dex dex_orig.taddr in
   (dex_orig, lqt_orig, tok_orig)
 
@@ -216,7 +213,6 @@ let test_modified_fa2_pool_is_inactive_by_default =
   let dex_orig =
     deploy_dex
       (Test.Typed_address.to_address tok_orig.taddr)
-      0n
       0n
       (other ()) in
   let storage : Dexter.storage =
@@ -277,7 +273,6 @@ let test_modified_fa2_only_manager_can_seed_inactive_pool =
     deploy_dex
       (Test.Typed_address.to_address tok_orig.taddr)
       0n
-      0n
       (other ()) in
   let () = Test.State.set_source (other ()) in
   let result =
@@ -289,7 +284,7 @@ let test_modified_fa2_only_manager_can_seed_inactive_pool =
 
 let test_modified_fa2_activation_rejects_unexpected_reserves =
   let test_name = "test_modified_fa2_activation_rejects_unexpected_reserves" in
-  let (dex_orig, _, _) = prepare_full_dex 0n 1000000n 0n in
+  let (dex_orig, _, _) = prepare_full_dex 1000000n 0n in
   let activate_param : Dexter.activate_pool =
     {
      expectedXtzPool = 1tez;
@@ -310,7 +305,7 @@ let test_modified_fa2_activation_rejects_unexpected_reserves =
 
 let test_modified_fa2_activation_verifies_lqt_total_supply =
   let test_name = "test_modified_fa2_activation_verifies_lqt_total_supply" in
-  let (dex_orig, _, _) = prepare_full_dex 0n 1000001n 0n in
+  let (dex_orig, _, _) = prepare_full_dex 1000001n 0n in
   let activate_param : Dexter.activate_pool =
     {
      expectedXtzPool = 1tez;
@@ -331,7 +326,7 @@ let test_modified_fa2_activation_verifies_lqt_total_supply =
 
 let test_modified_fa2_activation =
   let test_name = "test_modified_fa2_activation" in
-  let (dex_orig, _, _) = setup_full_dex 0n in
+  let (dex_orig, _, _) = setup_full_dex () in
   let storage : Dexter.storage =
     Test.Typed_address.get_storage dex_orig.taddr in
   if
@@ -362,7 +357,6 @@ let assert_malformed_fa2_response_rejected
   let dex_orig =
     deploy_dex
       (Test.Typed_address.to_address tok_orig.taddr)
-      0n
       0n
       (other ()) in
   let result =
@@ -403,7 +397,7 @@ let test_modified_fa2_rejects_empty_callback_result =
 
 let test_modified_fa2_nonzero_token_id_lifecycle =
   let test_name = "test_modified_fa2_nonzero_token_id_lifecycle" in
-  let (dex_orig, _, _) = prepare_full_dex 0n 1000000n 7n in
+  let (dex_orig, _, _) = prepare_full_dex 1000000n 7n in
   let () = activate_dex dex_orig.taddr in
   let storage : Dexter.storage =
     Test.Typed_address.get_storage dex_orig.taddr in
@@ -413,7 +407,7 @@ let test_modified_fa2_nonzero_token_id_lifecycle =
 
 let test_modified_fa2_cannot_activate_twice =
   let test_name = "test_modified_fa2_cannot_activate_twice" in
-  let (dex_orig, _, _) = setup_full_dex 0n in
+  let (dex_orig, _, _) = setup_full_dex () in
   let activate_param : Dexter.activate_pool =
     {
      expectedXtzPool = 1tez;
@@ -428,7 +422,7 @@ let test_modified_fa2_cannot_activate_twice =
 
 let test_modified_fa2_empty_pool_stays_fail_closed =
   let test_name = "test_modified_fa2_empty_pool_stays_fail_closed" in
-  let (dex_orig, _, _) = setup_full_dex 0n in
+  let (dex_orig, _, _) = setup_full_dex () in
   let remove_param : Dexter.remove_liquidity =
     {
      to_ = src ();
@@ -476,7 +470,6 @@ let test_modified_fa2_one_sided_active_states_fail_closed =
        manager = src ();
        tokenAddress = Test.Typed_address.to_address tok_orig.taddr;
        tokenId = 0n;
-       protocol_fee_bp = 0n;
        protocol_fee_recipient = other ();
       } in
   let xtz_only_storage =
@@ -536,7 +529,7 @@ let test_modified_fa2_one_sided_active_states_fail_closed =
 
 let test_modified_fa2_xtz_fee_claim_preserves_lp_reserve =
   let test_name = "test_modified_fa2_xtz_fee_claim_preserves_lp_reserve" in
-  let (dex_orig, _, _) = setup_full_dex 100n in
+  let (dex_orig, _, _) = setup_full_dex () in
   let swap_param : Dexter.xtz_to_token =
     {
      to_ = src ();
@@ -552,8 +545,8 @@ let test_modified_fa2_xtz_fee_claim_preserves_lp_reserve =
     Test.Typed_address.get_storage dex_orig.taddr in
   let () =
     if
-      storage_after_swap.xtzPool <> 1990000mutez
-      or storage_after_swap.accumulated_protocol_fee_xtz <> 10000mutez
+      storage_after_swap.xtzPool <> 1999500mutez
+      or storage_after_swap.accumulated_protocol_fee_xtz <> 500mutez
     then failwith (test_name ^ ": XTZ fee accounting mismatch")
     else () in
   let () = Test.State.set_source (other ()) in
@@ -572,7 +565,7 @@ let test_modified_fa2_xtz_fee_claim_preserves_lp_reserve =
 
 let test_modified_fa2_token_fee_survives_resynchronization =
   let test_name = "test_modified_fa2_token_fee_survives_resynchronization" in
-  let (dex_orig, _, tok_orig) = setup_full_dex 100n in
+  let (dex_orig, _, tok_orig) = setup_full_dex () in
   let swap_param : Dexter.token_to_xtz =
     {
      to_ = src ();
@@ -589,8 +582,8 @@ let test_modified_fa2_token_fee_survives_resynchronization =
     Test.Typed_address.get_storage dex_orig.taddr in
   let () =
     if
-      storage_after_swap.tokenPool <> 1990000n
-      or storage_after_swap.accumulated_protocol_fee_token <> 10000n
+      storage_after_swap.tokenPool <> 1999500n
+      or storage_after_swap.accumulated_protocol_fee_token <> 500n
     then failwith (test_name ^ ": fee accounting mismatch after swap")
     else () in
   let _ : nat =
@@ -602,8 +595,8 @@ let test_modified_fa2_token_fee_survives_resynchronization =
     Test.Typed_address.get_storage dex_orig.taddr in
   let () =
     if
-      storage_after_update.tokenPool <> 1990000n
-      or storage_after_update.accumulated_protocol_fee_token <> 10000n
+      storage_after_update.tokenPool <> 1999500n
+      or storage_after_update.accumulated_protocol_fee_token <> 500n
     then failwith (test_name ^ ": fee accounting changed during synchronization")
     else () in
   let () = Test.State.set_source (other ()) in
@@ -616,13 +609,13 @@ let test_modified_fa2_token_fee_survives_resynchronization =
     Test.Typed_address.get_storage dex_orig.taddr in
   if
     storage_after_claim.accumulated_protocol_fee_token <> 0n
-    or fa2_balance tok_orig.taddr (other ()) <> 10000n
+    or fa2_balance tok_orig.taddr (other ()) <> 500n
   then failwith (test_name ^ ": fee claim mismatch")
   else ()
 
 let test_modified_fa2_liquidity_lifecycle_after_activation =
   let test_name = "test_modified_fa2_liquidity_lifecycle_after_activation" in
-  let (dex_orig, lqt_orig, _) = setup_full_dex 0n in
+  let (dex_orig, lqt_orig, _) = setup_full_dex () in
   let add_param : Dexter.add_liquidity =
     {
      owner = src ();

--- a/dex/tests/dexter_mod_fa2.test.mligo
+++ b/dex/tests/dexter_mod_fa2.test.mligo
@@ -282,13 +282,13 @@ let test_modified_fa2_only_manager_can_seed_inactive_pool =
     Dexter.error_ONLY_MANAGER_CAN_INITIALIZE_POOL
     result
 
-let test_modified_fa2_activation_rejects_unexpected_reserves =
-  let test_name = "test_modified_fa2_activation_rejects_unexpected_reserves" in
+let test_modified_fa2_activation_rejects_underfunded_reserves =
+  let test_name = "test_modified_fa2_activation_rejects_underfunded_reserves" in
   let (dex_orig, _, _) = prepare_full_dex 1000000n 0n in
   let activate_param : Dexter.activate_pool =
     {
      expectedXtzPool = 1tez;
-     expectedTokenPool = 999999n;
+     expectedTokenPool = 1000001n;
      expectedLqtTotal = 1000000n;
     } in
   let activate_entrypoint : Dexter.activate_pool contract =
@@ -301,6 +301,32 @@ let test_modified_fa2_activation_rejects_unexpected_reserves =
     Test.Typed_address.get_storage dex_orig.taddr in
   if storage.active or storage.activationPending
   then failwith (test_name ^ ": failed activation changed lifecycle state")
+  else ()
+
+let test_modified_fa2_activation_accepts_donated_token_excess =
+  let test_name =
+    "test_modified_fa2_activation_accepts_donated_token_excess" in
+  let (dex_orig, _, tok_orig) = prepare_full_dex 1000000n 0n in
+  let dex_addr = Test.Typed_address.to_address dex_orig.taddr in
+  let donation : FA2.transfer =
+    [
+      {
+       from_ = src ();
+       txs = [{to_ = dex_addr; token_id = 0n; amount = 1n}];
+      }
+    ] in
+  let _ : nat =
+    Test.Typed_address.transfer_exn tok_orig.taddr (Transfer donation) 0tez in
+  let _ : nat =
+    Test.Typed_address.transfer_exn dex_orig.taddr (UpdateTokenPool ()) 0tez in
+  let () = activate_dex dex_orig.taddr in
+  let storage : Dexter.storage =
+    Test.Typed_address.get_storage dex_orig.taddr in
+  if
+    not storage.active
+    or storage.activationPending
+    or storage.tokenPool <> 1000001n
+  then failwith (test_name ^ ": donated excess did not remain in the pool")
   else ()
 
 let test_modified_fa2_activation_verifies_lqt_total_supply =

--- a/dex/tests/util_mod.mligo
+++ b/dex/tests/util_mod.mligo
@@ -61,7 +61,6 @@ let deploy_dex
     (manager : address)
     (token_address : address)
     (xtz_amount : tez)
-    (protocol_fee_bp : nat)
     (protocol_fee_recipient : address) =
   let dex_storage =
     DexterMod.Dexter.build_storage
@@ -69,7 +68,6 @@ let deploy_dex
        lqtTotal = lqt_total;
        manager = manager;
        tokenAddress = token_address;
-       protocol_fee_bp = protocol_fee_bp;
        protocol_fee_recipient = protocol_fee_recipient;
       } in
   Test.Originate.contract (contract_of DexterMod.Dexter) dex_storage xtz_amount
@@ -127,43 +125,7 @@ let setup_full_dex () =
   let () = Test.State.set_source (src ()) in
   let tok_orig = deploy_token 1001000000n (src ()) in
   let dex_orig =
-    deploy_dex 1000000n (src ()) (Test.Typed_address.to_address tok_orig.taddr) 0tez 0n (src ()) in
-  let lqt_orig = deploy_lqt 1000000n (src ()) (Test.Typed_address.to_address dex_orig.taddr) in
-  let approve_param : LQT.LQT.approve =
-    {
-     spender = Test.Typed_address.to_address dex_orig.taddr;
-     value = 1000000000000n
-    } in
-  let _ : nat = Test.Typed_address.transfer_exn tok_orig.taddr (Approve approve_param) 0tez in
-  let _ : nat = Test.Typed_address.transfer_exn dex_orig.taddr (Default_ ()) 1tez in
-  let transfer_param : LQT.LQT.transfer =
-    {
-     address_from = src ();
-     address_to = Test.Typed_address.to_address dex_orig.taddr;
-     value = 1000000n
-    } in
-  let _ : nat = Test.Typed_address.transfer_exn tok_orig.taddr (Transfer transfer_param) 0tez in
-  let _ : nat = Test.Typed_address.transfer_exn dex_orig.taddr (UpdateTokenPool ()) 0tez in
-  let _ : nat =
-    Test.Typed_address.transfer_exn
-      dex_orig.taddr
-      (SetLqtAddress (Test.Typed_address.to_address lqt_orig.taddr))
-      0tez in
-  let () = activate_dex dex_orig.taddr 1tez 1000000n 1000000n in
-  (dex_orig, lqt_orig, tok_orig)
-
-let setup_full_dex_with_fee (protocol_fee_bp : nat) =
-  let () = clean () in
-  let () = Test.State.set_source (src ()) in
-  let tok_orig = deploy_token 1001000000n (src ()) in
-  let dex_orig =
-    deploy_dex
-      1000000n
-      (src ())
-      (Test.Typed_address.to_address tok_orig.taddr)
-      0tez
-      protocol_fee_bp
-      (src ()) in
+    deploy_dex 1000000n (src ()) (Test.Typed_address.to_address tok_orig.taddr) 0tez (src ()) in
   let lqt_orig = deploy_lqt 1000000n (src ()) (Test.Typed_address.to_address dex_orig.taddr) in
   let approve_param : LQT.LQT.approve =
     {
@@ -198,7 +160,6 @@ let setup_dex_with_updating_pool () =
        lqtTotal = 1000000n;
        manager = src ();
        tokenAddress = Test.Typed_address.to_address tok_orig.taddr;
-       protocol_fee_bp = 0n;
        protocol_fee_recipient = src ();
       } in
   let dex_storage = {dex_storage with selfIsUpdatingTokenPool = true} in
@@ -218,7 +179,6 @@ let setup_custom_dex (xtz_pool : tez) (token_pool : nat) (lqt_total : nat) =
       (src ())
       (Test.Typed_address.to_address tok_orig.taddr)
       0mutez
-      0n
       (src ()) in
   let _ : nat = Test.Typed_address.transfer_exn dex_orig.taddr (Default_ ()) xtz_pool in
   let lqt_orig = deploy_lqt lqt_total (src ()) (Test.Typed_address.to_address dex_orig.taddr) in

--- a/dex/tests/util_mod.mligo
+++ b/dex/tests/util_mod.mligo
@@ -102,6 +102,26 @@ let deploy_lqt (lqt_amount : nat) (owner : address) (admin : address) =
     } in
   Test.Originate.contract (contract_of LQT.LQT) lqt_storage 0tez
 
+let activate_dex
+    (dex_taddr)
+    (expected_xtz_pool : tez)
+    (expected_token_pool : nat)
+    (expected_lqt_total : nat) =
+  let activate_param : DexterMod.Dexter.activate_pool =
+    {
+     expectedXtzPool = expected_xtz_pool;
+     expectedTokenPool = expected_token_pool;
+     expectedLqtTotal = expected_lqt_total;
+    } in
+  let activate_entrypoint : DexterMod.Dexter.activate_pool contract =
+    Test.Typed_address.get_entrypoint "activate" dex_taddr in
+  let _ : nat =
+    Test.Contract.transfer_exn
+      activate_entrypoint
+      activate_param
+      0tez in
+  ()
+
 let setup_full_dex () =
   let () = clean () in
   let () = Test.State.set_source (src ()) in
@@ -129,6 +149,7 @@ let setup_full_dex () =
       dex_orig.taddr
       (SetLqtAddress (Test.Typed_address.to_address lqt_orig.taddr))
       0tez in
+  let () = activate_dex dex_orig.taddr 1tez 1000000n 1000000n in
   (dex_orig, lqt_orig, tok_orig)
 
 let setup_full_dex_with_fee (protocol_fee_bp : nat) =
@@ -164,6 +185,7 @@ let setup_full_dex_with_fee (protocol_fee_bp : nat) =
       dex_orig.taddr
       (SetLqtAddress (Test.Typed_address.to_address lqt_orig.taddr))
       0tez in
+  let () = activate_dex dex_orig.taddr 1tez 1000000n 1000000n in
   (dex_orig, lqt_orig, tok_orig)
 
 let setup_dex_with_updating_pool () =
@@ -219,6 +241,7 @@ let setup_custom_dex (xtz_pool : tez) (token_pool : nat) (lqt_total : nat) =
     } in
   let _ : nat = Test.Typed_address.transfer_exn tok_orig.taddr (Transfer transfer_param) 0tez in
   let _ : nat = Test.Typed_address.transfer_exn dex_orig.taddr (UpdateTokenPool ()) 0tez in
+  let () = activate_dex dex_orig.taddr xtz_pool token_pool lqt_total in
   (dex_orig, lqt_orig, tok_orig)
 
 (*****************************************************************************)
@@ -267,6 +290,12 @@ let assert_dex_state
     then failwith (test_name ^ ": incorrect lqtTotal, expected: " ^ Test.String.show lqt_total ^ ", got: " ^ Test.String.show storage.lqtTotal)
     else () in
   ()
+
+let assert_dex_active (dex_taddr) (test_name : string) (expected : bool) =
+  let storage : DexterMod.Dexter.storage = Test.Typed_address.get_storage dex_taddr in
+  if storage.active <> expected
+  then failwith (test_name ^ ": incorrect active state")
+  else ()
 
 let assert_accumulated_fee_xtz (dex_taddr) (test_name : string) (expected : tez) =
   let storage : DexterMod.Dexter.storage = Test.Typed_address.get_storage dex_taddr in


### PR DESCRIPTION
## Summary

- Originate modified pools inactive and require verified reserve and LQT-supply activation.
- Seed, synchronize, activate, and transfer management in one atomic operation group.
- Make the 30 bp swap fee immutable, allocating 25 bp to LPs and 5 bp to the protocol recipient.
- Correct fee accounting so the protocol allocation is not charged on top of the total swap fee.
- Tighten FA2 balance callback validation and preserve configured token IDs.
- Use exact integer deployment arithmetic and verify the resulting on-chain state.
- Regenerate the modified FA1.2 and FA2 Michelson artifacts.

## Why

Partially initialized pools and configurable fee composition could produce unsafe or unexpected pool state. Deployment also relied on numeric conversions and callback assumptions that were too permissive for production use.

## Developer impact

The modified-pool storage and interface change. The fee-setting entrypoint and fee environment variables are removed. Deployment may use an implicit signer as the temporary initialization manager and transfer final management to an implicit or originated account.

## Validation

- Pinned LIGO 1.11.5 compilation for modified FA1.2 and FA2 artifacts
- Full modified FA1.2 contract suite
- Modified FA2 lifecycle, callback, fee, and liquidity suite
- TypeScript typecheck
- Deployment arithmetic, batch-ordering, and compiled-schema tests
