### PR TITLE
Add isolated token-to-token pool

### DIFF
--- a/.github/workflows/token-token-pool-ci.yml
+++ b/.github/workflows/token-token-pool-ci.yml
@@ -1,0 +1,68 @@
+name: Token-to-token pool CI
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/token-token-pool-ci.yml"
+      - "dex/contracts/token_token_pool.mligo"
+      - "dex/compiled_contracts/token_token_pool.tz"
+      - "dex/tests/token_token_pool.test.mligo"
+      - "dex/scripts/**"
+      - "dex/TOKEN_TOKEN_POOL*.md"
+  push:
+    branches:
+      - trunk
+    paths:
+      - ".github/workflows/token-token-pool-ci.yml"
+      - "dex/contracts/token_token_pool.mligo"
+      - "dex/compiled_contracts/token_token_pool.tz"
+      - "dex/tests/token_token_pool.test.mligo"
+      - "dex/scripts/**"
+      - "dex/TOKEN_TOKEN_POOL*.md"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: token-token-pool-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Reproduce Michelson artifact
+        run: |
+          docker run --rm -v "$PWD:/project" -w /project ligolang/ligo:1.11.5 \
+            compile contract dex/contracts/token_token_pool.mligo \
+            -m TokenTokenPool --no-warn > /tmp/token_token_pool.tz
+          cmp /tmp/token_token_pool.tz dex/compiled_contracts/token_token_pool.tz
+          echo "e80be7e08aed3782c338472d1faa578d73719414f2b80254a10df5c7300f6268  /tmp/token_token_pool.tz" \
+            | sha256sum --check --strict
+
+      - name: Run LIGO tests
+        run: |
+          docker run --rm -v "$PWD:/project" -w /project ligolang/ligo:1.11.5 \
+            run test dex/tests/token_token_pool.test.mligo --no-warn
+
+  deployment-tooling:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: dex/scripts
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: dex/scripts/package-lock.json
+
+      - run: npm ci --ignore-scripts
+      - run: npm run typecheck
+      - run: npm run test:token-token-config

--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,7 @@ dist
 
 .vscode
 .idea
+.ligo/
 
 build/
 tmp/

--- a/dex/README.md
+++ b/dex/README.md
@@ -1,5 +1,11 @@
 # Dexter v2 DEX
 
+## Token-to-token pool
+
+The asset-agnostic FA2-to-FA2 deployment candidate is documented in [TOKEN_TOKEN_POOL.md](./TOKEN_TOKEN_POOL.md). Its internal security review and residual launch gates are in [TOKEN_TOKEN_POOL_SECURITY_REVIEW.md](./TOKEN_TOKEN_POOL_SECURITY_REVIEW.md).
+
+This pool is separate from the native-XTZ Dexter contracts described below. It uses immutable 25 bp LP and 5 bp protocol fees and contains no hardcoded token, administrator, or fee-recipient address.
+
 Decentralized Exchange (DEX) implementation for Tezos blockchain based on Dexter v2 contracts updated to latest Ligo v1.11.5
 
 ## Project Structure

--- a/dex/TOKEN_TOKEN_POOL.md
+++ b/dex/TOKEN_TOKEN_POOL.md
@@ -1,0 +1,121 @@
+# Token-to-token pool
+
+This directory contains an asset-agnostic, single-pair FA2-to-FA2 constant-product pool intended for independent review and testnet deployment. It is deliberately smaller than a shared multi-pair DEX core.
+
+Mainnet deployment remains conditional on an independent contract review, exact token-code allowlisting, and a complete testnet rehearsal.
+
+## Design
+
+Each deployment serves exactly two immutable FA2 assets. The token contracts and token IDs are origination parameters; no asset address, administrator address, or fee-recipient address is compiled into the source or Michelson artifact.
+
+The contract includes:
+
+- constant-product swaps in both directions;
+- proportional liquidity deposits and withdrawals;
+- an integrated LP ledger, so pool reserves and LP supply cannot drift across separate contracts;
+- permanently locked minimum liquidity of 1,000 LP units;
+- exact before-and-after pool-balance verification for every underlying-token transfer;
+- immutable 25-basis-point LP and 5-basis-point protocol fees;
+- separate protocol-fee accounting outside tradable reserves;
+- a pause control that stops initialization, deposits, and swaps but never withdrawals or fee claims;
+- a two-step administrator handoff; and
+- an immutable protocol-fee recipient selected at origination.
+
+It intentionally excludes native XTZ handling, baker voting, reward buckets, auctions, buybacks, referrals, flash loans, multi-pair shared custody, and an oracle. Removing these systems avoids giving an asset-pair pool unrelated custody and governance responsibilities.
+
+## Swap economics
+
+For input `x`, input reserve `Rin`, and output reserve `Rout`:
+
+```text
+effective = x * 9,970
+output    = effective * Rout / (Rin * 10,000 + effective)
+```
+
+The output calculation charges 30 basis points. Five basis points of the gross input, rounded down, accrue to the protocol fee balance. The rest of the input enters the reserve, which leaves the 25-basis-point LP portion in the pool. Integer rounding is always in the pool's favor, and the test suite checks that the reserve product does not decrease.
+
+## Verified transfers and token requirements
+
+Every pool action is a short callback state machine:
+
+1. Read the pool's underlying-token balance.
+2. Execute one FA2 transfer.
+3. Read the balance again.
+4. Require the exact expected delta before advancing.
+
+An inbound token that credits the pool less than requested, or an outbound token that debits the pool by the wrong amount, causes the complete Tezos operation to fail. Callback entrypoints authenticate the configured token contract, requested pool owner, token ID, pending phase, and deadline.
+
+The pool must only be deployed against immutable, reviewed FA2 implementations that reliably execute `balance_of` callbacks and standard, non-taxed `transfer` operations. The pool verifies its own debit on an outbound transfer; the reviewed token implementation must guarantee that the same amount is credited to the requested recipient. A token that deliberately omits a requested callback can strand an in-progress action. These are deployment preconditions, not properties another contract can prove about arbitrary future token behavior. Pin and independently verify both token contracts and token IDs before origination.
+
+## LP interface limitation
+
+The integrated LP token exposes FA2-shaped `transfer`, `update_operators`, and `balance_of` entrypoints, but each call accepts exactly one item/request. Consumers must split batches into separate operations. This bound avoids unbounded gas and a LIGO 1.11.5 stack-join compiler defect reproduced by the repository's older batched FA2 helper.
+
+Do not advertise the LP interface as batch-complete FA2.
+
+## Build and test
+
+Use LIGO 1.11.5:
+
+```sh
+ligo compile contract dex/contracts/token_token_pool.mligo \
+  -m TokenTokenPool \
+  --no-warn \
+  -o dex/compiled_contracts/token_token_pool.tz
+
+ligo run test dex/tests/token_token_pool.test.mligo --no-warn
+```
+
+The checked-in Michelson artifact must have SHA-256:
+
+```text
+e80be7e08aed3782c338472d1faa578d73719414f2b80254a10df5c7300f6268
+```
+
+Recompile and compare the hash before deploying.
+
+## Deployment
+
+From `dex/scripts`:
+
+```sh
+npm ci
+npm run typecheck
+npm run test:token-token-config
+npm run deploy:token-token:testnet
+```
+
+The deployment package requires Node.js 22 or newer. Its locked production dependency tree reports zero known vulnerabilities under `npm audit --omit=dev` as of this review.
+
+The deployment script:
+
+1. validates that the two asset descriptors differ and that seed amounts exceed the locked minimum;
+2. verifies both token contracts expose `transfer`, `balance_of`, and `update_operators`;
+3. originates the pool with the deployer as temporary administrator;
+4. authorizes the pool as operator for each seed asset;
+5. initializes and balance-verifies both reserves;
+6. proposes the configured final administrator; and
+7. writes a local, gitignored deployment receipt.
+
+The proposed administrator must call `accept_admin`. Verify that acceptance on-chain before considering the handoff complete. The fee recipient is final at origination and is not mutable.
+
+Configuration values are documented in `dex/scripts/.env.example`. Private keys, token addresses, administrator addresses, deployment receipts, and live metadata locations belong in the deployment environment, not in commits.
+
+Mainnet origination also requires the explicit environment confirmation documented in that example. This guard is separate from, and does not replace, the launch gates below.
+
+## Provenance
+
+The architecture and constant-product conventions were informed by QuipuSwap Core V2, pinned for review at upstream commit `684f17d42293034764fd2ff70ce1075b912406da` from `madfish-solutions/quipuswap-core-v2`. That upstream package declares the MIT license in `package.json` but contains no license file at the pinned commit.
+
+This implementation is a reduced CameLIGO reimplementation. It does not vendor the upstream shared core, bucket, auction, baker registry, flash proxy, deployment scripts, or JavaScript dependency tree.
+
+## Launch gates
+
+- Independent smart-contract review completed.
+- Exact compiled artifact hash reviewed and reproduced.
+- Token contract addresses, token IDs, code, administrator controls, pause behavior, and callback behavior allowlisted.
+- Testnet initialization, both swap directions, deposits, withdrawals, fee claims, pause behavior, and administrator acceptance rehearsed.
+- Final administrator acceptance confirmed on-chain.
+- Fee recipient confirmed on-chain.
+- UI/router uses explicit pool allowlisting, independent deadlines and minimum outputs, and fails closed for unknown routes.
+- Monitoring checks held balances against `reserve + protocol_fees` for both assets.

--- a/dex/TOKEN_TOKEN_POOL_SECURITY_REVIEW.md
+++ b/dex/TOKEN_TOKEN_POOL_SECURITY_REVIEW.md
@@ -1,0 +1,81 @@
+# Token-to-token pool security review
+
+Date: 2026-07-30
+
+Scope: `dex/contracts/token_token_pool.mligo`, its compiled artifact, tests, and deployment configuration
+
+Compiler: LIGO 1.11.5
+
+## Summary
+
+The reviewed implementation is a standalone FA2-to-FA2 pool, not a fork of the complete shared QuipuSwap Core V2 system. The reduction removes native-XTZ custody, cross-contract LP synchronization, baker/reward handling, auctions, flash loans, and mutable fee policy.
+
+No known unresolved critical or high-severity issue was identified in this internal review of the scoped implementation. That conclusion is not an independent audit and is not sufficient authorization for mainnet deployment.
+
+## Security decisions
+
+| ID | Risk | Resolution |
+| --- | --- | --- |
+| TT-01 | A token reports success without crediting the requested input to the pool, allowing unbacked output. | Every inbound transfer is bracketed by authenticated `balance_of` callbacks and must produce the exact pool-balance increase. |
+| TT-02 | LP supply and reserve accounting drift across separate pool and LP contracts. | LP accounting is integrated into the pool storage and updated only when verified liquidity actions finalize. |
+| TT-03 | An administrator changes fee economics after liquidity is deposited. | The 25 bp LP and 5 bp protocol fees are constants and have no setter. |
+| TT-04 | A mistaken one-step administrator update transfers control immediately. | Administrator changes use `propose_admin` and `accept_admin`. |
+| TT-05 | A pause disables user exits. | Pause affects initialization, deposits, and swaps; withdrawals and fee claims remain live. |
+| TT-06 | The final liquidity provider drains the pool to an unusable zero state. | Initialization permanently locks 1,000 LP units at the pool address, and LP transfers to that address are rejected. |
+| TT-07 | Protocol fees are mixed into swap reserves or claimed twice. | Fees have separate per-asset counters, are excluded from reserves, and are decremented only after verified outbound transfers. |
+| TT-08 | A token or attacker fabricates callback data. | Callbacks validate pending phase, configured token sender, pool owner, token ID, response cardinality, deadline, and expected pool-balance delta. |
+| TT-09 | Unbounded LP batches create unpredictable gas or compiler behavior. | LP transfer/operator/balance calls are bounded to one item and documented as not batch-complete. |
+
+## Invariants reviewed
+
+For each asset, when no deliberate surplus transfer exists:
+
+```text
+underlying balance = reserve + accrued protocol fees
+```
+
+For a completed swap:
+
+```text
+new reserve A * new reserve B >= old reserve A * old reserve B
+```
+
+For LP accounting:
+
+```text
+total supply = sum of LP ledger balances
+total supply >= locked minimum liquidity after initialization
+```
+
+For lifecycle safety:
+
+```text
+pending = Some(...)  => user-mutating entrypoints reject with POOL_BUSY
+pending = None       => no partially finalized accounting action exists
+```
+
+The LIGO suite covers initialization, duplicate initialization, both swap directions, fee allocation, invariant-preserving rounding, add/remove liquidity, pause-withdrawal behavior, protocol-fee claims, administrator handoff, unsolicited callbacks, malformed balance deltas, singleton LP transfers, batch rejection, and held-balance solvency.
+
+The LIGO 1.11.5 compiler measures the encoded contract at 18,999 bytes. Independent recompilation produced a byte-identical Michelson artifact with SHA-256 `e80be7e08aed3782c338472d1faa578d73719414f2b80254a10df5c7300f6268`. The Node.js deployment package passes type checking and configuration tests, and its locked production dependency tree reports zero known vulnerabilities under `npm audit --omit=dev` as of this review.
+
+## Residual assumptions and launch blockers
+
+### Reviewed FA2 behavior is mandatory
+
+The callback verifier detects an incorrect pool-balance delta, but no pool can force an arbitrary token contract to execute an operation or report truthfully. On outbound transfers, the pool verifies its exact debit; the token implementation must guarantee the matching recipient credit. Both assets must be non-taxed FA2 implementations allowlisted by exact address and token ID after reviewing their code and administrative controls. A token that omits a callback can strand a pending action.
+
+### No oracle protection
+
+Pool reserves are not an oracle. Integrators must not use spot price as a collateral or liquidation oracle. Routing and UI code must enforce explicit pool allowlists, user deadlines, and minimum output amounts.
+
+### No arbitrary-token recovery
+
+The contract intentionally has no administrator rescue function for the two pool assets. Direct surplus transfers are not part of reserves and can remain locked. Users and deployment tooling must interact only through pool entrypoints.
+
+### LP calls are singleton-only
+
+The LP interface uses FA2-shaped entrypoints but rejects batched calls. Wallet, indexer, and router compatibility must be rehearsed on testnet.
+
+### Independent review required
+
+Before mainnet, commission an independent review of the source and compiled Michelson, reproduce the artifact hash, test the exact selected token contracts, and exercise the complete administrator and fee-recipient operational flow.

--- a/dex/compiled_contracts/token_token_pool.tz
+++ b/dex/compiled_contracts/token_token_pool.tz
@@ -1,0 +1,2881 @@
+{ parameter
+    (or (unit %default)
+        (or (unit %accept_admin)
+            (or (address %propose_admin)
+                (or (bool %set_paused)
+                    (or (pair %balance_of
+                           (list %requests (pair (address %owner) (nat %token_id)))
+                           (contract %callback
+                              (list (pair (pair %request (address %owner) (nat %token_id)) (nat %balance)))))
+                        (or (list %update_operators
+                               (or (pair %add_operator (address %owner) (pair (address %operator) (nat %token_id)))
+                                   (pair %remove_operator (address %owner) (pair (address %operator) (nat %token_id)))))
+                            (or (list %transfer
+                                   (pair (address %from_)
+                                         (list %txs (pair (address %to_) (pair (nat %token_id) (nat %amount))))))
+                                (or (list %receive_second_after
+                                       (pair (pair %request (address %owner) (nat %token_id)) (nat %balance)))
+                                    (or (list %receive_second_before
+                                           (pair (pair %request (address %owner) (nat %token_id)) (nat %balance)))
+                                        (or (list %receive_first_after
+                                               (pair (pair %request (address %owner) (nat %token_id)) (nat %balance)))
+                                            (or (list %receive_first_before
+                                                   (pair (pair %request (address %owner) (nat %token_id)) (nat %balance)))
+                                                (or (unit %claim_protocol_fees)
+                                                    (or (pair %remove_liquidity
+                                                           (nat %shares)
+                                                           (pair (nat %min_amount_a)
+                                                                 (pair (nat %min_amount_b) (pair (address %receiver) (timestamp %deadline)))))
+                                                        (or (pair %swap
+                                                               (or %direction (unit %a_to_b) (unit %b_to_a))
+                                                               (pair (nat %amount_in)
+                                                                     (pair (nat %min_amount_out) (pair (address %receiver) (timestamp %deadline)))))
+                                                            (or (pair %add_liquidity
+                                                                   (nat %max_amount_a)
+                                                                   (pair (nat %max_amount_b)
+                                                                         (pair (nat %min_shares) (pair (address %receiver) (timestamp %deadline)))))
+                                                                (pair %initialize
+                                                                   (nat %amount_a)
+                                                                   (pair (nat %amount_b) (pair (address %receiver) (timestamp %deadline))))))))))))))))))) ;
+  storage
+    (pair (pair %token_a (address %token_contract) (nat %token_id))
+          (pair (pair %token_b (address %token_contract) (nat %token_id))
+                (pair (nat %reserve_a)
+                      (pair (nat %reserve_b)
+                            (pair (nat %protocol_fees_a)
+                                  (pair (nat %protocol_fees_b)
+                                        (pair (nat %total_supply)
+                                              (pair (big_map %ledger address nat)
+                                                    (pair (big_map %operators (pair address address) unit)
+                                                          (pair (big_map %metadata string bytes)
+                                                                (pair (big_map %token_metadata nat (pair (nat %token_id) (map %token_info string bytes)))
+                                                                      (pair (address %admin)
+                                                                            (pair (option %pending_admin address)
+                                                                                  (pair (address %fee_recipient)
+                                                                                        (pair (bool %paused)
+                                                                                              (option %pending
+                                                                                                 (pair (or %final_action
+                                                                                                          (pair %finalize_initialize
+                                                                                                             (address %receiver)
+                                                                                                             (pair (nat %amount_a) (pair (nat %amount_b) (nat %total_shares))))
+                                                                                                          (or (pair %finalize_add
+                                                                                                                 (address %receiver)
+                                                                                                                 (pair (nat %amount_a) (pair (nat %amount_b) (nat %shares))))
+                                                                                                              (or (pair %finalize_swap
+                                                                                                                     (or %direction (unit %a_to_b) (unit %b_to_a))
+                                                                                                                     (pair (nat %amount_in) (pair (nat %amount_out) (nat %protocol_fee))))
+                                                                                                                  (or (pair %finalize_remove
+                                                                                                                         (address %owner)
+                                                                                                                         (pair (nat %shares) (pair (nat %amount_a) (nat %amount_b))))
+                                                                                                                      (pair %finalize_claim (nat %amount_a) (nat %amount_b))))))
+                                                                                                       (pair (pair %first_leg
+                                                                                                                (pair %asset (address %token_contract) (nat %token_id))
+                                                                                                                (pair (address %from_)
+                                                                                                                      (pair (address %to_) (pair (nat %amount) (or %mode (unit %inbound) (unit %outbound))))))
+                                                                                                             (pair (option %second_leg
+                                                                                                                      (pair (pair %asset (address %token_contract) (nat %token_id))
+                                                                                                                            (pair (address %from_)
+                                                                                                                                  (pair (address %to_) (pair (nat %amount) (or %mode (unit %inbound) (unit %outbound)))))))
+                                                                                                                   (pair (or %phase
+                                                                                                                            (unit %first_before)
+                                                                                                                            (or (unit %first_after) (or (unit %second_before) (unit %second_after))))
+                                                                                                                         (pair (option %observed_before nat) (option %deadline timestamp)))))))))))))))))))))) ;
+  code { PUSH nat 10000 ;
+         PUSH nat 5 ;
+         DUP ;
+         PUSH nat 25 ;
+         ADD ;
+         PUSH nat 1000 ;
+         PUSH nat 0 ;
+         PUSH string "POOL_PAUSED" ;
+         PUSH string "POOL_NOT_ADMIN" ;
+         PUSH string "POOL_NOT_PENDING_ADMIN" ;
+         PUSH string "POOL_ZERO_AMOUNT" ;
+         PUSH string "POOL_ZERO_OUTPUT" ;
+         PUSH string "POOL_SLIPPAGE" ;
+         PUSH string "POOL_INSUFFICIENT_LIQUIDITY" ;
+         PUSH string "FA2_INSUFFICIENT_BALANCE" ;
+         PUSH string "FA2_NOT_OPERATOR" ;
+         PUSH string "FA2_TOKEN_UNDEFINED" ;
+         PUSH string "POOL_INVALID_BALANCE_CALLBACK" ;
+         PUSH string "POOL_INSOLVENT" ;
+         LAMBDA
+           unit
+           unit
+           { DROP ;
+             PUSH string "POOL_NON_PAYABLE" ;
+             PUSH mutez 0 ;
+             AMOUNT ;
+             COMPARE ;
+             EQ ;
+             IF { DROP } { FAILWITH } ;
+             UNIT } ;
+         LAMBDA
+           (pair (pair address nat)
+                 (pair (pair address nat)
+                       (pair nat
+                             (pair nat
+                                   (pair nat
+                                         (pair nat
+                                               (pair nat
+                                                     (pair (big_map address nat)
+                                                           (pair (big_map (pair address address) unit)
+                                                                 (pair (big_map string bytes)
+                                                                       (pair (big_map nat (pair nat (map string bytes)))
+                                                                             (pair address
+                                                                                   (pair (option address)
+                                                                                         (pair address
+                                                                                               (pair bool
+                                                                                                     (option
+                                                                                                        (pair (or (pair address (pair nat (pair nat nat)))
+                                                                                                                  (or (pair address (pair nat (pair nat nat)))
+                                                                                                                      (or (pair (or unit unit) (pair nat (pair nat nat)))
+                                                                                                                          (or (pair address (pair nat (pair nat nat))) (pair nat nat)))))
+                                                                                                              (pair (pair (pair address nat) (pair address (pair address (pair nat (or unit unit)))))
+                                                                                                                    (pair (option (pair (pair address nat) (pair address (pair address (pair nat (or unit unit))))))
+                                                                                                                          (pair (or unit (or unit (or unit unit))) (pair (option nat) (option timestamp))))))))))))))))))))))
+           unit
+           { GET 30 ; IF_NONE {} { PUSH string "POOL_BUSY" ; FAILWITH } ; UNIT } ;
+         LAMBDA
+           (pair string
+                 (pair (pair address nat)
+                       (pair (pair address nat)
+                             (pair nat
+                                   (pair nat
+                                         (pair nat
+                                               (pair nat
+                                                     (pair nat
+                                                           (pair (big_map address nat)
+                                                                 (pair (big_map (pair address address) unit)
+                                                                       (pair (big_map string bytes)
+                                                                             (pair (big_map nat (pair nat (map string bytes)))
+                                                                                   (pair address
+                                                                                         (pair (option address)
+                                                                                               (pair address
+                                                                                                     (pair bool
+                                                                                                           (option
+                                                                                                              (pair (or (pair address (pair nat (pair nat nat)))
+                                                                                                                        (or (pair address (pair nat (pair nat nat)))
+                                                                                                                            (or (pair (or unit unit) (pair nat (pair nat nat)))
+                                                                                                                                (or (pair address (pair nat (pair nat nat))) (pair nat nat)))))
+                                                                                                                    (pair (pair (pair address nat) (pair address (pair address (pair nat (or unit unit)))))
+                                                                                                                          (pair (option (pair (pair address nat) (pair address (pair address (pair nat (or unit unit))))))
+                                                                                                                                (pair (or unit (or unit (or unit unit))) (pair (option nat) (option timestamp)))))))))))))))))))))))
+           unit
+           { UNPAIR ; SWAP ; GET 29 ; IF { FAILWITH } { DROP } ; UNIT } ;
+         DUP 15 ;
+         APPLY ;
+         LAMBDA
+           (pair (pair address nat)
+                 (pair (pair address nat)
+                       (pair nat
+                             (pair nat
+                                   (pair nat
+                                         (pair nat
+                                               (pair nat
+                                                     (pair (big_map address nat)
+                                                           (pair (big_map (pair address address) unit)
+                                                                 (pair (big_map string bytes)
+                                                                       (pair (big_map nat (pair nat (map string bytes)))
+                                                                             (pair address
+                                                                                   (pair (option address)
+                                                                                         (pair address
+                                                                                               (pair bool
+                                                                                                     (option
+                                                                                                        (pair (or (pair address (pair nat (pair nat nat)))
+                                                                                                                  (or (pair address (pair nat (pair nat nat)))
+                                                                                                                      (or (pair (or unit unit) (pair nat (pair nat nat)))
+                                                                                                                          (or (pair address (pair nat (pair nat nat))) (pair nat nat)))))
+                                                                                                              (pair (pair (pair address nat) (pair address (pair address (pair nat (or unit unit)))))
+                                                                                                                    (pair (option (pair (pair address nat) (pair address (pair address (pair nat (or unit unit))))))
+                                                                                                                          (pair (or unit (or unit (or unit unit))) (pair (option nat) (option timestamp))))))))))))))))))))))
+           unit
+           { GET 13 ;
+             PUSH nat 0 ;
+             COMPARE ;
+             LT ;
+             IF {} { PUSH string "POOL_NOT_INITIALIZED" ; FAILWITH } ;
+             UNIT } ;
+         LAMBDA
+           timestamp
+           unit
+           { PUSH string "POOL_DEADLINE_EXPIRED" ;
+             SWAP ;
+             NOW ;
+             COMPARE ;
+             LE ;
+             IF { DROP } { FAILWITH } ;
+             UNIT } ;
+         LAMBDA
+           address
+           unit
+           { PUSH string "POOL_INVALID_RECIPIENT" ;
+             SELF_ADDRESS ;
+             DIG 2 ;
+             COMPARE ;
+             NEQ ;
+             IF { DROP } { FAILWITH } ;
+             UNIT } ;
+         LAMBDA
+           (pair address (big_map address nat))
+           nat
+           { UNPAIR ; GET ; IF_NONE { PUSH nat 0 } {} } ;
+         LAMBDA
+           (pair address (pair nat (big_map address nat)))
+           (big_map address nat)
+           { UNPAIR 3 ;
+             DUP 2 ;
+             INT ;
+             EQ ;
+             IF { SWAP ; DROP ; SWAP ; NONE nat ; DIG 2 ; UPDATE }
+                { SWAP ; SOME ; SWAP ; UPDATE } } ;
+         LAMBDA
+           (pair (lambda (pair address (big_map address nat)) nat)
+                 (pair (lambda (pair address (pair nat (big_map address nat))) (big_map address nat))
+                       (pair address (pair nat (big_map address nat)))))
+           (big_map address nat)
+           { UNPAIR 3 ;
+             DIG 2 ;
+             UNPAIR 3 ;
+             DUP 3 ;
+             DIG 2 ;
+             DIG 3 ;
+             DUP 4 ;
+             PAIR ;
+             DIG 4 ;
+             SWAP ;
+             EXEC ;
+             ADD ;
+             DIG 2 ;
+             PAIR 3 ;
+             EXEC } ;
+         DUP 3 ;
+         APPLY ;
+         DUP 2 ;
+         APPLY ;
+         LAMBDA
+           (pair string
+                 (pair (lambda (pair address (big_map address nat)) nat)
+                       (pair (lambda (pair address (pair nat (big_map address nat))) (big_map address nat))
+                             (pair address (pair nat (big_map address nat))))))
+           (big_map address nat)
+           { UNPAIR 4 ;
+             DIG 3 ;
+             UNPAIR 3 ;
+             DUP 3 ;
+             DUP 2 ;
+             PAIR ;
+             DUP 6 ;
+             SWAP ;
+             EXEC ;
+             DUP 3 ;
+             DUP 2 ;
+             COMPARE ;
+             GE ;
+             IF { DIG 4 ; DROP ; DIG 4 ; DROP } { DUP 5 ; FAILWITH } ;
+             DIG 3 ;
+             DIG 3 ;
+             DIG 2 ;
+             SUB ;
+             ABS ;
+             DIG 2 ;
+             PAIR 3 ;
+             EXEC } ;
+         DUP 15 ;
+         APPLY ;
+         DUP 4 ;
+         APPLY ;
+         DIG 2 ;
+         APPLY ;
+         LAMBDA
+           (pair string (pair nat nat))
+           nat
+           { UNPAIR ;
+             SWAP ;
+             UNPAIR ;
+             EDIV ;
+             IF_NONE
+               { FAILWITH }
+               { SWAP ; DROP ; UNPAIR ; SWAP ; INT ; EQ ; IF {} { PUSH nat 1 ; ADD } } } ;
+         DUP 16 ;
+         APPLY ;
+         LAMBDA
+           (pair nat nat)
+           nat
+           { UNPAIR ;
+             DUP 2 ;
+             DUP 2 ;
+             COMPARE ;
+             LT ;
+             IF { SWAP ; DROP } { DROP } } ;
+         LAMBDA
+           (pair string
+                 (pair (pair address nat)
+                       (pair (pair address nat)
+                             (pair (pair address nat)
+                                   (pair nat
+                                         (pair nat
+                                               (pair nat
+                                                     (pair nat
+                                                           (pair nat
+                                                                 (pair (big_map address nat)
+                                                                       (pair (big_map (pair address address) unit)
+                                                                             (pair (big_map string bytes)
+                                                                                   (pair (big_map nat (pair nat (map string bytes)))
+                                                                                         (pair address
+                                                                                               (pair (option address)
+                                                                                                     (pair address
+                                                                                                           (pair bool
+                                                                                                                 (option
+                                                                                                                    (pair (or (pair address (pair nat (pair nat nat)))
+                                                                                                                              (or (pair address (pair nat (pair nat nat)))
+                                                                                                                                  (or (pair (or unit unit) (pair nat (pair nat nat)))
+                                                                                                                                      (or (pair address (pair nat (pair nat nat))) (pair nat nat)))))
+                                                                                                                          (pair (pair (pair address nat) (pair address (pair address (pair nat (or unit unit)))))
+                                                                                                                                (pair (option (pair (pair address nat) (pair address (pair address (pair nat (or unit unit))))))
+                                                                                                                                      (pair (or unit (or unit (or unit unit))) (pair (option nat) (option timestamp))))))))))))))))))))))))
+           nat
+           { UNPAIR ;
+             SWAP ;
+             UNPAIR ;
+             DUP 2 ;
+             CAR ;
+             DUP 2 ;
+             COMPARE ;
+             EQ ;
+             IF { DROP ; SWAP ; DROP ; DUP ; GET 9 ; SWAP ; GET 5 ; ADD }
+                { DUP 2 ;
+                  GET 3 ;
+                  COMPARE ;
+                  EQ ;
+                  IF { SWAP ; DROP ; DUP ; GET 11 ; SWAP ; GET 7 ; ADD }
+                     { DROP ; FAILWITH } } } ;
+         DUP 14 ;
+         APPLY ;
+         LAMBDA
+           (pair (pair address nat) (pair address (pair address (pair nat (or unit unit)))))
+           operation
+           { DUP ;
+             CAR ;
+             CAR ;
+             CONTRACT %transfer
+               (list (pair (address %from_)
+                           (list %txs (pair (address %to_) (pair (nat %token_id) (nat %amount)))))) ;
+             IF_NONE { PUSH string "POOL_MISSING_FA2_TRANSFER" ; FAILWITH } {} ;
+             PUSH mutez 0 ;
+             NIL (pair address (list (pair address (pair nat nat)))) ;
+             NIL (pair address (pair nat nat)) ;
+             DUP 5 ;
+             GET 7 ;
+             DUP 6 ;
+             CAR ;
+             CDR ;
+             DUP 7 ;
+             GET 5 ;
+             PAIR 3 ;
+             CONS ;
+             DIG 4 ;
+             GET 3 ;
+             PAIR ;
+             CONS ;
+             TRANSFER_TOKENS } ;
+         LAMBDA
+           (pair (pair address nat) (contract (list (pair (pair address nat) nat))))
+           operation
+           { UNPAIR ;
+             DUP ;
+             CAR ;
+             CONTRACT %balance_of
+               (pair (list %requests (pair (address %owner) (nat %token_id)))
+                     (contract %callback
+                        (list (pair (pair %request (address %owner) (nat %token_id)) (nat %balance))))) ;
+             IF_NONE { PUSH string "POOL_MISSING_FA2_BALANCE_OF" ; FAILWITH } {} ;
+             DIG 2 ;
+             NIL (pair address nat) ;
+             DIG 3 ;
+             CDR ;
+             SELF_ADDRESS ;
+             PAIR ;
+             CONS ;
+             PAIR ;
+             SWAP ;
+             PUSH mutez 0 ;
+             DIG 2 ;
+             TRANSFER_TOKENS } ;
+         LAMBDA
+           (pair string
+                 (pair (or (pair address (pair nat (pair nat nat)))
+                           (or (pair address (pair nat (pair nat nat)))
+                               (or (pair (or unit unit) (pair nat (pair nat nat)))
+                                   (or (pair address (pair nat (pair nat nat))) (pair nat nat)))))
+                       (pair (pair (pair address nat) (pair address (pair address (pair nat (or unit unit)))))
+                             (pair (option (pair (pair address nat) (pair address (pair address (pair nat (or unit unit))))))
+                                   (pair (or unit (or unit (or unit unit))) (pair (option nat) (option timestamp)))))))
+           (pair (pair address nat) (pair address (pair address (pair nat (or unit unit)))))
+           { UNPAIR ;
+             DUP 2 ;
+             GET 7 ;
+             IF_LEFT
+               { DROP 2 ; GET 3 }
+               { IF_LEFT
+                   { DROP 2 ; GET 3 }
+                   { IF_LEFT
+                       { DROP ; SWAP ; GET 5 ; IF_NONE { FAILWITH } { SWAP ; DROP } }
+                       { DROP ; SWAP ; GET 5 ; IF_NONE { FAILWITH } { SWAP ; DROP } } } } } ;
+         DUP 17 ;
+         APPLY ;
+         LAMBDA
+           (pair (lambda timestamp unit)
+                 (pair (or (pair address (pair nat (pair nat nat)))
+                           (or (pair address (pair nat (pair nat nat)))
+                               (or (pair (or unit unit) (pair nat (pair nat nat)))
+                                   (or (pair address (pair nat (pair nat nat))) (pair nat nat)))))
+                       (pair (pair (pair address nat) (pair address (pair address (pair nat (or unit unit)))))
+                             (pair (option (pair (pair address nat) (pair address (pair address (pair nat (or unit unit))))))
+                                   (pair (or unit (or unit (or unit unit))) (pair (option nat) (option timestamp)))))))
+           unit
+           { UNPAIR ; SWAP ; GET 10 ; IF_NONE { DROP ; UNIT } { EXEC } } ;
+         DUP 12 ;
+         APPLY ;
+         LAMBDA
+           (pair string
+                 (pair (lambda (pair (pair address nat) (contract (list (pair (pair address nat) nat)))) operation)
+                       (pair (pair (or (pair address (pair nat (pair nat nat)))
+                                       (or (pair address (pair nat (pair nat nat)))
+                                           (or (pair (or unit unit) (pair nat (pair nat nat)))
+                                               (or (pair address (pair nat (pair nat nat))) (pair nat nat)))))
+                                   (pair (pair (pair address nat) (pair address (pair address (pair nat (or unit unit)))))
+                                         (pair (option (pair (pair address nat) (pair address (pair address (pair nat (or unit unit))))))
+                                               (pair (or unit (or unit (or unit unit))) (pair (option nat) (option timestamp))))))
+                             (pair (pair address nat)
+                                   (pair (pair address nat)
+                                         (pair nat
+                                               (pair nat
+                                                     (pair nat
+                                                           (pair nat
+                                                                 (pair nat
+                                                                       (pair (big_map address nat)
+                                                                             (pair (big_map (pair address address) unit)
+                                                                                   (pair (big_map string bytes)
+                                                                                         (pair (big_map nat (pair nat (map string bytes)))
+                                                                                               (pair address
+                                                                                                     (pair (option address)
+                                                                                                           (pair address
+                                                                                                                 (pair bool
+                                                                                                                       (option
+                                                                                                                          (pair (or (pair address (pair nat (pair nat nat)))
+                                                                                                                                    (or (pair address (pair nat (pair nat nat)))
+                                                                                                                                        (or (pair (or unit unit) (pair nat (pair nat nat)))
+                                                                                                                                            (or (pair address (pair nat (pair nat nat))) (pair nat nat)))))
+                                                                                                                                (pair (pair (pair address nat) (pair address (pair address (pair nat (or unit unit)))))
+                                                                                                                                      (pair (option (pair (pair address nat) (pair address (pair address (pair nat (or unit unit))))))
+                                                                                                                                            (pair (or unit (or unit (or unit unit))) (pair (option nat) (option timestamp)))))))))))))))))))))))))
+           (pair (list operation)
+                 (pair (pair address nat)
+                       (pair (pair address nat)
+                             (pair nat
+                                   (pair nat
+                                         (pair nat
+                                               (pair nat
+                                                     (pair nat
+                                                           (pair (big_map address nat)
+                                                                 (pair (big_map (pair address address) unit)
+                                                                       (pair (big_map string bytes)
+                                                                             (pair (big_map nat (pair nat (map string bytes)))
+                                                                                   (pair address
+                                                                                         (pair (option address)
+                                                                                               (pair address
+                                                                                                     (pair bool
+                                                                                                           (option
+                                                                                                              (pair (or (pair address (pair nat (pair nat nat)))
+                                                                                                                        (or (pair address (pair nat (pair nat nat)))
+                                                                                                                            (or (pair (or unit unit) (pair nat (pair nat nat)))
+                                                                                                                                (or (pair address (pair nat (pair nat nat))) (pair nat nat)))))
+                                                                                                                    (pair (pair (pair address nat) (pair address (pair address (pair nat (or unit unit)))))
+                                                                                                                          (pair (option (pair (pair address nat) (pair address (pair address (pair nat (or unit unit))))))
+                                                                                                                                (pair (or unit (or unit (or unit unit))) (pair (option nat) (option timestamp)))))))))))))))))))))))
+           { UNPAIR 3 ;
+             DIG 2 ;
+             UNPAIR ;
+             SWAP ;
+             DUP 2 ;
+             SOME ;
+             UPDATE 30 ;
+             NIL operation ;
+             SELF_ADDRESS ;
+             CONTRACT %receive_first_before
+               (list (pair (pair %request (address %owner) (nat %token_id)) (nat %balance))) ;
+             IF_NONE { DUP 4 ; FAILWITH } { DIG 4 ; DROP } ;
+             DIG 3 ;
+             GET 3 ;
+             CAR ;
+             PAIR ;
+             DIG 3 ;
+             SWAP ;
+             EXEC ;
+             CONS ;
+             PAIR } ;
+         DUP 19 ;
+         APPLY ;
+         DUP 4 ;
+         APPLY ;
+         LAMBDA
+           (pair (lambda (pair address (pair nat (big_map address nat))) (big_map address nat))
+                 (pair nat
+                       (pair (lambda (pair address (pair nat (big_map address nat))) (big_map address nat))
+                             (pair (or (pair address (pair nat (pair nat nat)))
+                                       (or (pair address (pair nat (pair nat nat)))
+                                           (or (pair (or unit unit) (pair nat (pair nat nat)))
+                                               (or (pair address (pair nat (pair nat nat))) (pair nat nat)))))
+                                   (pair (pair address nat)
+                                         (pair (pair address nat)
+                                               (pair nat
+                                                     (pair nat
+                                                           (pair nat
+                                                                 (pair nat
+                                                                       (pair nat
+                                                                             (pair (big_map address nat)
+                                                                                   (pair (big_map (pair address address) unit)
+                                                                                         (pair (big_map string bytes)
+                                                                                               (pair (big_map nat (pair nat (map string bytes)))
+                                                                                                     (pair address
+                                                                                                           (pair (option address)
+                                                                                                                 (pair address
+                                                                                                                       (pair bool
+                                                                                                                             (option
+                                                                                                                                (pair (or (pair address (pair nat (pair nat nat)))
+                                                                                                                                          (or (pair address (pair nat (pair nat nat)))
+                                                                                                                                              (or (pair (or unit unit) (pair nat (pair nat nat)))
+                                                                                                                                                  (or (pair address (pair nat (pair nat nat))) (pair nat nat)))))
+                                                                                                                                      (pair (pair (pair address nat) (pair address (pair address (pair nat (or unit unit)))))
+                                                                                                                                            (pair (option (pair (pair address nat) (pair address (pair address (pair nat (or unit unit))))))
+                                                                                                                                                  (pair (or unit (or unit (or unit unit))) (pair (option nat) (option timestamp))))))))))))))))))))))))))
+           (pair (list operation)
+                 (pair (pair address nat)
+                       (pair (pair address nat)
+                             (pair nat
+                                   (pair nat
+                                         (pair nat
+                                               (pair nat
+                                                     (pair nat
+                                                           (pair (big_map address nat)
+                                                                 (pair (big_map (pair address address) unit)
+                                                                       (pair (big_map string bytes)
+                                                                             (pair (big_map nat (pair nat (map string bytes)))
+                                                                                   (pair address
+                                                                                         (pair (option address)
+                                                                                               (pair address
+                                                                                                     (pair bool
+                                                                                                           (option
+                                                                                                              (pair (or (pair address (pair nat (pair nat nat)))
+                                                                                                                        (or (pair address (pair nat (pair nat nat)))
+                                                                                                                            (or (pair (or unit unit) (pair nat (pair nat nat)))
+                                                                                                                                (or (pair address (pair nat (pair nat nat))) (pair nat nat)))))
+                                                                                                                    (pair (pair (pair address nat) (pair address (pair address (pair nat (or unit unit)))))
+                                                                                                                          (pair (option (pair (pair address nat) (pair address (pair address (pair nat (or unit unit))))))
+                                                                                                                                (pair (or unit (or unit (or unit unit))) (pair (option nat) (option timestamp)))))))))))))))))))))))
+           { UNPAIR 4 ;
+             DIG 3 ;
+             UNPAIR ;
+             IF_LEFT
+               { DIG 4 ;
+                 DROP ;
+                 DUP 4 ;
+                 DUP 2 ;
+                 GET 6 ;
+                 SUB ;
+                 ABS ;
+                 DUP 3 ;
+                 GET 15 ;
+                 DIG 5 ;
+                 SELF_ADDRESS ;
+                 PAIR 3 ;
+                 DUP 5 ;
+                 SWAP ;
+                 EXEC ;
+                 SWAP ;
+                 DUP 3 ;
+                 CAR ;
+                 PAIR 3 ;
+                 DIG 3 ;
+                 SWAP ;
+                 EXEC ;
+                 DIG 2 ;
+                 DUP 3 ;
+                 GET 3 ;
+                 UPDATE 5 ;
+                 DUP 3 ;
+                 GET 5 ;
+                 UPDATE 7 ;
+                 DIG 2 ;
+                 GET 6 ;
+                 UPDATE 13 ;
+                 SWAP ;
+                 UPDATE 15 ;
+                 NONE (pair (or (pair address (pair nat (pair nat nat)))
+                                (or (pair address (pair nat (pair nat nat)))
+                                    (or (pair (or unit unit) (pair nat (pair nat nat)))
+                                        (or (pair address (pair nat (pair nat nat))) (pair nat nat)))))
+                            (pair (pair (pair address nat) (pair address (pair address (pair nat (or unit unit)))))
+                                  (pair (option (pair (pair address nat) (pair address (pair address (pair nat (or unit unit))))))
+                                        (pair (or unit (or unit (or unit unit))) (pair (option nat) (option timestamp)))))) ;
+                 UPDATE 30 }
+               { IF_LEFT
+                   { DIG 3 ;
+                     DROP ;
+                     DIG 3 ;
+                     DROP ;
+                     DUP 2 ;
+                     GET 15 ;
+                     DUP 2 ;
+                     GET 6 ;
+                     DUP 3 ;
+                     CAR ;
+                     PAIR 3 ;
+                     DIG 3 ;
+                     SWAP ;
+                     EXEC ;
+                     DUP 3 ;
+                     DUP 3 ;
+                     GET 3 ;
+                     DUP 5 ;
+                     GET 5 ;
+                     ADD ;
+                     UPDATE 5 ;
+                     DUP 3 ;
+                     GET 5 ;
+                     DUP 5 ;
+                     GET 7 ;
+                     ADD ;
+                     UPDATE 7 ;
+                     DIG 2 ;
+                     GET 6 ;
+                     DIG 3 ;
+                     GET 13 ;
+                     ADD ;
+                     UPDATE 13 ;
+                     SWAP ;
+                     UPDATE 15 ;
+                     NONE (pair (or (pair address (pair nat (pair nat nat)))
+                                    (or (pair address (pair nat (pair nat nat)))
+                                        (or (pair (or unit unit) (pair nat (pair nat nat)))
+                                            (or (pair address (pair nat (pair nat nat))) (pair nat nat)))))
+                                (pair (pair (pair address nat) (pair address (pair address (pair nat (or unit unit)))))
+                                      (pair (option (pair (pair address nat) (pair address (pair address (pair nat (or unit unit))))))
+                                            (pair (or unit (or unit (or unit unit))) (pair (option nat) (option timestamp)))))) ;
+                     UPDATE 30 }
+                   { IF_LEFT
+                       { DIG 2 ;
+                         DROP ;
+                         DIG 2 ;
+                         DROP ;
+                         DIG 2 ;
+                         DROP ;
+                         DUP ;
+                         CAR ;
+                         IF_LEFT
+                           { DROP ;
+                             DUP 2 ;
+                             DUP 2 ;
+                             GET 6 ;
+                             DUP 3 ;
+                             GET 3 ;
+                             SUB ;
+                             ABS ;
+                             DUP 4 ;
+                             GET 5 ;
+                             ADD ;
+                             UPDATE 5 ;
+                             DUP 2 ;
+                             GET 5 ;
+                             DUP 4 ;
+                             GET 7 ;
+                             SUB ;
+                             ABS ;
+                             UPDATE 7 ;
+                             SWAP ;
+                             GET 6 ;
+                             DIG 2 ;
+                             GET 9 ;
+                             ADD ;
+                             UPDATE 9 ;
+                             NONE (pair (or (pair address (pair nat (pair nat nat)))
+                                            (or (pair address (pair nat (pair nat nat)))
+                                                (or (pair (or unit unit) (pair nat (pair nat nat)))
+                                                    (or (pair address (pair nat (pair nat nat))) (pair nat nat)))))
+                                        (pair (pair (pair address nat) (pair address (pair address (pair nat (or unit unit)))))
+                                              (pair (option (pair (pair address nat) (pair address (pair address (pair nat (or unit unit))))))
+                                                    (pair (or unit (or unit (or unit unit))) (pair (option nat) (option timestamp)))))) ;
+                             UPDATE 30 }
+                           { DROP ;
+                             DUP 2 ;
+                             DUP 2 ;
+                             GET 5 ;
+                             DUP 4 ;
+                             GET 5 ;
+                             SUB ;
+                             ABS ;
+                             UPDATE 5 ;
+                             DUP 2 ;
+                             GET 6 ;
+                             DUP 3 ;
+                             GET 3 ;
+                             SUB ;
+                             ABS ;
+                             DUP 4 ;
+                             GET 7 ;
+                             ADD ;
+                             UPDATE 7 ;
+                             SWAP ;
+                             GET 6 ;
+                             DIG 2 ;
+                             GET 11 ;
+                             ADD ;
+                             UPDATE 11 ;
+                             NONE (pair (or (pair address (pair nat (pair nat nat)))
+                                            (or (pair address (pair nat (pair nat nat)))
+                                                (or (pair (or unit unit) (pair nat (pair nat nat)))
+                                                    (or (pair address (pair nat (pair nat nat))) (pair nat nat)))))
+                                        (pair (pair (pair address nat) (pair address (pair address (pair nat (or unit unit)))))
+                                              (pair (option (pair (pair address nat) (pair address (pair address (pair nat (or unit unit))))))
+                                                    (pair (or unit (or unit (or unit unit))) (pair (option nat) (option timestamp)))))) ;
+                             UPDATE 30 } }
+                       { IF_LEFT
+                           { DIG 2 ;
+                             DROP ;
+                             DIG 2 ;
+                             DROP ;
+                             DUP 2 ;
+                             GET 15 ;
+                             DUP 2 ;
+                             GET 3 ;
+                             DUP 3 ;
+                             CAR ;
+                             PAIR 3 ;
+                             DIG 3 ;
+                             SWAP ;
+                             EXEC ;
+                             DUP 3 ;
+                             DUP 3 ;
+                             GET 5 ;
+                             DUP 5 ;
+                             GET 5 ;
+                             SUB ;
+                             ABS ;
+                             UPDATE 5 ;
+                             DUP 3 ;
+                             GET 6 ;
+                             DUP 5 ;
+                             GET 7 ;
+                             SUB ;
+                             ABS ;
+                             UPDATE 7 ;
+                             DIG 2 ;
+                             GET 3 ;
+                             DIG 3 ;
+                             GET 13 ;
+                             SUB ;
+                             ABS ;
+                             UPDATE 13 ;
+                             SWAP ;
+                             UPDATE 15 ;
+                             NONE (pair (or (pair address (pair nat (pair nat nat)))
+                                            (or (pair address (pair nat (pair nat nat)))
+                                                (or (pair (or unit unit) (pair nat (pair nat nat)))
+                                                    (or (pair address (pair nat (pair nat nat))) (pair nat nat)))))
+                                        (pair (pair (pair address nat) (pair address (pair address (pair nat (or unit unit)))))
+                                              (pair (option (pair (pair address nat) (pair address (pair address (pair nat (or unit unit))))))
+                                                    (pair (or unit (or unit (or unit unit))) (pair (option nat) (option timestamp)))))) ;
+                             UPDATE 30 }
+                           { DIG 2 ;
+                             DROP ;
+                             DIG 2 ;
+                             DROP ;
+                             DIG 2 ;
+                             DROP ;
+                             DUP 2 ;
+                             DUP 2 ;
+                             CAR ;
+                             DUP 4 ;
+                             GET 9 ;
+                             SUB ;
+                             ABS ;
+                             UPDATE 9 ;
+                             SWAP ;
+                             CDR ;
+                             DIG 2 ;
+                             GET 11 ;
+                             SUB ;
+                             ABS ;
+                             UPDATE 11 ;
+                             NONE (pair (or (pair address (pair nat (pair nat nat)))
+                                            (or (pair address (pair nat (pair nat nat)))
+                                                (or (pair (or unit unit) (pair nat (pair nat nat)))
+                                                    (or (pair address (pair nat (pair nat nat))) (pair nat nat)))))
+                                        (pair (pair (pair address nat) (pair address (pair address (pair nat (or unit unit)))))
+                                              (pair (option (pair (pair address nat) (pair address (pair address (pair nat (or unit unit))))))
+                                                    (pair (or unit (or unit (or unit unit))) (pair (option nat) (option timestamp)))))) ;
+                             UPDATE 30 } } } } ;
+             NIL operation ;
+             PAIR } ;
+         DUP 11 ;
+         APPLY ;
+         DUP 32 ;
+         APPLY ;
+         DUP 10 ;
+         APPLY ;
+         LAMBDA
+           (pair (lambda unit unit)
+                 (pair string (pair (pair address nat) (list (pair (pair address nat) nat)))))
+           nat
+           { UNPAIR 3 ;
+             DIG 2 ;
+             UNPAIR ;
+             UNIT ;
+             DUP 4 ;
+             SWAP ;
+             EXEC ;
+             DROP ;
+             DUP 4 ;
+             DUP 2 ;
+             CAR ;
+             SENDER ;
+             COMPARE ;
+             EQ ;
+             IF { DROP } { FAILWITH } ;
+             PUSH nat 1 ;
+             DUP 3 ;
+             SIZE ;
+             COMPARE ;
+             EQ ;
+             IF {} { DUP 4 ; FAILWITH } ;
+             SWAP ;
+             IF_CONS { SWAP ; DROP ; SOME } { NONE (pair (pair address nat) nat) } ;
+             IF_NONE { DUP 3 ; FAILWITH } { DIG 2 ; DROP } ;
+             DUG 2 ;
+             CDR ;
+             DUP 3 ;
+             CAR ;
+             CDR ;
+             COMPARE ;
+             EQ ;
+             SELF_ADDRESS ;
+             DUP 4 ;
+             CAR ;
+             CAR ;
+             COMPARE ;
+             EQ ;
+             AND ;
+             IF { DROP } { FAILWITH } ;
+             CDR } ;
+         DUP 19 ;
+         APPLY ;
+         DUP 21 ;
+         APPLY ;
+         LAMBDA
+           (pair string
+                 (pair (pair (or (pair address (pair nat (pair nat nat)))
+                                 (or (pair address (pair nat (pair nat nat)))
+                                     (or (pair (or unit unit) (pair nat (pair nat nat)))
+                                         (or (pair address (pair nat (pair nat nat))) (pair nat nat)))))
+                             (pair (pair (pair address nat) (pair address (pair address (pair nat (or unit unit)))))
+                                   (pair (option (pair (pair address nat) (pair address (pair address (pair nat (or unit unit))))))
+                                         (pair (or unit (or unit (or unit unit))) (pair (option nat) (option timestamp))))))
+                       (pair (pair (pair address nat) (pair address (pair address (pair nat (or unit unit))))) nat)))
+           unit
+           { UNPAIR ;
+             SWAP ;
+             UNPAIR 3 ;
+             GET 9 ;
+             IF_NONE { DUP 3 ; FAILWITH } { DIG 3 ; DROP } ;
+             DUP 2 ;
+             GET 8 ;
+             IF_LEFT
+               { DROP ; SWAP ; GET 7 ; ADD ; COMPARE ; EQ }
+               { DROP ;
+                 DUP 2 ;
+                 GET 7 ;
+                 DUP 2 ;
+                 SUB ;
+                 ABS ;
+                 DIG 3 ;
+                 COMPARE ;
+                 EQ ;
+                 DIG 2 ;
+                 GET 7 ;
+                 DIG 2 ;
+                 COMPARE ;
+                 GE ;
+                 AND } ;
+             IF {} { PUSH string "POOL_INVALID_BALANCE_DELTA" ; FAILWITH } ;
+             UNIT } ;
+         DUP 22 ;
+         APPLY ;
+         DIG 37 ;
+         UNPAIR ;
+         IF_LEFT
+           { DROP ;
+             DUG 19 ;
+             DROP 19 ;
+             DIG 2 ;
+             DROP ;
+             DIG 2 ;
+             DROP ;
+             DIG 2 ;
+             DROP ;
+             DIG 2 ;
+             DROP ;
+             DIG 2 ;
+             DROP ;
+             DIG 2 ;
+             DROP ;
+             DIG 2 ;
+             DROP ;
+             DIG 2 ;
+             DROP ;
+             DIG 2 ;
+             DROP ;
+             DIG 2 ;
+             DROP ;
+             DIG 2 ;
+             DROP ;
+             DIG 2 ;
+             DROP ;
+             DIG 2 ;
+             DROP ;
+             DIG 2 ;
+             DROP ;
+             DIG 2 ;
+             DROP ;
+             DIG 2 ;
+             DROP ;
+             DIG 2 ;
+             DROP ;
+             UNIT ;
+             DIG 2 ;
+             SWAP ;
+             EXEC ;
+             DROP ;
+             NIL operation ;
+             PAIR }
+           { IF_LEFT
+               { DROP ;
+                 DUG 18 ;
+                 DROP 18 ;
+                 DIG 3 ;
+                 DROP ;
+                 DIG 3 ;
+                 DROP ;
+                 DIG 3 ;
+                 DROP ;
+                 DIG 3 ;
+                 DROP ;
+                 DIG 3 ;
+                 DROP ;
+                 DIG 3 ;
+                 DROP ;
+                 DIG 3 ;
+                 DROP ;
+                 DIG 3 ;
+                 DROP ;
+                 DIG 3 ;
+                 DROP ;
+                 DIG 4 ;
+                 DROP ;
+                 DIG 4 ;
+                 DROP ;
+                 DIG 4 ;
+                 DROP ;
+                 DIG 4 ;
+                 DROP ;
+                 DIG 4 ;
+                 DROP ;
+                 DIG 4 ;
+                 DROP ;
+                 DIG 4 ;
+                 DROP ;
+                 UNIT ;
+                 DIG 3 ;
+                 SWAP ;
+                 EXEC ;
+                 DROP ;
+                 DUP ;
+                 DIG 2 ;
+                 SWAP ;
+                 EXEC ;
+                 DROP ;
+                 DUP ;
+                 GET 25 ;
+                 IF_NONE
+                   { SWAP ; FAILWITH }
+                   { DIG 2 ; SWAP ; SENDER ; COMPARE ; EQ ; IF { DROP } { FAILWITH } } ;
+                 SENDER ;
+                 UPDATE 23 ;
+                 NONE address ;
+                 UPDATE 25 ;
+                 NIL operation ;
+                 PAIR }
+               { DIG 31 ;
+                 DROP ;
+                 IF_LEFT
+                   { DIG 2 ;
+                     DROP ;
+                     DIG 2 ;
+                     DROP ;
+                     DIG 2 ;
+                     DROP ;
+                     DIG 2 ;
+                     DROP ;
+                     DIG 2 ;
+                     DROP ;
+                     DIG 2 ;
+                     DROP ;
+                     DIG 2 ;
+                     DROP ;
+                     DIG 2 ;
+                     DROP ;
+                     DIG 2 ;
+                     DROP ;
+                     DIG 2 ;
+                     DROP ;
+                     DIG 2 ;
+                     DROP ;
+                     DIG 2 ;
+                     DROP ;
+                     DIG 2 ;
+                     DROP ;
+                     DIG 2 ;
+                     DROP ;
+                     DIG 2 ;
+                     DROP ;
+                     DIG 2 ;
+                     DROP ;
+                     DIG 2 ;
+                     DROP ;
+                     DIG 2 ;
+                     DROP ;
+                     DIG 4 ;
+                     DROP ;
+                     DIG 4 ;
+                     DROP ;
+                     DIG 4 ;
+                     DROP ;
+                     DIG 4 ;
+                     DROP ;
+                     DIG 4 ;
+                     DROP ;
+                     DIG 4 ;
+                     DROP ;
+                     DIG 4 ;
+                     DROP ;
+                     DIG 4 ;
+                     DROP ;
+                     DIG 4 ;
+                     DROP ;
+                     DIG 5 ;
+                     DROP ;
+                     DIG 5 ;
+                     DROP ;
+                     DIG 5 ;
+                     DROP ;
+                     DIG 5 ;
+                     DROP ;
+                     DIG 5 ;
+                     DROP ;
+                     DIG 5 ;
+                     DROP ;
+                     UNIT ;
+                     DIG 4 ;
+                     SWAP ;
+                     EXEC ;
+                     DROP ;
+                     DUP 2 ;
+                     DIG 3 ;
+                     SWAP ;
+                     EXEC ;
+                     DROP ;
+                     DIG 2 ;
+                     DUP 3 ;
+                     GET 23 ;
+                     SENDER ;
+                     COMPARE ;
+                     EQ ;
+                     IF { DROP } { FAILWITH } ;
+                     SOME ;
+                     UPDATE 25 ;
+                     NIL operation ;
+                     PAIR }
+                   { IF_LEFT
+                       { DIG 2 ;
+                         DROP ;
+                         DIG 2 ;
+                         DROP ;
+                         DIG 2 ;
+                         DROP ;
+                         DIG 2 ;
+                         DROP ;
+                         DIG 2 ;
+                         DROP ;
+                         DIG 2 ;
+                         DROP ;
+                         DIG 2 ;
+                         DROP ;
+                         DIG 2 ;
+                         DROP ;
+                         DIG 2 ;
+                         DROP ;
+                         DIG 2 ;
+                         DROP ;
+                         DIG 2 ;
+                         DROP ;
+                         DIG 2 ;
+                         DROP ;
+                         DIG 2 ;
+                         DROP ;
+                         DIG 2 ;
+                         DROP ;
+                         DIG 2 ;
+                         DROP ;
+                         DIG 2 ;
+                         DROP ;
+                         DIG 2 ;
+                         DROP ;
+                         DIG 2 ;
+                         DROP ;
+                         DIG 4 ;
+                         DROP ;
+                         DIG 4 ;
+                         DROP ;
+                         DIG 4 ;
+                         DROP ;
+                         DIG 4 ;
+                         DROP ;
+                         DIG 4 ;
+                         DROP ;
+                         DIG 4 ;
+                         DROP ;
+                         DIG 4 ;
+                         DROP ;
+                         DIG 4 ;
+                         DROP ;
+                         DIG 4 ;
+                         DROP ;
+                         DIG 6 ;
+                         DROP ;
+                         DIG 6 ;
+                         DROP ;
+                         DIG 6 ;
+                         DROP ;
+                         DIG 6 ;
+                         DROP ;
+                         DIG 6 ;
+                         DROP ;
+                         UNIT ;
+                         DIG 4 ;
+                         SWAP ;
+                         EXEC ;
+                         DROP ;
+                         DUP 2 ;
+                         DIG 3 ;
+                         SWAP ;
+                         EXEC ;
+                         DROP ;
+                         DIG 2 ;
+                         DUP 3 ;
+                         GET 23 ;
+                         SENDER ;
+                         COMPARE ;
+                         EQ ;
+                         IF { DROP } { FAILWITH } ;
+                         DUP ;
+                         IF { DUP 2 ; GET 29 ; IF { DIG 2 ; FAILWITH } { DIG 2 ; DROP } }
+                            { DIG 2 ;
+                              DROP ;
+                              DUP 2 ;
+                              GET 29 ;
+                              IF {} { PUSH string "POOL_NOT_PAUSED" ; FAILWITH } } ;
+                         UPDATE 29 ;
+                         NIL operation ;
+                         PAIR }
+                       { DIG 32 ;
+                         DROP ;
+                         IF_LEFT
+                           { DIG 2 ;
+                             DROP ;
+                             DIG 2 ;
+                             DROP ;
+                             DIG 2 ;
+                             DROP ;
+                             DIG 2 ;
+                             DROP ;
+                             DIG 2 ;
+                             DROP ;
+                             DIG 2 ;
+                             DROP ;
+                             DIG 2 ;
+                             DROP ;
+                             DIG 2 ;
+                             DROP ;
+                             DIG 2 ;
+                             DROP ;
+                             DIG 2 ;
+                             DROP ;
+                             DIG 2 ;
+                             DROP ;
+                             DIG 2 ;
+                             DROP ;
+                             DIG 2 ;
+                             DROP ;
+                             DIG 3 ;
+                             DROP ;
+                             DIG 3 ;
+                             DROP ;
+                             DIG 3 ;
+                             DROP ;
+                             DIG 3 ;
+                             DROP ;
+                             DIG 3 ;
+                             DROP ;
+                             DIG 4 ;
+                             DROP ;
+                             DIG 6 ;
+                             DROP ;
+                             DIG 6 ;
+                             DROP ;
+                             DIG 6 ;
+                             DROP ;
+                             DIG 6 ;
+                             DROP ;
+                             DIG 6 ;
+                             DROP ;
+                             DIG 6 ;
+                             DROP ;
+                             DIG 6 ;
+                             DROP ;
+                             DIG 7 ;
+                             DROP ;
+                             DIG 7 ;
+                             DROP ;
+                             DIG 7 ;
+                             DROP ;
+                             DIG 7 ;
+                             DROP ;
+                             UNIT ;
+                             DIG 4 ;
+                             SWAP ;
+                             EXEC ;
+                             DROP ;
+                             PUSH nat 1 ;
+                             DUP 2 ;
+                             CAR ;
+                             SIZE ;
+                             COMPARE ;
+                             EQ ;
+                             IF {} { DUP 4 ; FAILWITH } ;
+                             DUP ;
+                             CAR ;
+                             IF_CONS { SWAP ; DROP ; SOME } { NONE (pair address nat) } ;
+                             IF_NONE { DIG 3 ; FAILWITH } { DIG 4 ; DROP } ;
+                             DIG 5 ;
+                             DUP 2 ;
+                             CDR ;
+                             COMPARE ;
+                             EQ ;
+                             IF { DIG 4 ; DROP } { DIG 4 ; FAILWITH } ;
+                             NIL (pair (pair address nat) nat) ;
+                             DUP 4 ;
+                             GET 15 ;
+                             DUP 3 ;
+                             CAR ;
+                             PAIR ;
+                             DIG 5 ;
+                             SWAP ;
+                             EXEC ;
+                             DIG 2 ;
+                             PAIR ;
+                             CONS ;
+                             DIG 2 ;
+                             NIL operation ;
+                             DIG 3 ;
+                             CDR ;
+                             PUSH mutez 0 ;
+                             DIG 4 ;
+                             TRANSFER_TOKENS ;
+                             CONS ;
+                             PAIR }
+                           { IF_LEFT
+                               { DIG 2 ;
+                                 DROP ;
+                                 DIG 2 ;
+                                 DROP ;
+                                 DIG 2 ;
+                                 DROP ;
+                                 DIG 2 ;
+                                 DROP ;
+                                 DIG 2 ;
+                                 DROP ;
+                                 DIG 2 ;
+                                 DROP ;
+                                 DIG 2 ;
+                                 DROP ;
+                                 DIG 2 ;
+                                 DROP ;
+                                 DIG 2 ;
+                                 DROP ;
+                                 DIG 2 ;
+                                 DROP ;
+                                 DIG 2 ;
+                                 DROP ;
+                                 DIG 2 ;
+                                 DROP ;
+                                 DIG 2 ;
+                                 DROP ;
+                                 DIG 2 ;
+                                 DROP ;
+                                 DIG 2 ;
+                                 DROP ;
+                                 DIG 2 ;
+                                 DROP ;
+                                 DIG 2 ;
+                                 DROP ;
+                                 DIG 2 ;
+                                 DROP ;
+                                 DIG 4 ;
+                                 DROP ;
+                                 DIG 7 ;
+                                 DROP ;
+                                 DIG 7 ;
+                                 DROP ;
+                                 DIG 7 ;
+                                 DROP ;
+                                 DIG 7 ;
+                                 DROP ;
+                                 DIG 7 ;
+                                 DROP ;
+                                 DIG 7 ;
+                                 DROP ;
+                                 DIG 8 ;
+                                 DROP ;
+                                 DIG 8 ;
+                                 DROP ;
+                                 DIG 8 ;
+                                 DROP ;
+                                 DIG 8 ;
+                                 DROP ;
+                                 UNIT ;
+                                 DIG 4 ;
+                                 SWAP ;
+                                 EXEC ;
+                                 DROP ;
+                                 DUP 2 ;
+                                 DIG 3 ;
+                                 SWAP ;
+                                 EXEC ;
+                                 DROP ;
+                                 PUSH nat 1 ;
+                                 DUP 2 ;
+                                 SIZE ;
+                                 COMPARE ;
+                                 EQ ;
+                                 IF {} { DUP 3 ; FAILWITH } ;
+                                 IF_CONS
+                                   { SWAP ; DROP ; SOME }
+                                   { NONE (or (pair address (pair address nat)) (pair address (pair address nat))) } ;
+                                 IF_NONE { SWAP ; FAILWITH } { DIG 2 ; DROP } ;
+                                 IF_LEFT
+                                   { DIG 4 ;
+                                     DUP 2 ;
+                                     GET 4 ;
+                                     COMPARE ;
+                                     EQ ;
+                                     IF { DIG 2 ; DROP } { DIG 2 ; FAILWITH } ;
+                                     DIG 2 ;
+                                     SENDER ;
+                                     DUP 3 ;
+                                     CAR ;
+                                     COMPARE ;
+                                     EQ ;
+                                     IF { DROP } { FAILWITH } ;
+                                     DUP 2 ;
+                                     GET 17 ;
+                                     UNIT ;
+                                     SOME ;
+                                     DUP 3 ;
+                                     GET 3 ;
+                                     DIG 3 ;
+                                     CAR ;
+                                     PAIR ;
+                                     UPDATE }
+                                   { DIG 4 ;
+                                     DUP 2 ;
+                                     GET 4 ;
+                                     COMPARE ;
+                                     EQ ;
+                                     IF { DIG 2 ; DROP } { DIG 2 ; FAILWITH } ;
+                                     DIG 2 ;
+                                     SENDER ;
+                                     DUP 3 ;
+                                     CAR ;
+                                     COMPARE ;
+                                     EQ ;
+                                     IF { DROP } { FAILWITH } ;
+                                     DUP 2 ;
+                                     GET 17 ;
+                                     NONE unit ;
+                                     DUP 3 ;
+                                     GET 3 ;
+                                     DIG 3 ;
+                                     CAR ;
+                                     PAIR ;
+                                     UPDATE } ;
+                                 UPDATE 17 ;
+                                 NIL operation ;
+                                 PAIR }
+                               { IF_LEFT
+                                   { DIG 2 ;
+                                     DROP ;
+                                     DIG 2 ;
+                                     DROP ;
+                                     DIG 2 ;
+                                     DROP ;
+                                     DIG 2 ;
+                                     DROP ;
+                                     DIG 2 ;
+                                     DROP ;
+                                     DIG 2 ;
+                                     DROP ;
+                                     DIG 2 ;
+                                     DROP ;
+                                     DIG 2 ;
+                                     DROP ;
+                                     DIG 2 ;
+                                     DROP ;
+                                     DIG 2 ;
+                                     DROP ;
+                                     DIG 2 ;
+                                     DROP ;
+                                     DIG 4 ;
+                                     DROP ;
+                                     DIG 4 ;
+                                     DROP ;
+                                     DIG 4 ;
+                                     DROP ;
+                                     DIG 4 ;
+                                     DROP ;
+                                     DIG 4 ;
+                                     DROP ;
+                                     DIG 6 ;
+                                     DROP ;
+                                     DIG 9 ;
+                                     DROP ;
+                                     DIG 9 ;
+                                     DROP ;
+                                     DIG 9 ;
+                                     DROP ;
+                                     DIG 9 ;
+                                     DROP ;
+                                     DIG 9 ;
+                                     DROP ;
+                                     DIG 9 ;
+                                     DROP ;
+                                     DIG 10 ;
+                                     DROP ;
+                                     DIG 10 ;
+                                     DROP ;
+                                     DIG 10 ;
+                                     DROP ;
+                                     DIG 10 ;
+                                     DROP ;
+                                     UNIT ;
+                                     DIG 6 ;
+                                     SWAP ;
+                                     EXEC ;
+                                     DROP ;
+                                     DUP 2 ;
+                                     DIG 5 ;
+                                     SWAP ;
+                                     EXEC ;
+                                     DROP ;
+                                     PUSH nat 1 ;
+                                     DUP 2 ;
+                                     SIZE ;
+                                     COMPARE ;
+                                     EQ ;
+                                     IF {} { DUP 5 ; FAILWITH } ;
+                                     IF_CONS
+                                       { SWAP ; DROP ; SOME }
+                                       { NONE (pair address (list (pair address (pair nat nat)))) } ;
+                                     IF_NONE { DUP 4 ; FAILWITH } {} ;
+                                     PUSH nat 1 ;
+                                     DUP 2 ;
+                                     CDR ;
+                                     SIZE ;
+                                     COMPARE ;
+                                     EQ ;
+                                     IF {} { DUP 5 ; FAILWITH } ;
+                                     DUP ;
+                                     CDR ;
+                                     IF_CONS { SWAP ; DROP ; SOME } { NONE (pair address (pair nat nat)) } ;
+                                     IF_NONE { DIG 4 ; FAILWITH } { DIG 5 ; DROP } ;
+                                     DIG 6 ;
+                                     DUP 4 ;
+                                     SENDER ;
+                                     DUP 5 ;
+                                     CAR ;
+                                     DIG 2 ;
+                                     GET 17 ;
+                                     DUP 3 ;
+                                     DUP 3 ;
+                                     PAIR ;
+                                     MEM ;
+                                     DUG 2 ;
+                                     COMPARE ;
+                                     EQ ;
+                                     OR ;
+                                     IF { DROP } { FAILWITH } ;
+                                     DIG 6 ;
+                                     DUP 2 ;
+                                     GET 3 ;
+                                     COMPARE ;
+                                     EQ ;
+                                     IF { DIG 5 ; DROP } { DIG 5 ; FAILWITH } ;
+                                     PUSH string "POOL_LOCKED_LIQUIDITY" ;
+                                     SELF_ADDRESS ;
+                                     DUP 3 ;
+                                     CAR ;
+                                     COMPARE ;
+                                     NEQ ;
+                                     IF { DROP } { FAILWITH } ;
+                                     DUP 3 ;
+                                     GET 15 ;
+                                     DUP 2 ;
+                                     GET 4 ;
+                                     DIG 3 ;
+                                     CAR ;
+                                     PAIR 3 ;
+                                     DIG 3 ;
+                                     SWAP ;
+                                     EXEC ;
+                                     DUP 2 ;
+                                     GET 4 ;
+                                     DIG 2 ;
+                                     CAR ;
+                                     PAIR 3 ;
+                                     DIG 2 ;
+                                     SWAP ;
+                                     EXEC ;
+                                     UPDATE 15 ;
+                                     NIL operation ;
+                                     PAIR }
+                                   { DIG 13 ;
+                                     DROP ;
+                                     DIG 13 ;
+                                     DROP ;
+                                     DIG 22 ;
+                                     DROP ;
+                                     DIG 22 ;
+                                     DROP ;
+                                     DIG 28 ;
+                                     DROP ;
+                                     IF_LEFT
+                                       { DIG 5 ;
+                                         DROP ;
+                                         DIG 7 ;
+                                         DROP ;
+                                         DIG 7 ;
+                                         DROP ;
+                                         DIG 7 ;
+                                         DROP ;
+                                         DIG 7 ;
+                                         DROP ;
+                                         DIG 7 ;
+                                         DROP ;
+                                         DIG 7 ;
+                                         DROP ;
+                                         DIG 7 ;
+                                         DROP ;
+                                         DIG 7 ;
+                                         DROP ;
+                                         DIG 7 ;
+                                         DROP ;
+                                         DIG 7 ;
+                                         DROP ;
+                                         DIG 7 ;
+                                         DROP ;
+                                         DIG 7 ;
+                                         DROP ;
+                                         DIG 7 ;
+                                         DROP ;
+                                         DIG 8 ;
+                                         DROP ;
+                                         DIG 8 ;
+                                         DROP ;
+                                         DIG 8 ;
+                                         DROP ;
+                                         DIG 8 ;
+                                         DROP ;
+                                         DIG 8 ;
+                                         DROP ;
+                                         DIG 8 ;
+                                         DROP ;
+                                         DIG 8 ;
+                                         DROP ;
+                                         DIG 8 ;
+                                         DROP ;
+                                         DIG 8 ;
+                                         DROP ;
+                                         DIG 8 ;
+                                         DROP ;
+                                         DUP 2 ;
+                                         GET 30 ;
+                                         IF_NONE { DUP 8 ; FAILWITH } {} ;
+                                         DUP ;
+                                         DIG 7 ;
+                                         SWAP ;
+                                         EXEC ;
+                                         DROP ;
+                                         DIG 7 ;
+                                         UNIT ;
+                                         RIGHT unit ;
+                                         RIGHT unit ;
+                                         RIGHT unit ;
+                                         DUP 3 ;
+                                         GET 7 ;
+                                         COMPARE ;
+                                         EQ ;
+                                         IF { DROP } { FAILWITH } ;
+                                         DUP ;
+                                         DIG 7 ;
+                                         SWAP ;
+                                         EXEC ;
+                                         DIG 2 ;
+                                         DUP 2 ;
+                                         CAR ;
+                                         PAIR ;
+                                         DIG 5 ;
+                                         SWAP ;
+                                         EXEC ;
+                                         SWAP ;
+                                         DUP 3 ;
+                                         PAIR 3 ;
+                                         DIG 3 ;
+                                         SWAP ;
+                                         EXEC ;
+                                         DROP ;
+                                         CAR ;
+                                         PAIR ;
+                                         EXEC }
+                                       { IF_LEFT
+                                           { DIG 2 ;
+                                             DROP ;
+                                             DIG 3 ;
+                                             DROP ;
+                                             DIG 3 ;
+                                             DROP ;
+                                             DIG 8 ;
+                                             DROP ;
+                                             DIG 8 ;
+                                             DROP ;
+                                             DIG 8 ;
+                                             DROP ;
+                                             DIG 8 ;
+                                             DROP ;
+                                             DIG 8 ;
+                                             DROP ;
+                                             DIG 8 ;
+                                             DROP ;
+                                             DIG 8 ;
+                                             DROP ;
+                                             DIG 8 ;
+                                             DROP ;
+                                             DIG 8 ;
+                                             DROP ;
+                                             DIG 10 ;
+                                             DROP ;
+                                             DIG 10 ;
+                                             DROP ;
+                                             DIG 10 ;
+                                             DROP ;
+                                             DIG 10 ;
+                                             DROP ;
+                                             DIG 10 ;
+                                             DROP ;
+                                             DIG 10 ;
+                                             DROP ;
+                                             DIG 10 ;
+                                             DROP ;
+                                             DIG 10 ;
+                                             DROP ;
+                                             DIG 10 ;
+                                             DROP ;
+                                             DIG 10 ;
+                                             DROP ;
+                                             DUP 2 ;
+                                             GET 30 ;
+                                             IF_NONE { DUP 10 ; FAILWITH } {} ;
+                                             DUP ;
+                                             DIG 5 ;
+                                             SWAP ;
+                                             EXEC ;
+                                             DROP ;
+                                             DUP 10 ;
+                                             UNIT ;
+                                             LEFT unit ;
+                                             RIGHT unit ;
+                                             RIGHT unit ;
+                                             DUP 3 ;
+                                             GET 7 ;
+                                             COMPARE ;
+                                             EQ ;
+                                             IF { DROP } { FAILWITH } ;
+                                             DUP ;
+                                             DIG 5 ;
+                                             SWAP ;
+                                             EXEC ;
+                                             DIG 2 ;
+                                             DUP 2 ;
+                                             CAR ;
+                                             PAIR ;
+                                             DIG 4 ;
+                                             SWAP ;
+                                             EXEC ;
+                                             DIG 7 ;
+                                             DUP 5 ;
+                                             DUP 4 ;
+                                             CAR ;
+                                             PAIR ;
+                                             DIG 8 ;
+                                             SWAP ;
+                                             EXEC ;
+                                             DUP 3 ;
+                                             COMPARE ;
+                                             GE ;
+                                             IF { DROP } { FAILWITH } ;
+                                             DIG 2 ;
+                                             UNIT ;
+                                             RIGHT unit ;
+                                             RIGHT unit ;
+                                             RIGHT unit ;
+                                             UPDATE 7 ;
+                                             DIG 3 ;
+                                             SWAP ;
+                                             DIG 2 ;
+                                             SOME ;
+                                             UPDATE 9 ;
+                                             SOME ;
+                                             UPDATE 30 ;
+                                             NIL operation ;
+                                             SELF_ADDRESS ;
+                                             CONTRACT %receive_second_after
+                                               (list (pair (pair %request (address %owner) (nat %token_id)) (nat %balance))) ;
+                                             IF_NONE { DIG 5 ; FAILWITH } { DIG 6 ; DROP } ;
+                                             DUP 4 ;
+                                             CAR ;
+                                             PAIR ;
+                                             DIG 4 ;
+                                             SWAP ;
+                                             EXEC ;
+                                             CONS ;
+                                             DIG 2 ;
+                                             DIG 3 ;
+                                             SWAP ;
+                                             EXEC ;
+                                             CONS ;
+                                             PAIR }
+                                           { IF_LEFT
+                                               { DIG 5 ;
+                                                 DROP ;
+                                                 DIG 8 ;
+                                                 DROP ;
+                                                 DIG 8 ;
+                                                 DROP ;
+                                                 DIG 8 ;
+                                                 DROP ;
+                                                 DIG 8 ;
+                                                 DROP ;
+                                                 DIG 8 ;
+                                                 DROP ;
+                                                 DIG 8 ;
+                                                 DROP ;
+                                                 DIG 8 ;
+                                                 DROP ;
+                                                 DIG 8 ;
+                                                 DROP ;
+                                                 DIG 8 ;
+                                                 DROP ;
+                                                 DIG 8 ;
+                                                 DROP ;
+                                                 DIG 8 ;
+                                                 DROP ;
+                                                 DIG 8 ;
+                                                 DROP ;
+                                                 DIG 9 ;
+                                                 DROP ;
+                                                 DIG 9 ;
+                                                 DROP ;
+                                                 DIG 9 ;
+                                                 DROP ;
+                                                 DIG 9 ;
+                                                 DROP ;
+                                                 DIG 9 ;
+                                                 DROP ;
+                                                 DIG 9 ;
+                                                 DROP ;
+                                                 DIG 9 ;
+                                                 DROP ;
+                                                 DIG 9 ;
+                                                 DROP ;
+                                                 DIG 9 ;
+                                                 DROP ;
+                                                 DIG 9 ;
+                                                 DROP ;
+                                                 DUP 2 ;
+                                                 GET 30 ;
+                                                 IF_NONE { DUP 9 ; FAILWITH } {} ;
+                                                 DUP ;
+                                                 DIG 7 ;
+                                                 SWAP ;
+                                                 EXEC ;
+                                                 DROP ;
+                                                 DUP 9 ;
+                                                 UNIT ;
+                                                 LEFT (or unit unit) ;
+                                                 RIGHT unit ;
+                                                 DUP 3 ;
+                                                 GET 7 ;
+                                                 COMPARE ;
+                                                 EQ ;
+                                                 IF { DROP } { FAILWITH } ;
+                                                 DUP ;
+                                                 DIG 7 ;
+                                                 SWAP ;
+                                                 EXEC ;
+                                                 DIG 2 ;
+                                                 DUP 2 ;
+                                                 CAR ;
+                                                 PAIR ;
+                                                 DIG 5 ;
+                                                 SWAP ;
+                                                 EXEC ;
+                                                 SWAP ;
+                                                 DUP 3 ;
+                                                 PAIR 3 ;
+                                                 DIG 3 ;
+                                                 SWAP ;
+                                                 EXEC ;
+                                                 DROP ;
+                                                 DUP ;
+                                                 GET 5 ;
+                                                 IF_NONE
+                                                   { DIG 3 ; DROP ; DIG 3 ; DROP ; CAR ; PAIR ; EXEC }
+                                                   { DIG 3 ;
+                                                     DROP ;
+                                                     SWAP ;
+                                                     UNIT ;
+                                                     LEFT unit ;
+                                                     RIGHT unit ;
+                                                     RIGHT unit ;
+                                                     UPDATE 7 ;
+                                                     DIG 2 ;
+                                                     SWAP ;
+                                                     NONE nat ;
+                                                     UPDATE 9 ;
+                                                     SOME ;
+                                                     UPDATE 30 ;
+                                                     NIL operation ;
+                                                     SELF_ADDRESS ;
+                                                     CONTRACT %receive_second_before
+                                                       (list (pair (pair %request (address %owner) (nat %token_id)) (nat %balance))) ;
+                                                     IF_NONE { DIG 4 ; FAILWITH } { DIG 5 ; DROP } ;
+                                                     DIG 3 ;
+                                                     CAR ;
+                                                     PAIR ;
+                                                     DIG 3 ;
+                                                     SWAP ;
+                                                     EXEC ;
+                                                     CONS ;
+                                                     PAIR } }
+                                               { DIG 2 ;
+                                                 DROP ;
+                                                 DIG 3 ;
+                                                 DROP ;
+                                                 IF_LEFT
+                                                   { DIG 3 ;
+                                                     DROP ;
+                                                     DIG 8 ;
+                                                     DROP ;
+                                                     DIG 8 ;
+                                                     DROP ;
+                                                     DIG 8 ;
+                                                     DROP ;
+                                                     DIG 8 ;
+                                                     DROP ;
+                                                     DIG 8 ;
+                                                     DROP ;
+                                                     DIG 8 ;
+                                                     DROP ;
+                                                     DIG 8 ;
+                                                     DROP ;
+                                                     DIG 8 ;
+                                                     DROP ;
+                                                     DIG 8 ;
+                                                     DROP ;
+                                                     DIG 10 ;
+                                                     DROP ;
+                                                     DIG 10 ;
+                                                     DROP ;
+                                                     DIG 10 ;
+                                                     DROP ;
+                                                     DIG 10 ;
+                                                     DROP ;
+                                                     DIG 10 ;
+                                                     DROP ;
+                                                     DIG 10 ;
+                                                     DROP ;
+                                                     DIG 10 ;
+                                                     DROP ;
+                                                     DIG 10 ;
+                                                     DROP ;
+                                                     DIG 10 ;
+                                                     DROP ;
+                                                     DIG 10 ;
+                                                     DROP ;
+                                                     DUP 2 ;
+                                                     GET 30 ;
+                                                     IF_NONE { DUP 10 ; FAILWITH } {} ;
+                                                     DUP ;
+                                                     DIG 5 ;
+                                                     SWAP ;
+                                                     EXEC ;
+                                                     DROP ;
+                                                     DUP 10 ;
+                                                     UNIT ;
+                                                     LEFT (or unit (or unit unit)) ;
+                                                     DUP 3 ;
+                                                     GET 7 ;
+                                                     COMPARE ;
+                                                     EQ ;
+                                                     IF { DROP } { FAILWITH } ;
+                                                     DUP ;
+                                                     DIG 5 ;
+                                                     SWAP ;
+                                                     EXEC ;
+                                                     DIG 2 ;
+                                                     DUP 2 ;
+                                                     CAR ;
+                                                     PAIR ;
+                                                     DIG 4 ;
+                                                     SWAP ;
+                                                     EXEC ;
+                                                     DIG 7 ;
+                                                     DUP 5 ;
+                                                     DUP 4 ;
+                                                     CAR ;
+                                                     PAIR ;
+                                                     DIG 8 ;
+                                                     SWAP ;
+                                                     EXEC ;
+                                                     DUP 3 ;
+                                                     COMPARE ;
+                                                     GE ;
+                                                     IF { DROP } { FAILWITH } ;
+                                                     DIG 2 ;
+                                                     UNIT ;
+                                                     LEFT (or unit unit) ;
+                                                     RIGHT unit ;
+                                                     UPDATE 7 ;
+                                                     DIG 3 ;
+                                                     SWAP ;
+                                                     DIG 2 ;
+                                                     SOME ;
+                                                     UPDATE 9 ;
+                                                     SOME ;
+                                                     UPDATE 30 ;
+                                                     NIL operation ;
+                                                     SELF_ADDRESS ;
+                                                     CONTRACT %receive_first_after
+                                                       (list (pair (pair %request (address %owner) (nat %token_id)) (nat %balance))) ;
+                                                     IF_NONE { DIG 5 ; FAILWITH } { DIG 6 ; DROP } ;
+                                                     DUP 4 ;
+                                                     CAR ;
+                                                     PAIR ;
+                                                     DIG 4 ;
+                                                     SWAP ;
+                                                     EXEC ;
+                                                     CONS ;
+                                                     DIG 2 ;
+                                                     DIG 3 ;
+                                                     SWAP ;
+                                                     EXEC ;
+                                                     CONS ;
+                                                     PAIR }
+                                                   { DIG 2 ;
+                                                     DROP ;
+                                                     DIG 3 ;
+                                                     DROP ;
+                                                     DIG 3 ;
+                                                     DROP ;
+                                                     DIG 3 ;
+                                                     DROP ;
+                                                     DIG 3 ;
+                                                     DROP ;
+                                                     DIG 3 ;
+                                                     DROP ;
+                                                     DIG 12 ;
+                                                     DROP ;
+                                                     DIG 12 ;
+                                                     DROP ;
+                                                     IF_LEFT
+                                                       { DROP ;
+                                                         DIG 2 ;
+                                                         DROP ;
+                                                         DIG 2 ;
+                                                         DROP ;
+                                                         DIG 2 ;
+                                                         DROP ;
+                                                         DIG 2 ;
+                                                         DROP ;
+                                                         DIG 2 ;
+                                                         DROP ;
+                                                         DIG 2 ;
+                                                         DROP ;
+                                                         DIG 2 ;
+                                                         DROP ;
+                                                         DIG 4 ;
+                                                         DROP ;
+                                                         DIG 4 ;
+                                                         DROP ;
+                                                         DIG 4 ;
+                                                         DROP ;
+                                                         DIG 4 ;
+                                                         DROP ;
+                                                         DIG 4 ;
+                                                         DROP ;
+                                                         DIG 4 ;
+                                                         DROP ;
+                                                         DIG 4 ;
+                                                         DROP ;
+                                                         DIG 4 ;
+                                                         DROP ;
+                                                         DIG 4 ;
+                                                         DROP ;
+                                                         DIG 4 ;
+                                                         DROP ;
+                                                         UNIT ;
+                                                         DIG 4 ;
+                                                         SWAP ;
+                                                         EXEC ;
+                                                         DROP ;
+                                                         DUP ;
+                                                         DIG 3 ;
+                                                         SWAP ;
+                                                         EXEC ;
+                                                         DROP ;
+                                                         PUSH string "POOL_NOT_FEE_RECIPIENT" ;
+                                                         DUP 2 ;
+                                                         GET 27 ;
+                                                         SENDER ;
+                                                         COMPARE ;
+                                                         EQ ;
+                                                         IF { DROP } { FAILWITH } ;
+                                                         PUSH nat 0 ;
+                                                         DUP 2 ;
+                                                         GET 11 ;
+                                                         COMPARE ;
+                                                         GT ;
+                                                         PUSH nat 0 ;
+                                                         DUP 3 ;
+                                                         GET 9 ;
+                                                         COMPARE ;
+                                                         GT ;
+                                                         OR ;
+                                                         IF {} { PUSH string "POOL_NO_PROTOCOL_FEES" ; FAILWITH } ;
+                                                         SELF_ADDRESS ;
+                                                         UNIT ;
+                                                         RIGHT unit ;
+                                                         DUP 3 ;
+                                                         GET 9 ;
+                                                         DUP 4 ;
+                                                         GET 27 ;
+                                                         DUP 4 ;
+                                                         DUP 6 ;
+                                                         CAR ;
+                                                         PAIR 5 ;
+                                                         UNIT ;
+                                                         RIGHT unit ;
+                                                         DUP 4 ;
+                                                         GET 11 ;
+                                                         DUP 5 ;
+                                                         GET 27 ;
+                                                         DIG 4 ;
+                                                         DUP 6 ;
+                                                         GET 3 ;
+                                                         PAIR 5 ;
+                                                         PUSH nat 0 ;
+                                                         DUP 4 ;
+                                                         GET 11 ;
+                                                         COMPARE ;
+                                                         GT ;
+                                                         PUSH nat 0 ;
+                                                         DUP 5 ;
+                                                         GET 9 ;
+                                                         COMPARE ;
+                                                         GT ;
+                                                         AND ;
+                                                         IF { SOME }
+                                                            { PUSH nat 0 ;
+                                                              DUP 4 ;
+                                                              GET 9 ;
+                                                              COMPARE ;
+                                                              GT ;
+                                                              IF { DROP } { SWAP ; DROP } ;
+                                                              NONE (pair (pair address nat) (pair address (pair address (pair nat (or unit unit))))) } ;
+                                                         SWAP ;
+                                                         PAIR ;
+                                                         UNPAIR ;
+                                                         NONE timestamp ;
+                                                         NONE nat ;
+                                                         UNIT ;
+                                                         LEFT (or unit (or unit unit)) ;
+                                                         DIG 4 ;
+                                                         DIG 4 ;
+                                                         DUP 6 ;
+                                                         GET 11 ;
+                                                         DUP 7 ;
+                                                         GET 9 ;
+                                                         PAIR ;
+                                                         RIGHT (pair address (pair nat (pair nat nat))) ;
+                                                         RIGHT (pair (or unit unit) (pair nat (pair nat nat))) ;
+                                                         RIGHT (pair address (pair nat (pair nat nat))) ;
+                                                         RIGHT (pair address (pair nat (pair nat nat))) ;
+                                                         PAIR 6 ;
+                                                         PAIR ;
+                                                         EXEC }
+                                                       { IF_LEFT
+                                                           { DIG 3 ;
+                                                             DROP ;
+                                                             DIG 3 ;
+                                                             DROP ;
+                                                             DIG 7 ;
+                                                             DROP ;
+                                                             DIG 10 ;
+                                                             DROP ;
+                                                             DIG 13 ;
+                                                             DROP ;
+                                                             DIG 13 ;
+                                                             DROP ;
+                                                             DIG 13 ;
+                                                             DROP ;
+                                                             DIG 13 ;
+                                                             DROP ;
+                                                             DIG 13 ;
+                                                             DROP ;
+                                                             UNIT ;
+                                                             DIG 9 ;
+                                                             SWAP ;
+                                                             EXEC ;
+                                                             DROP ;
+                                                             DUP 2 ;
+                                                             DIG 8 ;
+                                                             SWAP ;
+                                                             EXEC ;
+                                                             DROP ;
+                                                             DUP 2 ;
+                                                             DIG 7 ;
+                                                             SWAP ;
+                                                             EXEC ;
+                                                             DROP ;
+                                                             DUP ;
+                                                             GET 8 ;
+                                                             DIG 6 ;
+                                                             SWAP ;
+                                                             EXEC ;
+                                                             DROP ;
+                                                             DUP ;
+                                                             GET 7 ;
+                                                             DIG 5 ;
+                                                             SWAP ;
+                                                             EXEC ;
+                                                             DROP ;
+                                                             PUSH nat 0 ;
+                                                             DUP 2 ;
+                                                             CAR ;
+                                                             COMPARE ;
+                                                             GT ;
+                                                             IF { DIG 7 ; DROP } { DIG 7 ; FAILWITH } ;
+                                                             SENDER ;
+                                                             DIG 5 ;
+                                                             DUP 3 ;
+                                                             CAR ;
+                                                             DUP 5 ;
+                                                             GET 15 ;
+                                                             DUP 4 ;
+                                                             PAIR ;
+                                                             DIG 7 ;
+                                                             SWAP ;
+                                                             EXEC ;
+                                                             COMPARE ;
+                                                             GE ;
+                                                             IF { DROP } { FAILWITH } ;
+                                                             DUP 3 ;
+                                                             GET 13 ;
+                                                             DUP 4 ;
+                                                             GET 5 ;
+                                                             DUP 4 ;
+                                                             CAR ;
+                                                             MUL ;
+                                                             EDIV ;
+                                                             IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                             DUP 4 ;
+                                                             GET 13 ;
+                                                             DUP 5 ;
+                                                             GET 7 ;
+                                                             DUP 5 ;
+                                                             CAR ;
+                                                             MUL ;
+                                                             EDIV ;
+                                                             IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                             DUP ;
+                                                             INT ;
+                                                             GT ;
+                                                             DUP 3 ;
+                                                             INT ;
+                                                             GT ;
+                                                             AND ;
+                                                             IF { DIG 7 ; DROP } { DIG 7 ; FAILWITH } ;
+                                                             DUP 4 ;
+                                                             GET 5 ;
+                                                             DUP 2 ;
+                                                             COMPARE ;
+                                                             GE ;
+                                                             DUP 5 ;
+                                                             GET 3 ;
+                                                             DUP 4 ;
+                                                             COMPARE ;
+                                                             GE ;
+                                                             AND ;
+                                                             IF { DIG 6 ; DROP } { DIG 6 ; FAILWITH } ;
+                                                             SELF_ADDRESS ;
+                                                             UNIT ;
+                                                             RIGHT unit ;
+                                                             DUP 4 ;
+                                                             DUP 7 ;
+                                                             GET 7 ;
+                                                             DUP 4 ;
+                                                             DUP 10 ;
+                                                             CAR ;
+                                                             PAIR 5 ;
+                                                             UNIT ;
+                                                             RIGHT unit ;
+                                                             DUP 4 ;
+                                                             DUP 8 ;
+                                                             GET 7 ;
+                                                             DIG 4 ;
+                                                             DUP 10 ;
+                                                             GET 3 ;
+                                                             PAIR 5 ;
+                                                             DUP 6 ;
+                                                             GET 8 ;
+                                                             SOME ;
+                                                             NONE nat ;
+                                                             UNIT ;
+                                                             LEFT (or unit (or unit unit)) ;
+                                                             DIG 3 ;
+                                                             SOME ;
+                                                             DIG 4 ;
+                                                             DIG 5 ;
+                                                             DIG 6 ;
+                                                             DIG 8 ;
+                                                             CAR ;
+                                                             DIG 8 ;
+                                                             PAIR 4 ;
+                                                             LEFT (pair nat nat) ;
+                                                             RIGHT (pair (or unit unit) (pair nat (pair nat nat))) ;
+                                                             RIGHT (pair address (pair nat (pair nat nat))) ;
+                                                             RIGHT (pair address (pair nat (pair nat nat))) ;
+                                                             PAIR 6 ;
+                                                             PAIR ;
+                                                             EXEC }
+                                                           { DIG 5 ;
+                                                             DROP ;
+                                                             DIG 11 ;
+                                                             DROP ;
+                                                             IF_LEFT
+                                                               { DIG 3 ;
+                                                                 DROP ;
+                                                                 DIG 3 ;
+                                                                 DROP ;
+                                                                 DIG 13 ;
+                                                                 DROP ;
+                                                                 DIG 13 ;
+                                                                 DROP ;
+                                                                 UNIT ;
+                                                                 DIG 9 ;
+                                                                 SWAP ;
+                                                                 EXEC ;
+                                                                 DROP ;
+                                                                 DUP 2 ;
+                                                                 DIG 8 ;
+                                                                 SWAP ;
+                                                                 EXEC ;
+                                                                 DROP ;
+                                                                 DUP 2 ;
+                                                                 DIG 7 ;
+                                                                 SWAP ;
+                                                                 EXEC ;
+                                                                 DROP ;
+                                                                 DUP 2 ;
+                                                                 DIG 6 ;
+                                                                 SWAP ;
+                                                                 EXEC ;
+                                                                 DROP ;
+                                                                 DUP ;
+                                                                 GET 8 ;
+                                                                 DIG 5 ;
+                                                                 SWAP ;
+                                                                 EXEC ;
+                                                                 DROP ;
+                                                                 DUP ;
+                                                                 GET 7 ;
+                                                                 DIG 4 ;
+                                                                 SWAP ;
+                                                                 EXEC ;
+                                                                 DROP ;
+                                                                 PUSH nat 0 ;
+                                                                 DUP 2 ;
+                                                                 GET 3 ;
+                                                                 COMPARE ;
+                                                                 GT ;
+                                                                 IF { DIG 6 ; DROP } { DIG 6 ; FAILWITH } ;
+                                                                 DUP ;
+                                                                 CAR ;
+                                                                 IF_LEFT
+                                                                   { DROP ; DUP 2 ; GET 7 ; DUP 3 ; GET 5 ; DUP 4 ; GET 3 ; DUP 5 ; CAR }
+                                                                   { DROP ; DUP 2 ; GET 5 ; DUP 3 ; GET 7 ; DUP 4 ; CAR ; DUP 5 ; GET 3 } ;
+                                                                 PAIR 4 ;
+                                                                 UNPAIR 4 ;
+                                                                 DUP 5 ;
+                                                                 GET 3 ;
+                                                                 DUP 5 ;
+                                                                 INT ;
+                                                                 EQ ;
+                                                                 DUP 5 ;
+                                                                 INT ;
+                                                                 EQ ;
+                                                                 DUP 3 ;
+                                                                 INT ;
+                                                                 EQ ;
+                                                                 OR ;
+                                                                 OR ;
+                                                                 IF { DIG 11 ; DROP 2 ; DIG 2 ; DROP ; PUSH nat 0 }
+                                                                    { DIG 11 ;
+                                                                      DUP 14 ;
+                                                                      SUB ;
+                                                                      ABS ;
+                                                                      SWAP ;
+                                                                      MUL ;
+                                                                      DUP ;
+                                                                      DUP 14 ;
+                                                                      DIG 5 ;
+                                                                      MUL ;
+                                                                      ADD ;
+                                                                      DUP 5 ;
+                                                                      DIG 2 ;
+                                                                      MUL ;
+                                                                      EDIV ;
+                                                                      IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } } ;
+                                                                 DUP ;
+                                                                 INT ;
+                                                                 GT ;
+                                                                 IF { DIG 9 ; DROP } { DIG 9 ; FAILWITH } ;
+                                                                 DIG 3 ;
+                                                                 DUP 2 ;
+                                                                 COMPARE ;
+                                                                 LT ;
+                                                                 IF { DIG 6 ; DROP } { DIG 6 ; FAILWITH } ;
+                                                                 DUP 4 ;
+                                                                 GET 5 ;
+                                                                 DUP 2 ;
+                                                                 COMPARE ;
+                                                                 GE ;
+                                                                 IF { DIG 6 ; DROP } { DIG 6 ; FAILWITH } ;
+                                                                 SELF_ADDRESS ;
+                                                                 UNIT ;
+                                                                 LEFT unit ;
+                                                                 DUP 6 ;
+                                                                 GET 3 ;
+                                                                 DUP 3 ;
+                                                                 SENDER ;
+                                                                 DIG 6 ;
+                                                                 PAIR 5 ;
+                                                                 UNIT ;
+                                                                 RIGHT unit ;
+                                                                 DUP 4 ;
+                                                                 DUP 7 ;
+                                                                 GET 7 ;
+                                                                 DIG 4 ;
+                                                                 DIG 6 ;
+                                                                 PAIR 5 ;
+                                                                 DUP 4 ;
+                                                                 GET 8 ;
+                                                                 SOME ;
+                                                                 NONE nat ;
+                                                                 UNIT ;
+                                                                 LEFT (or unit (or unit unit)) ;
+                                                                 DIG 3 ;
+                                                                 SOME ;
+                                                                 DIG 4 ;
+                                                                 DIG 10 ;
+                                                                 DIG 10 ;
+                                                                 DUP 9 ;
+                                                                 GET 3 ;
+                                                                 MUL ;
+                                                                 EDIV ;
+                                                                 IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                 DIG 6 ;
+                                                                 DUP 8 ;
+                                                                 GET 3 ;
+                                                                 DIG 8 ;
+                                                                 CAR ;
+                                                                 PAIR 4 ;
+                                                                 LEFT (or (pair address (pair nat (pair nat nat))) (pair nat nat)) ;
+                                                                 RIGHT (pair address (pair nat (pair nat nat))) ;
+                                                                 RIGHT (pair address (pair nat (pair nat nat))) ;
+                                                                 PAIR 6 ;
+                                                                 PAIR ;
+                                                                 EXEC }
+                                                               { DIG 13 ;
+                                                                 DROP ;
+                                                                 DIG 16 ;
+                                                                 DROP ;
+                                                                 DIG 16 ;
+                                                                 DROP ;
+                                                                 DIG 16 ;
+                                                                 DROP ;
+                                                                 IF_LEFT
+                                                                   { DIG 11 ;
+                                                                     DROP ;
+                                                                     DIG 13 ;
+                                                                     DROP ;
+                                                                     DIG 13 ;
+                                                                     DROP ;
+                                                                     UNIT ;
+                                                                     DIG 11 ;
+                                                                     SWAP ;
+                                                                     EXEC ;
+                                                                     DROP ;
+                                                                     DUP 2 ;
+                                                                     DIG 10 ;
+                                                                     SWAP ;
+                                                                     EXEC ;
+                                                                     DROP ;
+                                                                     DUP 2 ;
+                                                                     DIG 9 ;
+                                                                     SWAP ;
+                                                                     EXEC ;
+                                                                     DROP ;
+                                                                     DUP 2 ;
+                                                                     DIG 8 ;
+                                                                     SWAP ;
+                                                                     EXEC ;
+                                                                     DROP ;
+                                                                     DUP ;
+                                                                     GET 8 ;
+                                                                     DIG 7 ;
+                                                                     SWAP ;
+                                                                     EXEC ;
+                                                                     DROP ;
+                                                                     DUP ;
+                                                                     GET 7 ;
+                                                                     DIG 6 ;
+                                                                     SWAP ;
+                                                                     EXEC ;
+                                                                     DROP ;
+                                                                     DUP 2 ;
+                                                                     GET 5 ;
+                                                                     DUP 3 ;
+                                                                     GET 13 ;
+                                                                     DUP 3 ;
+                                                                     CAR ;
+                                                                     MUL ;
+                                                                     EDIV ;
+                                                                     IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                     DUP 3 ;
+                                                                     GET 7 ;
+                                                                     DUP 4 ;
+                                                                     GET 13 ;
+                                                                     DUP 4 ;
+                                                                     GET 3 ;
+                                                                     MUL ;
+                                                                     EDIV ;
+                                                                     IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                     SWAP ;
+                                                                     PAIR ;
+                                                                     DIG 4 ;
+                                                                     SWAP ;
+                                                                     EXEC ;
+                                                                     DUP ;
+                                                                     INT ;
+                                                                     GT ;
+                                                                     IF { DIG 6 ; DROP } { DIG 6 ; FAILWITH } ;
+                                                                     DUP 2 ;
+                                                                     GET 5 ;
+                                                                     DUP 2 ;
+                                                                     COMPARE ;
+                                                                     GE ;
+                                                                     IF {} { DUP 6 ; FAILWITH } ;
+                                                                     DUP 3 ;
+                                                                     GET 13 ;
+                                                                     DUP 4 ;
+                                                                     GET 5 ;
+                                                                     DUP 3 ;
+                                                                     MUL ;
+                                                                     PAIR ;
+                                                                     DUP 6 ;
+                                                                     SWAP ;
+                                                                     EXEC ;
+                                                                     DUP 4 ;
+                                                                     GET 13 ;
+                                                                     DUP 5 ;
+                                                                     GET 7 ;
+                                                                     DUP 4 ;
+                                                                     MUL ;
+                                                                     PAIR ;
+                                                                     DIG 6 ;
+                                                                     SWAP ;
+                                                                     EXEC ;
+                                                                     DUP 4 ;
+                                                                     GET 3 ;
+                                                                     DUP 2 ;
+                                                                     COMPARE ;
+                                                                     LE ;
+                                                                     DUP 5 ;
+                                                                     CAR ;
+                                                                     DUP 4 ;
+                                                                     COMPARE ;
+                                                                     LE ;
+                                                                     AND ;
+                                                                     IF { DIG 6 ; DROP } { DIG 6 ; FAILWITH } ;
+                                                                     SELF_ADDRESS ;
+                                                                     UNIT ;
+                                                                     LEFT unit ;
+                                                                     DUP 4 ;
+                                                                     DUP 3 ;
+                                                                     SENDER ;
+                                                                     DUP 10 ;
+                                                                     CAR ;
+                                                                     PAIR 5 ;
+                                                                     UNIT ;
+                                                                     LEFT unit ;
+                                                                     DUP 4 ;
+                                                                     DIG 3 ;
+                                                                     SENDER ;
+                                                                     DUP 10 ;
+                                                                     GET 3 ;
+                                                                     PAIR 5 ;
+                                                                     DUP 6 ;
+                                                                     GET 8 ;
+                                                                     SOME ;
+                                                                     NONE nat ;
+                                                                     UNIT ;
+                                                                     LEFT (or unit (or unit unit)) ;
+                                                                     DIG 3 ;
+                                                                     SOME ;
+                                                                     DIG 4 ;
+                                                                     DIG 7 ;
+                                                                     DIG 6 ;
+                                                                     DIG 7 ;
+                                                                     DIG 8 ;
+                                                                     GET 7 ;
+                                                                     PAIR 4 ;
+                                                                     LEFT (or (pair (or unit unit) (pair nat (pair nat nat)))
+                                                                              (or (pair address (pair nat (pair nat nat))) (pair nat nat))) ;
+                                                                     RIGHT (pair address (pair nat (pair nat nat))) ;
+                                                                     PAIR 6 ;
+                                                                     PAIR ;
+                                                                     EXEC }
+                                                                   { DIG 4 ;
+                                                                     DROP ;
+                                                                     DIG 6 ;
+                                                                     DROP ;
+                                                                     DIG 10 ;
+                                                                     DROP ;
+                                                                     UNIT ;
+                                                                     DIG 9 ;
+                                                                     SWAP ;
+                                                                     EXEC ;
+                                                                     DROP ;
+                                                                     DUP 2 ;
+                                                                     DIG 8 ;
+                                                                     SWAP ;
+                                                                     EXEC ;
+                                                                     DROP ;
+                                                                     DUP 2 ;
+                                                                     DIG 7 ;
+                                                                     SWAP ;
+                                                                     EXEC ;
+                                                                     DROP ;
+                                                                     DIG 8 ;
+                                                                     DUP 3 ;
+                                                                     GET 23 ;
+                                                                     SENDER ;
+                                                                     COMPARE ;
+                                                                     EQ ;
+                                                                     IF { DROP } { FAILWITH } ;
+                                                                     PUSH nat 0 ;
+                                                                     DUP 3 ;
+                                                                     GET 13 ;
+                                                                     COMPARE ;
+                                                                     EQ ;
+                                                                     IF {} { PUSH string "POOL_ALREADY_INITIALIZED" ; FAILWITH } ;
+                                                                     DUP 2 ;
+                                                                     GET 3 ;
+                                                                     DUP 3 ;
+                                                                     CAR ;
+                                                                     COMPARE ;
+                                                                     NEQ ;
+                                                                     IF {} { PUSH string "POOL_IDENTICAL_ASSETS" ; FAILWITH } ;
+                                                                     DUP ;
+                                                                     GET 6 ;
+                                                                     DIG 6 ;
+                                                                     SWAP ;
+                                                                     EXEC ;
+                                                                     DROP ;
+                                                                     DUP ;
+                                                                     GET 5 ;
+                                                                     DIG 5 ;
+                                                                     SWAP ;
+                                                                     EXEC ;
+                                                                     DROP ;
+                                                                     PUSH nat 0 ;
+                                                                     DUP 2 ;
+                                                                     GET 3 ;
+                                                                     COMPARE ;
+                                                                     GT ;
+                                                                     PUSH nat 0 ;
+                                                                     DUP 3 ;
+                                                                     CAR ;
+                                                                     COMPARE ;
+                                                                     GT ;
+                                                                     AND ;
+                                                                     IF { DIG 5 ; DROP } { DIG 5 ; FAILWITH } ;
+                                                                     DUP ;
+                                                                     GET 3 ;
+                                                                     DUP 2 ;
+                                                                     CAR ;
+                                                                     PAIR ;
+                                                                     DIG 4 ;
+                                                                     SWAP ;
+                                                                     EXEC ;
+                                                                     DIG 5 ;
+                                                                     DUP 2 ;
+                                                                     COMPARE ;
+                                                                     GT ;
+                                                                     IF { DIG 4 ; DROP } { DIG 4 ; FAILWITH } ;
+                                                                     SELF_ADDRESS ;
+                                                                     UNIT ;
+                                                                     LEFT unit ;
+                                                                     DUP 4 ;
+                                                                     CAR ;
+                                                                     DUP 3 ;
+                                                                     SENDER ;
+                                                                     DUP 8 ;
+                                                                     CAR ;
+                                                                     PAIR 5 ;
+                                                                     UNIT ;
+                                                                     LEFT unit ;
+                                                                     DUP 5 ;
+                                                                     GET 3 ;
+                                                                     DIG 3 ;
+                                                                     SENDER ;
+                                                                     DUP 8 ;
+                                                                     GET 3 ;
+                                                                     PAIR 5 ;
+                                                                     DUP 4 ;
+                                                                     GET 6 ;
+                                                                     SOME ;
+                                                                     NONE nat ;
+                                                                     UNIT ;
+                                                                     LEFT (or unit (or unit unit)) ;
+                                                                     DIG 3 ;
+                                                                     SOME ;
+                                                                     DIG 4 ;
+                                                                     DIG 5 ;
+                                                                     DUP 7 ;
+                                                                     GET 3 ;
+                                                                     DUP 8 ;
+                                                                     CAR ;
+                                                                     DIG 8 ;
+                                                                     GET 5 ;
+                                                                     PAIR 4 ;
+                                                                     LEFT (or (pair address (pair nat (pair nat nat)))
+                                                                              (or (pair (or unit unit) (pair nat (pair nat nat)))
+                                                                                  (or (pair address (pair nat (pair nat nat))) (pair nat nat)))) ;
+                                                                     PAIR 6 ;
+                                                                     PAIR ;
+                                                                     EXEC } } } } } } } } } } } } } } } } ;
+  view "get_reserves"
+       unit
+       (pair nat nat)
+       { PUSH nat 5 ;
+         PUSH nat 25 ;
+         ADD ;
+         DROP ;
+         CDR ;
+         DUP ;
+         GET 7 ;
+         SWAP ;
+         GET 5 ;
+         PAIR } ;
+  view "get_protocol_fees"
+       unit
+       (pair nat nat)
+       { PUSH nat 5 ;
+         PUSH nat 25 ;
+         ADD ;
+         DROP ;
+         CDR ;
+         DUP ;
+         GET 11 ;
+         SWAP ;
+         GET 9 ;
+         PAIR } ;
+  view "get_fee_bps"
+       unit
+       (pair nat (pair nat nat))
+       { DROP ;
+         PUSH nat 25 ;
+         PUSH nat 5 ;
+         DUP ;
+         DUP 3 ;
+         ADD ;
+         SWAP ;
+         DIG 2 ;
+         PAIR 3 } ;
+  view "quote_swap"
+       (pair (or (unit %a_to_b) (unit %b_to_a)) nat)
+       nat
+       { PUSH nat 10000 ;
+         PUSH nat 5 ;
+         PUSH nat 25 ;
+         ADD ;
+         LAMBDA
+           (pair nat (pair nat (pair nat (pair nat nat))))
+           nat
+           { UNPAIR 3 ;
+             DIG 2 ;
+             UNPAIR 3 ;
+             DUP 3 ;
+             INT ;
+             EQ ;
+             DUP 3 ;
+             INT ;
+             EQ ;
+             DUP 3 ;
+             INT ;
+             EQ ;
+             OR ;
+             OR ;
+             IF { DROP 5 ; PUSH nat 0 }
+                { DIG 4 ;
+                  DUP 5 ;
+                  SUB ;
+                  ABS ;
+                  SWAP ;
+                  MUL ;
+                  DUP ;
+                  DIG 4 ;
+                  DIG 3 ;
+                  MUL ;
+                  ADD ;
+                  DUG 2 ;
+                  MUL ;
+                  EDIV ;
+                  IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } } } ;
+         DIG 2 ;
+         APPLY ;
+         SWAP ;
+         APPLY ;
+         SWAP ;
+         UNPAIR ;
+         UNPAIR ;
+         IF_LEFT
+           { DROP ; DUP 2 ; GET 7 ; DIG 2 ; GET 5 ; DIG 2 ; PAIR 3 ; EXEC }
+           { DROP ; DUP 2 ; GET 5 ; DIG 2 ; GET 7 ; DIG 2 ; PAIR 3 ; EXEC } } ;
+  view "get_balance_view"
+       (pair address nat)
+       nat
+       { PUSH nat 5 ;
+         PUSH nat 25 ;
+         ADD ;
+         DROP ;
+         UNPAIR ;
+         UNPAIR ;
+         SWAP ;
+         INT ;
+         EQ ;
+         IF {} { PUSH string "FA2_TOKEN_UNDEFINED" ; FAILWITH } ;
+         SWAP ;
+         GET 15 ;
+         SWAP ;
+         GET ;
+         IF_NONE { PUSH nat 0 } {} } ;
+  view "total_supply"
+       nat
+       nat
+       { PUSH nat 5 ;
+         PUSH nat 25 ;
+         ADD ;
+         DROP ;
+         UNPAIR ;
+         PUSH nat 0 ;
+         COMPARE ;
+         EQ ;
+         IF {} { PUSH string "FA2_TOKEN_UNDEFINED" ; FAILWITH } ;
+         GET 13 } ;
+  view "all_tokens"
+       unit
+       (set nat)
+       { DROP ; PUSH nat 5 ; PUSH nat 25 ; ADD ; DROP ; PUSH (set nat) { 0 } } ;
+  view "token_metadata"
+       nat
+       (pair (nat %token_id) (map %token_info string bytes))
+       { PUSH nat 5 ;
+         PUSH nat 25 ;
+         ADD ;
+         DROP ;
+         UNPAIR ;
+         SWAP ;
+         GET 21 ;
+         SWAP ;
+         GET ;
+         IF_NONE { PUSH string "FA2_TOKEN_UNDEFINED" ; FAILWITH } {} } ;
+  view "is_operator_view"
+       (pair (address %owner) (pair (address %operator) (nat %token_id)))
+       bool
+       { PUSH nat 5 ;
+         PUSH nat 25 ;
+         ADD ;
+         DROP ;
+         UNPAIR ;
+         DUP ;
+         GET 3 ;
+         DUP 2 ;
+         CAR ;
+         DIG 3 ;
+         GET 17 ;
+         DUP 3 ;
+         DUP 3 ;
+         PAIR ;
+         MEM ;
+         DUG 2 ;
+         COMPARE ;
+         EQ ;
+         OR ;
+         PUSH nat 0 ;
+         DIG 2 ;
+         GET 4 ;
+         COMPARE ;
+         EQ ;
+         AND } }
+

--- a/dex/contracts/token_token_pool.mligo
+++ b/dex/contracts/token_token_pool.mligo
@@ -1,0 +1,1085 @@
+(*
+  Asset-agnostic FA2-to-FA2 constant-product pool.
+
+  Design lineage:
+  - QuipuSwap Core V2, pinned at 684f17d42293034764fd2ff70ce1075b912406da
+  - Reworked as an isolated, single-pair pool with an integrated FA2 LP ledger.
+
+  The fee schedule is intentionally immutable:
+  - 25 basis points remain in the pool for liquidity providers.
+  - 5 basis points accrue separately for the protocol fee recipient.
+*)
+
+module TokenTokenPool = struct
+  (* ----------------------------------------------------------------------- *)
+  (* Constants and errors                                                    *)
+  (* ----------------------------------------------------------------------- *)
+
+  let fee_denominator = 10000n
+  let lp_fee_bps = 25n
+  let protocol_fee_bps = 5n
+  let total_fee_bps = lp_fee_bps + protocol_fee_bps
+  let minimum_liquidity = 1000n
+  let lp_token_id = 0n
+
+  let err_non_payable = "POOL_NON_PAYABLE"
+  let err_busy = "POOL_BUSY"
+  let err_paused = "POOL_PAUSED"
+  let err_not_paused = "POOL_NOT_PAUSED"
+  let err_not_admin = "POOL_NOT_ADMIN"
+  let err_not_pending_admin = "POOL_NOT_PENDING_ADMIN"
+  let err_not_fee_recipient = "POOL_NOT_FEE_RECIPIENT"
+  let err_initialized = "POOL_ALREADY_INITIALIZED"
+  let err_not_initialized = "POOL_NOT_INITIALIZED"
+  let err_same_asset = "POOL_IDENTICAL_ASSETS"
+  let err_expired = "POOL_DEADLINE_EXPIRED"
+  let err_zero_amount = "POOL_ZERO_AMOUNT"
+  let err_zero_output = "POOL_ZERO_OUTPUT"
+  let err_slippage = "POOL_SLIPPAGE"
+  let err_insufficient_liquidity = "POOL_INSUFFICIENT_LIQUIDITY"
+  let err_insufficient_lp = "FA2_INSUFFICIENT_BALANCE"
+  let err_not_operator = "FA2_NOT_OPERATOR"
+  let err_undefined_token = "FA2_TOKEN_UNDEFINED"
+  let err_invalid_callback = "POOL_INVALID_BALANCE_CALLBACK"
+  let err_invalid_balance_delta = "POOL_INVALID_BALANCE_DELTA"
+  let err_insolvent = "POOL_INSOLVENT"
+  let err_no_fees = "POOL_NO_PROTOCOL_FEES"
+  let err_invalid_recipient = "POOL_INVALID_RECIPIENT"
+  let err_locked_liquidity = "POOL_LOCKED_LIQUIDITY"
+  let err_missing_transfer = "POOL_MISSING_FA2_TRANSFER"
+  let err_missing_balance_of = "POOL_MISSING_FA2_BALANCE_OF"
+
+  (* ----------------------------------------------------------------------- *)
+  (* FA2 types used by the two underlying assets and the integrated LP token *)
+  (* ----------------------------------------------------------------------- *)
+
+  type asset =
+    [@layout:comb]
+    {
+      token_contract : address;
+      token_id : nat
+    }
+
+  type fa2_tx =
+    [@layout:comb]
+    {
+      to_ : address;
+      token_id : nat;
+      amount : nat
+    }
+
+  type fa2_transfer_item =
+    [@layout:comb]
+    {
+      from_ : address;
+      txs : fa2_tx list
+    }
+
+  type fa2_transfer = fa2_transfer_item list
+
+  type balance_request =
+    [@layout:comb]
+    {
+      owner : address;
+      token_id : nat
+    }
+
+  type balance_response =
+    [@layout:comb]
+    {
+      request : balance_request;
+      balance : nat
+    }
+
+  type balance_of_param =
+    [@layout:comb]
+    {
+      requests : balance_request list;
+      callback : (balance_response list) contract
+    }
+
+  type operator_param =
+    [@layout:comb]
+    {
+      owner : address;
+      operator : address;
+      token_id : nat
+    }
+
+  type operator_update =
+    | Add_operator of operator_param
+    | Remove_operator of operator_param
+
+  type token_metadata_value =
+    [@layout:comb]
+    {
+      token_id : nat;
+      token_info : (string, bytes) map
+    }
+
+  (* ----------------------------------------------------------------------- *)
+  (* Pool actions and verified-transfer state machine                        *)
+  (* ----------------------------------------------------------------------- *)
+
+  type swap_direction = A_to_b | B_to_a
+  type leg_mode = Inbound | Outbound
+
+  type transfer_leg =
+    [@layout:comb]
+    {
+      asset : asset;
+      from_ : address;
+      to_ : address;
+      amount : nat;
+      mode : leg_mode
+    }
+
+  type initialize_action =
+    [@layout:comb]
+    {
+      receiver : address;
+      amount_a : nat;
+      amount_b : nat;
+      total_shares : nat
+    }
+
+  type add_action =
+    [@layout:comb]
+    {
+      receiver : address;
+      amount_a : nat;
+      amount_b : nat;
+      shares : nat
+    }
+
+  type swap_action =
+    [@layout:comb]
+    {
+      direction : swap_direction;
+      amount_in : nat;
+      amount_out : nat;
+      protocol_fee : nat
+    }
+
+  type remove_action =
+    [@layout:comb]
+    {
+      owner : address;
+      shares : nat;
+      amount_a : nat;
+      amount_b : nat
+    }
+
+  type claim_action =
+    [@layout:comb]
+    {
+      amount_a : nat;
+      amount_b : nat
+    }
+
+  type final_action =
+    | Finalize_initialize of initialize_action
+    | Finalize_add of add_action
+    | Finalize_swap of swap_action
+    | Finalize_remove of remove_action
+    | Finalize_claim of claim_action
+
+  type pending_phase = First_before | First_after | Second_before | Second_after
+
+  type pending_action =
+    [@layout:comb]
+    {
+      final_action : final_action;
+      first_leg : transfer_leg;
+      second_leg : transfer_leg option;
+      phase : pending_phase;
+      observed_before : nat option;
+      deadline : timestamp option
+    }
+
+  (* ----------------------------------------------------------------------- *)
+  (* Public entrypoint parameters                                            *)
+  (* ----------------------------------------------------------------------- *)
+
+  type initialize_param =
+    [@layout:comb]
+    {
+      amount_a : nat;
+      amount_b : nat;
+      receiver : address;
+      deadline : timestamp
+    }
+
+  type add_liquidity_param =
+    [@layout:comb]
+    {
+      max_amount_a : nat;
+      max_amount_b : nat;
+      min_shares : nat;
+      receiver : address;
+      deadline : timestamp
+    }
+
+  type remove_liquidity_param =
+    [@layout:comb]
+    {
+      shares : nat;
+      min_amount_a : nat;
+      min_amount_b : nat;
+      receiver : address;
+      deadline : timestamp
+    }
+
+  type swap_param =
+    [@layout:comb]
+    {
+      direction : swap_direction;
+      amount_in : nat;
+      min_amount_out : nat;
+      receiver : address;
+      deadline : timestamp
+    }
+
+  (* ----------------------------------------------------------------------- *)
+  (* Storage                                                                 *)
+  (* ----------------------------------------------------------------------- *)
+
+  type storage =
+    [@layout:comb]
+    {
+      token_a : asset;
+      token_b : asset;
+      reserve_a : nat;
+      reserve_b : nat;
+      protocol_fees_a : nat;
+      protocol_fees_b : nat;
+      total_supply : nat;
+      ledger : (address, nat) big_map;
+      operators : ((address * address), unit) big_map;
+      metadata : (string, bytes) big_map;
+      token_metadata : (nat, token_metadata_value) big_map;
+      admin : address;
+      pending_admin : address option;
+      fee_recipient : address;
+      paused : bool;
+      pending : pending_action option
+    }
+
+  type result = operation list * storage
+
+  (* ----------------------------------------------------------------------- *)
+  (* Common helpers                                                          *)
+  (* ----------------------------------------------------------------------- *)
+
+  let assert_non_payable () : unit =
+    Assert.Error.assert (Tezos.get_amount () = 0mutez) err_non_payable
+
+  let assert_idle (s : storage) : unit =
+    match s.pending with
+    | None -> ()
+    | Some _ -> failwith err_busy
+
+  let assert_live (s : storage) : unit =
+    Assert.Error.assert (not s.paused) err_paused
+
+  let assert_initialized (s : storage) : unit =
+    Assert.Error.assert (s.total_supply > 0n) err_not_initialized
+
+  let assert_deadline (deadline : timestamp) : unit =
+    Assert.Error.assert (Tezos.get_now () <= deadline) err_expired
+
+  let assert_receiver (receiver : address) : unit =
+    Assert.Error.assert (receiver <> Tezos.get_self_address ()) err_invalid_recipient
+
+  let get_balance (owner : address) (ledger : (address, nat) big_map) : nat =
+    match Big_map.find_opt owner ledger with
+    | Some balance -> balance
+    | None -> 0n
+
+  let set_balance
+    (owner : address)
+    (balance : nat)
+    (ledger : (address, nat) big_map)
+  : (address, nat) big_map =
+    if balance = 0n
+    then Big_map.remove owner ledger
+    else Big_map.update owner (Some balance) ledger
+
+  let add_balance
+    (owner : address)
+    (amount : nat)
+    (ledger : (address, nat) big_map)
+  : (address, nat) big_map =
+    set_balance owner (get_balance owner ledger + amount) ledger
+
+  let sub_balance
+    (owner : address)
+    (amount : nat)
+    (ledger : (address, nat) big_map)
+  : (address, nat) big_map =
+    let balance = get_balance owner ledger in
+    let () = Assert.Error.assert (balance >= amount) err_insufficient_lp in
+    set_balance owner (abs (balance - amount)) ledger
+
+  let ceil_div (numerator : nat) (denominator : nat) : nat =
+    match ediv numerator denominator with
+    | None -> failwith err_insufficient_liquidity
+    | Some (quotient, remainder) ->
+        if remainder = 0n then quotient else quotient + 1n
+
+  let min_nat (a : nat) (b : nat) : nat = if a < b then a else b
+
+  let protocol_fee (amount : nat) : nat =
+    (amount * protocol_fee_bps) / fee_denominator
+
+  let quote_output (amount_in : nat) (reserve_in : nat) (reserve_out : nat) : nat =
+    if amount_in = 0n || reserve_in = 0n || reserve_out = 0n
+    then 0n
+    else
+      let amount_with_fee = amount_in * abs (fee_denominator - total_fee_bps) in
+      (amount_with_fee * reserve_out)
+      / ((reserve_in * fee_denominator) + amount_with_fee)
+
+  let accounted_balance (selected : asset) (s : storage) : nat =
+    if selected = s.token_a
+    then s.reserve_a + s.protocol_fees_a
+    else if selected = s.token_b
+    then s.reserve_b + s.protocol_fees_b
+    else failwith err_invalid_callback
+
+  let transfer_asset (leg : transfer_leg) : operation =
+    let token_entrypoint : fa2_transfer contract =
+      match
+        (Tezos.get_entrypoint_opt "%transfer" leg.asset.token_contract
+          : fa2_transfer contract option)
+      with
+      | Some contract -> contract
+      | None -> failwith err_missing_transfer in
+    let transfer_param : fa2_transfer =
+      [
+        {
+          from_ = leg.from_;
+          txs =
+            [
+              {
+                to_ = leg.to_;
+                token_id = leg.asset.token_id;
+                amount = leg.amount
+              }
+            ]
+        }
+      ] in
+    Tezos.transaction transfer_param 0mutez token_entrypoint
+
+  let first_before_callback () : (balance_response list) contract =
+    match
+      (Tezos.get_entrypoint_opt "%receive_first_before" (Tezos.get_self_address ())
+        : (balance_response list) contract option)
+    with
+    | Some contract -> contract
+    | None -> failwith err_invalid_callback
+
+  let first_after_callback () : (balance_response list) contract =
+    match
+      (Tezos.get_entrypoint_opt "%receive_first_after" (Tezos.get_self_address ())
+        : (balance_response list) contract option)
+    with
+    | Some contract -> contract
+    | None -> failwith err_invalid_callback
+
+  let second_before_callback () : (balance_response list) contract =
+    match
+      (Tezos.get_entrypoint_opt "%receive_second_before" (Tezos.get_self_address ())
+        : (balance_response list) contract option)
+    with
+    | Some contract -> contract
+    | None -> failwith err_invalid_callback
+
+  let second_after_callback () : (balance_response list) contract =
+    match
+      (Tezos.get_entrypoint_opt "%receive_second_after" (Tezos.get_self_address ())
+        : (balance_response list) contract option)
+    with
+    | Some contract -> contract
+    | None -> failwith err_invalid_callback
+
+  let request_balance_with
+    (selected : asset)
+    (callback : (balance_response list) contract)
+  : operation =
+    let balance_entrypoint : balance_of_param contract =
+      match
+        (Tezos.get_entrypoint_opt "%balance_of" selected.token_contract
+          : balance_of_param contract option)
+      with
+      | Some contract -> contract
+      | None -> failwith err_missing_balance_of in
+    let param : balance_of_param =
+      {
+        requests =
+          [{owner = Tezos.get_self_address (); token_id = selected.token_id}];
+        callback = callback
+      } in
+    Tezos.transaction param 0mutez balance_entrypoint
+
+  let current_leg (pending : pending_action) : transfer_leg =
+    match pending.phase with
+    | First_before -> pending.first_leg
+    | First_after -> pending.first_leg
+    | Second_before ->
+        (match pending.second_leg with
+         | Some leg -> leg
+         | None -> failwith err_invalid_callback)
+    | Second_after ->
+        (match pending.second_leg with
+         | Some leg -> leg
+         | None -> failwith err_invalid_callback)
+
+  let assert_pending_deadline (pending : pending_action) : unit =
+    match pending.deadline with
+    | Some deadline -> assert_deadline deadline
+    | None -> ()
+
+  let start_action (pending : pending_action) (s : storage) : result =
+    ([request_balance_with pending.first_leg.asset (first_before_callback ())],
+     {s with pending = Some pending})
+
+  (* ----------------------------------------------------------------------- *)
+  (* Finalization after every token transfer has been balance-verified        *)
+  (* ----------------------------------------------------------------------- *)
+
+  let finalize (action : final_action) (s : storage) : result =
+    match action with
+    | Finalize_initialize action ->
+        let provider_shares = abs (action.total_shares - minimum_liquidity) in
+        let ledger =
+          add_balance
+            action.receiver
+            provider_shares
+            (add_balance (Tezos.get_self_address ()) minimum_liquidity s.ledger) in
+        ([],
+         {
+           s with
+           reserve_a = action.amount_a;
+           reserve_b = action.amount_b;
+           total_supply = action.total_shares;
+           ledger = ledger;
+           pending = None
+         })
+    | Finalize_add action ->
+        let ledger = add_balance action.receiver action.shares s.ledger in
+        ([],
+         {
+           s with
+           reserve_a = s.reserve_a + action.amount_a;
+           reserve_b = s.reserve_b + action.amount_b;
+           total_supply = s.total_supply + action.shares;
+           ledger = ledger;
+           pending = None
+         })
+    | Finalize_swap action ->
+        (match action.direction with
+         | A_to_b ->
+             ([],
+              {
+                s with
+                reserve_a = s.reserve_a + abs (action.amount_in - action.protocol_fee);
+                reserve_b = abs (s.reserve_b - action.amount_out);
+                protocol_fees_a = s.protocol_fees_a + action.protocol_fee;
+                pending = None
+              })
+         | B_to_a ->
+             ([],
+              {
+                s with
+                reserve_a = abs (s.reserve_a - action.amount_out);
+                reserve_b = s.reserve_b + abs (action.amount_in - action.protocol_fee);
+                protocol_fees_b = s.protocol_fees_b + action.protocol_fee;
+                pending = None
+              }))
+    | Finalize_remove action ->
+        let ledger = sub_balance action.owner action.shares s.ledger in
+        ([],
+         {
+           s with
+           reserve_a = abs (s.reserve_a - action.amount_a);
+           reserve_b = abs (s.reserve_b - action.amount_b);
+           total_supply = abs (s.total_supply - action.shares);
+           ledger = ledger;
+           pending = None
+         })
+    | Finalize_claim action ->
+        ([],
+         {
+           s with
+           protocol_fees_a = abs (s.protocol_fees_a - action.amount_a);
+           protocol_fees_b = abs (s.protocol_fees_b - action.amount_b);
+           pending = None
+         })
+
+  (* ----------------------------------------------------------------------- *)
+  (* Pool entrypoints                                                        *)
+  (* ----------------------------------------------------------------------- *)
+
+  [@entry]
+  let initialize (param : initialize_param) (s : storage) : result =
+    let () = assert_non_payable () in
+    let () = assert_idle s in
+    let () = assert_live s in
+    let () = Assert.Error.assert (Tezos.get_sender () = s.admin) err_not_admin in
+    let () = Assert.Error.assert (s.total_supply = 0n) err_initialized in
+    let () = Assert.Error.assert (s.token_a <> s.token_b) err_same_asset in
+    let () = assert_deadline param.deadline in
+    let () = assert_receiver param.receiver in
+    let () =
+      Assert.Error.assert (param.amount_a > 0n && param.amount_b > 0n) err_zero_amount in
+    (* LP units are arbitrary; using the smaller seed amount avoids an
+       unbounded square-root loop and follows the pinned Core V2 convention. *)
+    let total_shares = min_nat param.amount_a param.amount_b in
+    let () =
+      Assert.Error.assert (total_shares > minimum_liquidity) err_insufficient_liquidity in
+    let pool = Tezos.get_self_address () in
+    let first_leg : transfer_leg =
+      {
+        asset = s.token_a;
+        from_ = Tezos.get_sender ();
+        to_ = pool;
+        amount = param.amount_a;
+        mode = Inbound
+      } in
+    let second_leg : transfer_leg =
+      {
+        asset = s.token_b;
+        from_ = Tezos.get_sender ();
+        to_ = pool;
+        amount = param.amount_b;
+        mode = Inbound
+      } in
+    let pending : pending_action =
+      {
+        final_action =
+          Finalize_initialize
+            {
+              receiver = param.receiver;
+              amount_a = param.amount_a;
+              amount_b = param.amount_b;
+              total_shares = total_shares
+            };
+        first_leg = first_leg;
+        second_leg = Some second_leg;
+        phase = First_before;
+        observed_before = None;
+        deadline = Some param.deadline
+      } in
+    start_action pending s
+
+  [@entry]
+  let add_liquidity (param : add_liquidity_param) (s : storage) : result =
+    let () = assert_non_payable () in
+    let () = assert_idle s in
+    let () = assert_live s in
+    let () = assert_initialized s in
+    let () = assert_deadline param.deadline in
+    let () = assert_receiver param.receiver in
+    let shares_a = (param.max_amount_a * s.total_supply) / s.reserve_a in
+    let shares_b = (param.max_amount_b * s.total_supply) / s.reserve_b in
+    let shares = min_nat shares_a shares_b in
+    let () = Assert.Error.assert (shares > 0n) err_zero_amount in
+    let () = Assert.Error.assert (shares >= param.min_shares) err_slippage in
+    let amount_a = ceil_div (shares * s.reserve_a) s.total_supply in
+    let amount_b = ceil_div (shares * s.reserve_b) s.total_supply in
+    let () =
+      Assert.Error.assert
+        (amount_a <= param.max_amount_a && amount_b <= param.max_amount_b)
+        err_slippage in
+    let pool = Tezos.get_self_address () in
+    let first_leg : transfer_leg =
+      {
+        asset = s.token_a;
+        from_ = Tezos.get_sender ();
+        to_ = pool;
+        amount = amount_a;
+        mode = Inbound
+      } in
+    let second_leg : transfer_leg =
+      {
+        asset = s.token_b;
+        from_ = Tezos.get_sender ();
+        to_ = pool;
+        amount = amount_b;
+        mode = Inbound
+      } in
+    let pending : pending_action =
+      {
+        final_action =
+          Finalize_add
+            {
+              receiver = param.receiver;
+              amount_a = amount_a;
+              amount_b = amount_b;
+              shares = shares
+            };
+        first_leg = first_leg;
+        second_leg = Some second_leg;
+        phase = First_before;
+        observed_before = None;
+        deadline = Some param.deadline
+      } in
+    start_action pending s
+
+  [@entry]
+  let swap (param : swap_param) (s : storage) : result =
+    let () = assert_non_payable () in
+    let () = assert_idle s in
+    let () = assert_live s in
+    let () = assert_initialized s in
+    let () = assert_deadline param.deadline in
+    let () = assert_receiver param.receiver in
+    let () = Assert.Error.assert (param.amount_in > 0n) err_zero_amount in
+    let (input_asset, output_asset, reserve_in, reserve_out) =
+      match param.direction with
+      | A_to_b -> (s.token_a, s.token_b, s.reserve_a, s.reserve_b)
+      | B_to_a -> (s.token_b, s.token_a, s.reserve_b, s.reserve_a) in
+    let amount_out = quote_output param.amount_in reserve_in reserve_out in
+    let () = Assert.Error.assert (amount_out > 0n) err_zero_output in
+    let () = Assert.Error.assert (amount_out < reserve_out) err_insufficient_liquidity in
+    let () = Assert.Error.assert (amount_out >= param.min_amount_out) err_slippage in
+    let pool = Tezos.get_self_address () in
+    let first_leg : transfer_leg =
+      {
+        asset = input_asset;
+        from_ = Tezos.get_sender ();
+        to_ = pool;
+        amount = param.amount_in;
+        mode = Inbound
+      } in
+    let second_leg : transfer_leg =
+      {
+        asset = output_asset;
+        from_ = pool;
+        to_ = param.receiver;
+        amount = amount_out;
+        mode = Outbound
+      } in
+    let pending : pending_action =
+      {
+        final_action =
+          Finalize_swap
+            {
+              direction = param.direction;
+              amount_in = param.amount_in;
+              amount_out = amount_out;
+              protocol_fee = protocol_fee param.amount_in
+            };
+        first_leg = first_leg;
+        second_leg = Some second_leg;
+        phase = First_before;
+        observed_before = None;
+        deadline = Some param.deadline
+      } in
+    start_action pending s
+
+  [@entry]
+  let remove_liquidity (param : remove_liquidity_param) (s : storage) : result =
+    let () = assert_non_payable () in
+    let () = assert_idle s in
+    let () = assert_initialized s in
+    let () = assert_deadline param.deadline in
+    let () = assert_receiver param.receiver in
+    let () = Assert.Error.assert (param.shares > 0n) err_zero_amount in
+    let owner = Tezos.get_sender () in
+    let () =
+      Assert.Error.assert (get_balance owner s.ledger >= param.shares) err_insufficient_lp in
+    let amount_a = (param.shares * s.reserve_a) / s.total_supply in
+    let amount_b = (param.shares * s.reserve_b) / s.total_supply in
+    let () =
+      Assert.Error.assert (amount_a > 0n && amount_b > 0n) err_zero_output in
+    let () =
+      Assert.Error.assert
+        (amount_a >= param.min_amount_a && amount_b >= param.min_amount_b)
+        err_slippage in
+    let pool = Tezos.get_self_address () in
+    let first_leg : transfer_leg =
+      {
+        asset = s.token_a;
+        from_ = pool;
+        to_ = param.receiver;
+        amount = amount_a;
+        mode = Outbound
+      } in
+    let second_leg : transfer_leg =
+      {
+        asset = s.token_b;
+        from_ = pool;
+        to_ = param.receiver;
+        amount = amount_b;
+        mode = Outbound
+      } in
+    let pending : pending_action =
+      {
+        final_action =
+          Finalize_remove
+            {
+              owner = owner;
+              shares = param.shares;
+              amount_a = amount_a;
+              amount_b = amount_b
+            };
+        first_leg = first_leg;
+        second_leg = Some second_leg;
+        phase = First_before;
+        observed_before = None;
+        deadline = Some param.deadline
+      } in
+    start_action pending s
+
+  [@entry]
+  let claim_protocol_fees (_ : unit) (s : storage) : result =
+    let () = assert_non_payable () in
+    let () = assert_idle s in
+    let () =
+      Assert.Error.assert (Tezos.get_sender () = s.fee_recipient) err_not_fee_recipient in
+    let () =
+      Assert.Error.assert (s.protocol_fees_a > 0n || s.protocol_fees_b > 0n) err_no_fees in
+    let pool = Tezos.get_self_address () in
+    let leg_a : transfer_leg =
+      {
+        asset = s.token_a;
+        from_ = pool;
+        to_ = s.fee_recipient;
+        amount = s.protocol_fees_a;
+        mode = Outbound
+      } in
+    let leg_b : transfer_leg =
+      {
+        asset = s.token_b;
+        from_ = pool;
+        to_ = s.fee_recipient;
+        amount = s.protocol_fees_b;
+        mode = Outbound
+      } in
+    let (first_leg, second_leg) =
+      if s.protocol_fees_a > 0n && s.protocol_fees_b > 0n
+      then (leg_a, Some leg_b)
+      else if s.protocol_fees_a > 0n
+      then (leg_a, None)
+      else (leg_b, None) in
+    let pending : pending_action =
+      {
+        final_action =
+          Finalize_claim
+            {amount_a = s.protocol_fees_a; amount_b = s.protocol_fees_b};
+        first_leg = first_leg;
+        second_leg = second_leg;
+        phase = First_before;
+        observed_before = None;
+        deadline = None
+      } in
+    start_action pending s
+
+  (* ----------------------------------------------------------------------- *)
+  (* Balance callbacks: verify each inbound and outbound transfer exactly     *)
+  (* ----------------------------------------------------------------------- *)
+
+  let authenticated_balance
+    (expected_asset : asset)
+    (responses : balance_response list)
+  : nat =
+    let () = assert_non_payable () in
+    let () =
+      Assert.Error.assert
+        (Tezos.get_sender () = expected_asset.token_contract)
+        err_invalid_callback in
+    let () = Assert.Error.assert (List.length responses = 1n) err_invalid_callback in
+    let response =
+      match List.head responses with
+      | Some response -> response
+      | None -> failwith err_invalid_callback in
+    let () =
+      Assert.Error.assert
+        (response.request.owner = Tezos.get_self_address ()
+         && response.request.token_id = expected_asset.token_id)
+        err_invalid_callback in
+    response.balance
+
+  let assert_verified_delta
+    (pending : pending_action)
+    (leg : transfer_leg)
+    (balance_after : nat)
+  : unit =
+    let before =
+      match pending.observed_before with
+      | Some before -> before
+      | None -> failwith err_invalid_callback in
+    let valid_delta =
+      match leg.mode with
+      | Inbound -> balance_after = before + leg.amount
+      | Outbound -> before >= leg.amount && balance_after = abs (before - leg.amount) in
+    Assert.Error.assert valid_delta err_invalid_balance_delta
+
+  [@entry]
+  let receive_first_before (responses : balance_response list) (s : storage) : result =
+    let pending =
+      match s.pending with
+      | Some pending -> pending
+      | None -> failwith err_invalid_callback in
+    let () = assert_pending_deadline pending in
+    let () = Assert.Error.assert (pending.phase = First_before) err_invalid_callback in
+    let leg = current_leg pending in
+    let balance_before = authenticated_balance leg.asset responses in
+    let () =
+      Assert.Error.assert
+        (balance_before >= accounted_balance leg.asset s)
+        err_insolvent in
+    let updated_pending =
+      {pending with phase = First_after; observed_before = Some balance_before} in
+    ([transfer_asset leg;
+      request_balance_with leg.asset (first_after_callback ())],
+     {s with pending = Some updated_pending})
+
+  [@entry]
+  let receive_first_after (responses : balance_response list) (s : storage) : result =
+    let pending =
+      match s.pending with
+      | Some pending -> pending
+      | None -> failwith err_invalid_callback in
+    let () = assert_pending_deadline pending in
+    let () = Assert.Error.assert (pending.phase = First_after) err_invalid_callback in
+    let leg = current_leg pending in
+    let balance_after = authenticated_balance leg.asset responses in
+    let () = assert_verified_delta pending leg balance_after in
+    match pending.second_leg with
+    | Some next_leg ->
+        let updated_pending =
+          {pending with phase = Second_before; observed_before = None} in
+        ([request_balance_with next_leg.asset (second_before_callback ())],
+         {s with pending = Some updated_pending})
+    | None -> finalize pending.final_action s
+
+  [@entry]
+  let receive_second_before (responses : balance_response list) (s : storage) : result =
+    let pending =
+      match s.pending with
+      | Some pending -> pending
+      | None -> failwith err_invalid_callback in
+    let () = assert_pending_deadline pending in
+    let () = Assert.Error.assert (pending.phase = Second_before) err_invalid_callback in
+    let leg = current_leg pending in
+    let balance_before = authenticated_balance leg.asset responses in
+    let () =
+      Assert.Error.assert
+        (balance_before >= accounted_balance leg.asset s)
+        err_insolvent in
+    let updated_pending =
+      {pending with phase = Second_after; observed_before = Some balance_before} in
+    ([transfer_asset leg;
+      request_balance_with leg.asset (second_after_callback ())],
+     {s with pending = Some updated_pending})
+
+  [@entry]
+  let receive_second_after (responses : balance_response list) (s : storage) : result =
+    let pending =
+      match s.pending with
+      | Some pending -> pending
+      | None -> failwith err_invalid_callback in
+    let () = assert_pending_deadline pending in
+    let () = Assert.Error.assert (pending.phase = Second_after) err_invalid_callback in
+    let leg = current_leg pending in
+    let balance_after = authenticated_balance leg.asset responses in
+    let () = assert_verified_delta pending leg balance_after in
+    finalize pending.final_action s
+
+  (* ----------------------------------------------------------------------- *)
+  (* Integrated LP-token FA2 entrypoints                                     *)
+  (* ----------------------------------------------------------------------- *)
+
+  let is_operator (owner : address) (operator : address) (s : storage) : bool =
+    owner = operator || Big_map.mem (owner, operator) s.operators
+
+  [@entry]
+  let transfer (transfers : fa2_transfer) (s : storage) : result =
+    let () = assert_non_payable () in
+    let () = assert_idle s in
+    (* A single-pair pool deliberately accepts one FA2 transfer item and one
+       destination per call. This bounds gas and keeps the LP/reserve update
+       atomic; callers can submit additional transfers as separate operations. *)
+    let () = Assert.Error.assert (List.length transfers = 1n) err_invalid_callback in
+    let transfer_item =
+      match List.head transfers with
+      | Some transfer_item -> transfer_item
+      | None -> failwith err_invalid_callback in
+    let () = Assert.Error.assert (List.length transfer_item.txs = 1n) err_invalid_callback in
+    let tx =
+      match List.head transfer_item.txs with
+      | Some tx -> tx
+      | None -> failwith err_invalid_callback in
+    let () =
+      Assert.Error.assert
+        (is_operator transfer_item.from_ (Tezos.get_sender ()) s)
+        err_not_operator in
+    let () = Assert.Error.assert (tx.token_id = lp_token_id) err_undefined_token in
+    let () =
+      Assert.Error.assert (tx.to_ <> Tezos.get_self_address ()) err_locked_liquidity in
+    let ledger =
+      add_balance tx.to_ tx.amount
+        (sub_balance transfer_item.from_ tx.amount s.ledger) in
+    ([], {s with ledger = ledger})
+
+  [@entry]
+  let update_operators (updates : operator_update list) (s : storage) : result =
+    let () = assert_non_payable () in
+    let () = assert_idle s in
+    let () = Assert.Error.assert (List.length updates = 1n) err_invalid_callback in
+    let update =
+      match List.head updates with
+      | Some update -> update
+      | None -> failwith err_invalid_callback in
+    let operators =
+      match update with
+      | Add_operator operator ->
+          let () =
+            Assert.Error.assert (operator.token_id = lp_token_id) err_undefined_token in
+          let () =
+            Assert.Error.assert (operator.owner = Tezos.get_sender ()) err_not_operator in
+          Big_map.update (operator.owner, operator.operator) (Some ()) s.operators
+      | Remove_operator operator ->
+          let () =
+            Assert.Error.assert (operator.token_id = lp_token_id) err_undefined_token in
+          let () =
+            Assert.Error.assert (operator.owner = Tezos.get_sender ()) err_not_operator in
+          Big_map.remove (operator.owner, operator.operator) s.operators in
+    ([], {s with operators = operators})
+
+  [@entry]
+  let balance_of (param : balance_of_param) (s : storage) : result =
+    let () = assert_non_payable () in
+    let () = Assert.Error.assert (List.length param.requests = 1n) err_invalid_callback in
+    let request =
+      match List.head param.requests with
+      | Some request -> request
+      | None -> failwith err_invalid_callback in
+    let () = Assert.Error.assert (request.token_id = lp_token_id) err_undefined_token in
+    let responses : balance_response list =
+      [{request = request; balance = get_balance request.owner s.ledger}] in
+    ([Tezos.transaction responses 0mutez param.callback], s)
+
+  (* ----------------------------------------------------------------------- *)
+  (* Bounded administration                                                  *)
+  (* ----------------------------------------------------------------------- *)
+
+  [@entry]
+  let set_paused (paused : bool) (s : storage) : result =
+    let () = assert_non_payable () in
+    let () = assert_idle s in
+    let () = Assert.Error.assert (Tezos.get_sender () = s.admin) err_not_admin in
+    let () =
+      if paused
+      then Assert.Error.assert (not s.paused) err_paused
+      else Assert.Error.assert s.paused err_not_paused in
+    ([], {s with paused = paused})
+
+  [@entry]
+  let propose_admin (new_admin : address) (s : storage) : result =
+    let () = assert_non_payable () in
+    let () = assert_idle s in
+    let () = Assert.Error.assert (Tezos.get_sender () = s.admin) err_not_admin in
+    ([], {s with pending_admin = Some new_admin})
+
+  [@entry]
+  let accept_admin (_ : unit) (s : storage) : result =
+    let () = assert_non_payable () in
+    let () = assert_idle s in
+    let () =
+      match s.pending_admin with
+      | Some pending_admin ->
+          Assert.Error.assert (Tezos.get_sender () = pending_admin) err_not_pending_admin
+      | None -> failwith err_not_pending_admin in
+    ([], {s with admin = Tezos.get_sender (); pending_admin = None})
+
+  [@entry]
+  let default (_ : unit) (s : storage) : result =
+    let () = assert_non_payable () in
+    ([], s)
+
+  (* ----------------------------------------------------------------------- *)
+  (* Views                                                                   *)
+  (* ----------------------------------------------------------------------- *)
+
+  [@view]
+  let get_reserves (_ : unit) (s : storage) : nat * nat =
+    (s.reserve_a, s.reserve_b)
+
+  [@view]
+  let get_protocol_fees (_ : unit) (s : storage) : nat * nat =
+    (s.protocol_fees_a, s.protocol_fees_b)
+
+  [@view]
+  let get_fee_bps (_ : unit) (_s : storage) : nat * nat * nat =
+    (lp_fee_bps, protocol_fee_bps, total_fee_bps)
+
+  [@view]
+  let quote_swap (param : swap_direction * nat) (s : storage) : nat =
+    let (direction, amount_in) = param in
+    match direction with
+    | A_to_b -> quote_output amount_in s.reserve_a s.reserve_b
+    | B_to_a -> quote_output amount_in s.reserve_b s.reserve_a
+
+  [@view]
+  let get_balance_view (param : address * nat) (s : storage) : nat =
+    let (owner, token_id) = param in
+    let () = Assert.Error.assert (token_id = lp_token_id) err_undefined_token in
+    get_balance owner s.ledger
+
+  [@view]
+  let total_supply (token_id : nat) (s : storage) : nat =
+    let () = Assert.Error.assert (token_id = lp_token_id) err_undefined_token in
+    s.total_supply
+
+  [@view]
+  let all_tokens (_ : unit) (_s : storage) : nat set = Set.literal [lp_token_id]
+
+  [@view]
+  let token_metadata (token_id : nat) (s : storage) : token_metadata_value =
+    match Big_map.find_opt token_id s.token_metadata with
+    | Some metadata -> metadata
+    | None -> failwith err_undefined_token
+
+  [@view]
+  let is_operator_view (operator : operator_param) (s : storage) : bool =
+    operator.token_id = lp_token_id && is_operator operator.owner operator.operator s
+
+  (* ----------------------------------------------------------------------- *)
+  (* Origination helper                                                      *)
+  (* ----------------------------------------------------------------------- *)
+
+  type build_storage_param =
+    [@layout:comb]
+    {
+      token_a : asset;
+      token_b : asset;
+      admin : address;
+      fee_recipient : address;
+      metadata : (string, bytes) big_map;
+      token_metadata : (nat, token_metadata_value) big_map
+    }
+
+  let build_storage (param : build_storage_param) : storage =
+    {
+      token_a = param.token_a;
+      token_b = param.token_b;
+      reserve_a = 0n;
+      reserve_b = 0n;
+      protocol_fees_a = 0n;
+      protocol_fees_b = 0n;
+      total_supply = 0n;
+      ledger = (Big_map.empty : (address, nat) big_map);
+      operators = (Big_map.empty : ((address * address), unit) big_map);
+      metadata = param.metadata;
+      token_metadata = param.token_metadata;
+      admin = param.admin;
+      pending_admin = None;
+      fee_recipient = param.fee_recipient;
+      paused = false;
+      pending = None
+    }
+end

--- a/dex/scripts/.env.example
+++ b/dex/scripts/.env.example
@@ -33,5 +33,24 @@ TOKEN_ID=
 POOL_TYPE=
 # Protocol fee in basis points (1% = 100 basis points). Only applicable for "mod" pool type.
 PROTOCOL_FEE_BP=
-# Address that will receive protocol fees. Only applicable for "mod" pool type.
+# Address that will receive protocol fees. Used by the "mod" and token-to-token pools.
 PROTOCOL_FEE_RECIPIENT=
+
+# Token-to-token pool deployment (FA2 assets only)
+# Values are supplied at deployment time; no address is compiled into the pool.
+TOKEN_A_ADDRESS=
+TOKEN_A_ID=0
+TOKEN_B_ADDRESS=
+TOKEN_B_ID=0
+SEED_AMOUNT_A=
+SEED_AMOUNT_B=
+SEED_RECEIVER=
+FINAL_ADMIN=
+TOKEN_TOKEN_POOL_METADATA_URI=
+LP_TOKEN_METADATA_URI=
+LP_TOKEN_NAME=Token Pair Liquidity
+LP_TOKEN_SYMBOL=TPLP
+LP_TOKEN_DECIMALS=0
+CONFIRMATIONS=2
+# For mainnet only, set this to ORIGINATE_TOKEN_TOKEN_POOL after completing the launch gates.
+CONFIRM_MAINNET_DEPLOYMENT=

--- a/dex/scripts/.gitignore
+++ b/dex/scripts/.gitignore
@@ -1,0 +1,2 @@
+deployments/
+dist/

--- a/dex/scripts/package-lock.json
+++ b/dex/scripts/package-lock.json
@@ -9,18 +9,20 @@
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
-                "@taquito/michel-codec": "^23.1.0",
-                "@taquito/michelson-encoder": "^23.1.0",
-                "@taquito/signer": "^23.0.3",
-                "@taquito/taquito": "^23.0.3",
-                "@taquito/utils": "^23.1.0",
-                "bn.js": "^5.2.2",
+                "@taquito/michel-codec": "^25.0.0",
+                "@taquito/michelson-encoder": "^25.0.0",
+                "@taquito/signer": "^25.0.0",
+                "@taquito/taquito": "^25.0.0",
                 "dotenv": "^17.2.3"
             },
             "devDependencies": {
+                "@taquito/utils": "^25.0.0",
                 "@types/node": "^25.0.0",
                 "tsx": "4.21.0",
                 "typescript": "5.9.3"
+            },
+            "engines": {
+                "node": ">=22"
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
@@ -492,6 +494,40 @@
                 "url": "https://paulmillr.com/funding/"
             }
         },
+        "node_modules/@scure/base": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+            "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/@scure/bip39": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-2.2.0.tgz",
+            "integrity": "sha512-T/Bj/YvYMNkIPq6EENO6/rcs2e7qTNuyoUXf0KBFDmp0ZDu0H2X4Lq6yC3i0c8PcWkov5EbW+yQZZbdMmk154A==",
+            "license": "MIT",
+            "dependencies": {
+                "@noble/hashes": "2.2.0",
+                "@scure/base": "2.2.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/@scure/bip39/node_modules/@noble/hashes": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+            "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20.19.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
         "node_modules/@stablelib/binary": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/@stablelib/binary/-/binary-1.0.1.tgz",
@@ -499,17 +535,6 @@
             "license": "MIT",
             "dependencies": {
                 "@stablelib/int": "^1.0.1"
-            }
-        },
-        "node_modules/@stablelib/blake2b": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@stablelib/blake2b/-/blake2b-1.0.1.tgz",
-            "integrity": "sha512-B3KyKoBAjkIFeH7romcF96i+pVFYk7K2SBQ1pZvaxV+epSBXJ+n0C66esUhyz6FF+5FbdQVm77C5fzGFcEZpKA==",
-            "license": "MIT",
-            "dependencies": {
-                "@stablelib/binary": "^1.0.1",
-                "@stablelib/hash": "^1.0.1",
-                "@stablelib/wipe": "^1.0.1"
             }
         },
         "node_modules/@stablelib/bytes": {
@@ -523,34 +548,6 @@
             "resolved": "https://registry.npmjs.org/@stablelib/constant-time/-/constant-time-1.0.1.tgz",
             "integrity": "sha512-tNOs3uD0vSJcK6z1fvef4Y+buN7DXhzHDPqRLSXUel1UfqMB1PWNsnnAezrKfEwTLpN0cGH2p9NNjs6IqeD0eg==",
             "license": "MIT"
-        },
-        "node_modules/@stablelib/ed25519": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@stablelib/ed25519/-/ed25519-1.0.3.tgz",
-            "integrity": "sha512-puIMWaX9QlRsbhxfDc5i+mNPMY+0TmQEskunY1rZEBPi1acBCVQAhnsk/1Hk50DGPtVsZtAWQg4NHGlVaO9Hqg==",
-            "license": "MIT",
-            "dependencies": {
-                "@stablelib/random": "^1.0.2",
-                "@stablelib/sha512": "^1.0.1",
-                "@stablelib/wipe": "^1.0.1"
-            }
-        },
-        "node_modules/@stablelib/hash": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@stablelib/hash/-/hash-1.0.1.tgz",
-            "integrity": "sha512-eTPJc/stDkdtOcrNMZ6mcMK1e6yBbqRBaNW55XA1jU8w/7QdnCF0CmMmOD1m7VSkBR44PWrMHU2l6r8YEQHMgg==",
-            "license": "MIT"
-        },
-        "node_modules/@stablelib/hmac": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@stablelib/hmac/-/hmac-1.0.1.tgz",
-            "integrity": "sha512-V2APD9NSnhVpV/QMYgCVMIYKiYG6LSqw1S65wxVoirhU/51ACio6D4yDVSwMzuTJXWZoVHbDdINioBwKy5kVmA==",
-            "license": "MIT",
-            "dependencies": {
-                "@stablelib/constant-time": "^1.0.1",
-                "@stablelib/hash": "^1.0.1",
-                "@stablelib/wipe": "^1.0.1"
-            }
         },
         "node_modules/@stablelib/int": {
             "version": "1.0.1",
@@ -578,18 +575,6 @@
                 "@stablelib/wipe": "^1.0.1",
                 "@stablelib/x25519": "^1.0.3",
                 "@stablelib/xsalsa20": "^1.0.2"
-            }
-        },
-        "node_modules/@stablelib/pbkdf2": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@stablelib/pbkdf2/-/pbkdf2-1.0.1.tgz",
-            "integrity": "sha512-d5jwK6jW1DkMyzqY8D1Io+fRXcsUVr95lk5LKX9ghaUdAITTc1ZL0bff+R0IrwSixbHluxhnivG7vDw59AZ/Nw==",
-            "license": "MIT",
-            "dependencies": {
-                "@stablelib/binary": "^1.0.1",
-                "@stablelib/hash": "^1.0.1",
-                "@stablelib/hmac": "^1.0.1",
-                "@stablelib/wipe": "^1.0.1"
             }
         },
         "node_modules/@stablelib/poly1305": {
@@ -623,17 +608,6 @@
                 "@stablelib/wipe": "^1.0.1"
             }
         },
-        "node_modules/@stablelib/sha512": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@stablelib/sha512/-/sha512-1.0.1.tgz",
-            "integrity": "sha512-13gl/iawHV9zvDKciLo1fQ8Bgn2Pvf7OV6amaRVKiq3pjQ3UmEpXxWiAfV8tYjUpeZroBxtyrwtdooQT/i3hzw==",
-            "license": "MIT",
-            "dependencies": {
-                "@stablelib/binary": "^1.0.1",
-                "@stablelib/hash": "^1.0.1",
-                "@stablelib/wipe": "^1.0.1"
-            }
-        },
         "node_modules/@stablelib/wipe": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.1.tgz",
@@ -663,154 +637,171 @@
             }
         },
         "node_modules/@taquito/core": {
-            "version": "23.1.0",
-            "resolved": "https://registry.npmjs.org/@taquito/core/-/core-23.1.0.tgz",
-            "integrity": "sha512-7gTcQ2XtyGzXRPuph0mBRd2AfwOzagGrIZ6OPwlurl3RlOvUSInA0v8GOud7JwNVgLJJCz4L4EEfkdOZY9/LIg==",
+            "version": "25.0.0",
+            "resolved": "https://registry.npmjs.org/@taquito/core/-/core-25.0.0.tgz",
+            "integrity": "sha512-TlU+eMEn47mAmIjTFP2U4ReHRU05FsnyVn/c5DQnJC0psZ6LRJXimAIA1KQ94afsCDByewsXLN5fjKwn47l72A==",
             "license": "Apache-2.0",
             "dependencies": {
                 "json-stringify-safe": "^5.0.1"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=22"
             }
         },
         "node_modules/@taquito/http-utils": {
-            "version": "23.1.0",
-            "resolved": "https://registry.npmjs.org/@taquito/http-utils/-/http-utils-23.1.0.tgz",
-            "integrity": "sha512-720BWBvkYAhuRbKYpU7ebNV8EWlUp5eD0/ra2ZfWrLV6iYxDf1tayER/cKYkLvJhw4B0ZK12/G+B3urf8ot+OQ==",
+            "version": "25.0.0",
+            "resolved": "https://registry.npmjs.org/@taquito/http-utils/-/http-utils-25.0.0.tgz",
+            "integrity": "sha512-/nkwDeTXEW10lSQdyTrLgp9GIWQc2yi6wQLjEFvXveevrMjuA+lfFU8QoOOZxXH0GM42KEmU/y/VA1wcgl+gKQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@taquito/core": "^23.1.0",
-                "node-fetch": "^2.7.0"
+                "@taquito/core": "^25.0.0"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=22"
             }
         },
         "node_modules/@taquito/local-forging": {
-            "version": "23.1.0",
-            "resolved": "https://registry.npmjs.org/@taquito/local-forging/-/local-forging-23.1.0.tgz",
-            "integrity": "sha512-6JZTWY60fEfhutXj3xx167tQgluzXdBwov694ESrZ8wi7wGEQYa69F047SGJIQFM53o/iGMVSgaGsPCSOaDf/Q==",
+            "version": "25.0.0",
+            "resolved": "https://registry.npmjs.org/@taquito/local-forging/-/local-forging-25.0.0.tgz",
+            "integrity": "sha512-sFeObpxya59PP5xFFsPWb3zLxASe3QwQqQ1fJWTPCs/Fph7/cxk5Kj0Oco961SC7CVSkG/ayz4/WINmm+oTlPA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@taquito/core": "^23.1.0",
-                "@taquito/utils": "^23.1.0",
-                "bignumber.js": "^9.1.2",
+                "@taquito/core": "^25.0.0",
+                "@taquito/utils": "^25.0.0",
+                "bignumber.js": "^10.0.2",
                 "fast-text-encoding": "^1.0.6"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=22"
             }
         },
         "node_modules/@taquito/michel-codec": {
-            "version": "23.1.0",
-            "resolved": "https://registry.npmjs.org/@taquito/michel-codec/-/michel-codec-23.1.0.tgz",
-            "integrity": "sha512-lrCfw7yrVkONDjw8cq4PwGzi8DycBMp6QpNfqoLB2t7DsCyGBwfudz+iTo+RIRPCXtBi7SP6U9u6GhOK/dWs1Q==",
+            "version": "25.0.0",
+            "resolved": "https://registry.npmjs.org/@taquito/michel-codec/-/michel-codec-25.0.0.tgz",
+            "integrity": "sha512-ITM3lM3tEAblPVdzQk5Rv2nLMMOalrXbnIt5b5St8OVYwqaDyfsH3fxSGIVDPxRQyyBdgJ1403aVu6768/8m4Q==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@taquito/core": "^23.1.0"
+                "@taquito/core": "^25.0.0"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=22"
             }
         },
         "node_modules/@taquito/michelson-encoder": {
-            "version": "23.1.0",
-            "resolved": "https://registry.npmjs.org/@taquito/michelson-encoder/-/michelson-encoder-23.1.0.tgz",
-            "integrity": "sha512-zUYXWUIxaQQlL6GCRLfTdUiguHea7YlJ9Hv5QMayegDu2We97AAOJSD8QttpeKii+YDhhybbvMX7KrXQidSt2g==",
+            "version": "25.0.0",
+            "resolved": "https://registry.npmjs.org/@taquito/michelson-encoder/-/michelson-encoder-25.0.0.tgz",
+            "integrity": "sha512-BWwAAwBhY3zngcMK8SkmBWDZ5aNVRnHlHvi7Xu6jnGW109yM3n9awxxCrFD8jOXPb3dly+/pulGnkv28+EvIIQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@taquito/core": "^23.1.0",
-                "@taquito/rpc": "^23.1.0",
-                "@taquito/signer": "^23.1.0",
-                "@taquito/utils": "^23.1.0",
-                "bignumber.js": "^9.1.2",
+                "@taquito/core": "^25.0.0",
+                "@taquito/rpc": "^25.0.0",
+                "@taquito/signer": "^25.0.0",
+                "@taquito/utils": "^25.0.0",
+                "bignumber.js": "^10.0.2",
                 "fast-json-stable-stringify": "^2.1.0"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=22"
             }
         },
         "node_modules/@taquito/rpc": {
-            "version": "23.1.0",
-            "resolved": "https://registry.npmjs.org/@taquito/rpc/-/rpc-23.1.0.tgz",
-            "integrity": "sha512-daP1M42qC66Wyc91qWVUPfoHNRbv2SFVZvwcAx/jwhrV+Jpd2YkyZUArYJ13PYUEIRAKiFV2ym67cobEShsMkQ==",
+            "version": "25.0.0",
+            "resolved": "https://registry.npmjs.org/@taquito/rpc/-/rpc-25.0.0.tgz",
+            "integrity": "sha512-qqV4boldGOavsM6ZzK6xky4xAEyllYDyIO5C16cvkoUzoMCCsWMpRuXa1csSrQc+0IECkkDurNLTbrMJPne9tA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@taquito/core": "^23.1.0",
-                "@taquito/http-utils": "^23.1.0",
-                "@taquito/utils": "^23.1.0",
-                "bignumber.js": "^9.1.2"
+                "@taquito/core": "^25.0.0",
+                "@taquito/http-utils": "^25.0.0",
+                "@taquito/utils": "^25.0.0",
+                "bignumber.js": "^10.0.2"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=22"
             }
         },
         "node_modules/@taquito/signer": {
-            "version": "23.1.0",
-            "resolved": "https://registry.npmjs.org/@taquito/signer/-/signer-23.1.0.tgz",
-            "integrity": "sha512-eA4Z0L88L57RG6CGzhPFSa2I9VTrMSvycKA3UXi1zBwSnxWh1atL4ndPKUeg+qVFC9k/thOAo7x8eT1C4MZ3RA==",
+            "version": "25.0.0",
+            "resolved": "https://registry.npmjs.org/@taquito/signer/-/signer-25.0.0.tgz",
+            "integrity": "sha512-UDHwWd3O0VwZjbEw0NDsoQoIhoQv+xHxb/XAKW7ruSjUT6OkH5whhHpgTZ+T2eJLPDBZLY1RH8IdSl+6ZFtUXg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@noble/curves": "^1.9.7",
-                "@stablelib/blake2b": "^1.0.1",
-                "@stablelib/ed25519": "^1.0.3",
-                "@stablelib/hmac": "^1.0.1",
+                "@noble/hashes": "^2.2.0",
+                "@scure/bip39": "^2.2.0",
                 "@stablelib/nacl": "^1.0.4",
-                "@stablelib/pbkdf2": "^1.0.1",
-                "@stablelib/sha512": "^1.0.1",
-                "@taquito/core": "^23.1.0",
-                "@taquito/utils": "^23.1.0",
+                "@taquito/core": "^25.0.0",
+                "@taquito/utils": "^25.0.0",
                 "@types/bn.js": "^5.1.5",
-                "bip39": "3.1.0",
-                "pbkdf2": "^3.1.2",
+                "bn.js": "^5.2.2",
                 "typedarray-to-buffer": "^4.0.0"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=22"
+            }
+        },
+        "node_modules/@taquito/signer/node_modules/@noble/hashes": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+            "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20.19.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
             }
         },
         "node_modules/@taquito/taquito": {
-            "version": "23.1.0",
-            "resolved": "https://registry.npmjs.org/@taquito/taquito/-/taquito-23.1.0.tgz",
-            "integrity": "sha512-M3GtA9ICmZ6KHn3z8jKgzr/5D9cOnjZ/guXm8gtyzmJPyJssL5JRykPQS5H0UdXBvEfSc3GOCqSioqbJFrl6Vg==",
-            "hasInstallScript": true,
+            "version": "25.0.0",
+            "resolved": "https://registry.npmjs.org/@taquito/taquito/-/taquito-25.0.0.tgz",
+            "integrity": "sha512-MBNKXK1CrOlwBrI0IkjWbVcuwY238ZF8B6fuf2qA0uYp+UmVjukUJ4QCvRf+bayWzfiWBbkYP0upY6VGV3C1VQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@taquito/core": "^23.1.0",
-                "@taquito/http-utils": "^23.1.0",
-                "@taquito/local-forging": "^23.1.0",
-                "@taquito/michel-codec": "^23.1.0",
-                "@taquito/michelson-encoder": "^23.1.0",
-                "@taquito/rpc": "^23.1.0",
-                "@taquito/signer": "^23.1.0",
-                "@taquito/utils": "^23.1.0",
-                "bignumber.js": "^9.1.2",
+                "@taquito/core": "^25.0.0",
+                "@taquito/http-utils": "^25.0.0",
+                "@taquito/local-forging": "^25.0.0",
+                "@taquito/michel-codec": "^25.0.0",
+                "@taquito/michelson-encoder": "^25.0.0",
+                "@taquito/rpc": "^25.0.0",
+                "@taquito/signer": "^25.0.0",
+                "@taquito/utils": "^25.0.0",
+                "bignumber.js": "^10.0.2",
                 "rxjs": "^7.8.2"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=22"
             }
         },
         "node_modules/@taquito/utils": {
-            "version": "23.1.0",
-            "resolved": "https://registry.npmjs.org/@taquito/utils/-/utils-23.1.0.tgz",
-            "integrity": "sha512-CC6dLj6Ppjn28HZEok3q/7IjwCAyCUUC9olczz1S9diEAByxgI+XKKbkCXAOjAC8ogpCosHvU3n3crQuCd8ycg==",
+            "version": "25.0.0",
+            "resolved": "https://registry.npmjs.org/@taquito/utils/-/utils-25.0.0.tgz",
+            "integrity": "sha512-I/9hndZcx0yL6f1djPMhgxCpAopbh/E1ta5kYGs3AxDGrYKt0QpbWAvvUV7fwU9kgzHRQlm7fX8DP7zUbz7ntg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@noble/curves": "^1.9.7",
-                "@stablelib/blake2b": "^1.0.1",
-                "@stablelib/ed25519": "^1.0.3",
-                "@taquito/core": "^23.1.0",
+                "@noble/hashes": "^2.2.0",
+                "@taquito/core": "^25.0.0",
                 "@types/bs58check": "^2.1.2",
-                "bignumber.js": "^9.1.2",
+                "bignumber.js": "^10.0.2",
                 "blakejs": "^1.2.1",
                 "bs58check": "^3.0.1",
                 "buffer": "^6.0.3",
                 "typedarray-to-buffer": "^4.0.0"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=22"
+            }
+        },
+        "node_modules/@taquito/utils/node_modules/@noble/hashes": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+            "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20.19.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
             }
         },
         "node_modules/@types/bn.js": {
@@ -840,21 +831,6 @@
                 "undici-types": "~7.16.0"
             }
         },
-        "node_modules/available-typed-arrays": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
-            "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-            "license": "MIT",
-            "dependencies": {
-                "possible-typed-array-names": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/base-x": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.1.tgz",
@@ -882,22 +858,10 @@
             "license": "MIT"
         },
         "node_modules/bignumber.js": {
-            "version": "9.3.1",
-            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
-            "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
-            "license": "MIT",
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/bip39": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.1.0.tgz",
-            "integrity": "sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==",
-            "license": "ISC",
-            "dependencies": {
-                "@noble/hashes": "^1.2.0"
-            }
+            "version": "10.0.2",
+            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-10.0.2.tgz",
+            "integrity": "sha512-E8Wp9O06QA6lneJ4aRUXKYf/1GIomqUEmUMwtIOMtDxf1U52ffJY+y7JBk/8wRafA8qOIqLnXQGqonYXZdBnFQ==",
+            "license": "MIT"
         },
         "node_modules/blakejs": {
             "version": "1.2.1",
@@ -906,9 +870,9 @@
             "license": "MIT"
         },
         "node_modules/bn.js": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.2.tgz",
-            "integrity": "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==",
+            "version": "5.2.5",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.5.tgz",
+            "integrity": "sha512-Vq886eXykuP5E6HcKSSStP3bJgrE6In5WKxVUvJ8XGpWWYs2xZHWqUwzCtGgEtBcxyd57KBFDPFoUfNzdaHCNg==",
             "license": "MIT"
         },
         "node_modules/bs58": {
@@ -954,117 +918,6 @@
                 "ieee754": "^1.2.1"
             }
         },
-        "node_modules/call-bind": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-            "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
-            "license": "MIT",
-            "dependencies": {
-                "call-bind-apply-helpers": "^1.0.0",
-                "es-define-property": "^1.0.0",
-                "get-intrinsic": "^1.2.4",
-                "set-function-length": "^1.2.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/call-bind-apply-helpers": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "function-bind": "^1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/call-bound": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-            "license": "MIT",
-            "dependencies": {
-                "call-bind-apply-helpers": "^1.0.2",
-                "get-intrinsic": "^1.3.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/cipher-base": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.7.tgz",
-            "integrity": "sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==",
-            "license": "MIT",
-            "dependencies": {
-                "inherits": "^2.0.4",
-                "safe-buffer": "^5.2.1",
-                "to-buffer": "^1.2.2"
-            },
-            "engines": {
-                "node": ">= 0.10"
-            }
-        },
-        "node_modules/core-util-is": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-            "license": "MIT"
-        },
-        "node_modules/create-hash": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
-            "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-            "license": "MIT",
-            "dependencies": {
-                "cipher-base": "^1.0.1",
-                "inherits": "^2.0.1",
-                "md5.js": "^1.3.4",
-                "ripemd160": "^2.0.1",
-                "sha.js": "^2.4.0"
-            }
-        },
-        "node_modules/create-hmac": {
-            "version": "1.1.7",
-            "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
-            "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-            "license": "MIT",
-            "dependencies": {
-                "cipher-base": "^1.0.3",
-                "create-hash": "^1.1.0",
-                "inherits": "^2.0.1",
-                "ripemd160": "^2.0.0",
-                "safe-buffer": "^5.0.1",
-                "sha.js": "^2.4.8"
-            }
-        },
-        "node_modules/define-data-property": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-            "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-            "license": "MIT",
-            "dependencies": {
-                "es-define-property": "^1.0.0",
-                "es-errors": "^1.3.0",
-                "gopd": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/dotenv": {
             "version": "17.2.3",
             "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
@@ -1075,50 +928,6 @@
             },
             "funding": {
                 "url": "https://dotenvx.com"
-            }
-        },
-        "node_modules/dunder-proto": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-            "license": "MIT",
-            "dependencies": {
-                "call-bind-apply-helpers": "^1.0.1",
-                "es-errors": "^1.3.0",
-                "gopd": "^1.2.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-define-property": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-errors": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-object-atoms": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
             }
         },
         "node_modules/esbuild": {
@@ -1175,21 +984,6 @@
             "integrity": "sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==",
             "license": "Apache-2.0"
         },
-        "node_modules/for-each": {
-            "version": "0.3.5",
-            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
-            "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
-            "license": "MIT",
-            "dependencies": {
-                "is-callable": "^1.2.7"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/fsevents": {
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1205,52 +999,6 @@
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
         },
-        "node_modules/function-bind": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/get-intrinsic": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-            "license": "MIT",
-            "dependencies": {
-                "call-bind-apply-helpers": "^1.0.2",
-                "es-define-property": "^1.0.1",
-                "es-errors": "^1.3.0",
-                "es-object-atoms": "^1.1.1",
-                "function-bind": "^1.1.2",
-                "get-proto": "^1.0.1",
-                "gopd": "^1.2.0",
-                "has-symbols": "^1.1.0",
-                "hasown": "^2.0.2",
-                "math-intrinsics": "^1.1.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/get-proto": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-            "license": "MIT",
-            "dependencies": {
-                "dunder-proto": "^1.0.1",
-                "es-object-atoms": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
         "node_modules/get-tsconfig": {
             "version": "4.13.0",
             "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
@@ -1262,84 +1010,6 @@
             },
             "funding": {
                 "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-            }
-        },
-        "node_modules/gopd": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/has-property-descriptors": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-            "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-            "license": "MIT",
-            "dependencies": {
-                "es-define-property": "^1.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/has-symbols": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/has-tostringtag": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-            "license": "MIT",
-            "dependencies": {
-                "has-symbols": "^1.0.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/hash-base": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.2.tgz",
-            "integrity": "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==",
-            "license": "MIT",
-            "dependencies": {
-                "inherits": "^2.0.4",
-                "readable-stream": "^2.3.8",
-                "safe-buffer": "^5.2.1",
-                "to-buffer": "^1.2.1"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "node_modules/hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-            "license": "MIT",
-            "dependencies": {
-                "function-bind": "^1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
             }
         },
         "node_modules/ieee754": {
@@ -1362,143 +1032,11 @@
             ],
             "license": "BSD-3-Clause"
         },
-        "node_modules/inherits": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "license": "ISC"
-        },
-        "node_modules/is-callable": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-            "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-typed-array": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
-            "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
-            "license": "MIT",
-            "dependencies": {
-                "which-typed-array": "^1.1.16"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/isarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-            "license": "MIT"
-        },
         "node_modules/json-stringify-safe": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
             "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
             "license": "ISC"
-        },
-        "node_modules/math-intrinsics": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/md5.js": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
-            "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
-            "license": "MIT",
-            "dependencies": {
-                "hash-base": "^3.0.0",
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.1.2"
-            }
-        },
-        "node_modules/node-fetch": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-            "license": "MIT",
-            "dependencies": {
-                "whatwg-url": "^5.0.0"
-            },
-            "engines": {
-                "node": "4.x || >=6.0.0"
-            },
-            "peerDependencies": {
-                "encoding": "^0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "encoding": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/pbkdf2": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.5.tgz",
-            "integrity": "sha512-Q3CG/cYvCO1ye4QKkuH7EXxs3VC/rI1/trd+qX2+PolbaKG0H+bgcZzrTt96mMyRtejk+JMCiLUn3y29W8qmFQ==",
-            "license": "MIT",
-            "dependencies": {
-                "create-hash": "^1.2.0",
-                "create-hmac": "^1.1.7",
-                "ripemd160": "^2.0.3",
-                "safe-buffer": "^5.2.1",
-                "sha.js": "^2.4.12",
-                "to-buffer": "^1.2.1"
-            },
-            "engines": {
-                "node": ">= 0.10"
-            }
-        },
-        "node_modules/possible-typed-array-names": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
-            "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/process-nextick-args": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-            "license": "MIT"
-        },
-        "node_modules/readable-stream": {
-            "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-            "license": "MIT",
-            "dependencies": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-            }
-        },
-        "node_modules/readable-stream/node_modules/safe-buffer": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "license": "MIT"
         },
         "node_modules/resolve-pkg-maps": {
             "version": "1.0.0",
@@ -1510,19 +1048,6 @@
                 "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
             }
         },
-        "node_modules/ripemd160": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.3.tgz",
-            "integrity": "sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==",
-            "license": "MIT",
-            "dependencies": {
-                "hash-base": "^3.1.2",
-                "inherits": "^2.0.4"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
         "node_modules/rxjs": {
             "version": "7.8.2",
             "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
@@ -1531,104 +1056,6 @@
             "dependencies": {
                 "tslib": "^2.1.0"
             }
-        },
-        "node_modules/safe-buffer": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT"
-        },
-        "node_modules/set-function-length": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-            "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-            "license": "MIT",
-            "dependencies": {
-                "define-data-property": "^1.1.4",
-                "es-errors": "^1.3.0",
-                "function-bind": "^1.1.2",
-                "get-intrinsic": "^1.2.4",
-                "gopd": "^1.0.1",
-                "has-property-descriptors": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/sha.js": {
-            "version": "2.4.12",
-            "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
-            "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
-            "license": "(MIT AND BSD-3-Clause)",
-            "dependencies": {
-                "inherits": "^2.0.4",
-                "safe-buffer": "^5.2.1",
-                "to-buffer": "^1.2.0"
-            },
-            "bin": {
-                "sha.js": "bin.js"
-            },
-            "engines": {
-                "node": ">= 0.10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/string_decoder": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-            "license": "MIT",
-            "dependencies": {
-                "safe-buffer": "~5.1.0"
-            }
-        },
-        "node_modules/string_decoder/node_modules/safe-buffer": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "license": "MIT"
-        },
-        "node_modules/to-buffer": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
-            "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
-            "license": "MIT",
-            "dependencies": {
-                "isarray": "^2.0.5",
-                "safe-buffer": "^5.2.1",
-                "typed-array-buffer": "^1.0.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/to-buffer/node_modules/isarray": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-            "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-            "license": "MIT"
-        },
-        "node_modules/tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-            "license": "MIT"
         },
         "node_modules/tslib": {
             "version": "2.8.1",
@@ -1654,20 +1081,6 @@
             },
             "optionalDependencies": {
                 "fsevents": "~2.3.3"
-            }
-        },
-        "node_modules/typed-array-buffer": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
-            "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
-            "license": "MIT",
-            "dependencies": {
-                "call-bound": "^1.0.3",
-                "es-errors": "^1.3.0",
-                "is-typed-array": "^1.1.14"
-            },
-            "engines": {
-                "node": ">= 0.4"
             }
         },
         "node_modules/typedarray-to-buffer": {
@@ -1709,49 +1122,6 @@
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
             "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
             "license": "MIT"
-        },
-        "node_modules/util-deprecate": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-            "license": "MIT"
-        },
-        "node_modules/webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-            "license": "BSD-2-Clause"
-        },
-        "node_modules/whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-            "license": "MIT",
-            "dependencies": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
-            }
-        },
-        "node_modules/which-typed-array": {
-            "version": "1.1.19",
-            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
-            "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
-            "license": "MIT",
-            "dependencies": {
-                "available-typed-arrays": "^1.0.7",
-                "call-bind": "^1.0.8",
-                "call-bound": "^1.0.4",
-                "for-each": "^0.3.5",
-                "get-proto": "^1.0.1",
-                "gopd": "^1.2.0",
-                "has-tostringtag": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
         }
     }
 }

--- a/dex/scripts/package.json
+++ b/dex/scripts/package.json
@@ -4,21 +4,31 @@
     "type": "module",
     "scripts": {
         "deploy:testnet": "tsx src/deploy.ts --network=testnet",
-        "deploy:mainnet": "tsx src/deploy.ts --network=mainnet"
+        "deploy:mainnet": "tsx src/deploy.ts --network=mainnet",
+        "deploy:token-token:testnet": "tsx src/deploy-token-token.ts --network=testnet",
+        "deploy:token-token:mainnet": "tsx src/deploy-token-token.ts --network=mainnet",
+        "test:token-token-config": "node --import tsx --test src/token-token-config.test.ts",
+        "typecheck": "tsc --noEmit"
     },
     "keywords": [],
     "author": "",
     "license": "ISC",
     "description": "",
+    "engines": {
+        "node": ">=22"
+    },
     "dependencies": {
-        "@taquito/michel-codec": "^23.1.0",
-        "@taquito/michelson-encoder": "^23.1.0",
-        "@taquito/signer": "^23.0.3",
-        "@taquito/taquito": "^23.0.3",
-        "bn.js": "^5.2.2",
+        "@taquito/michel-codec": "^25.0.0",
+        "@taquito/michelson-encoder": "^25.0.0",
+        "@taquito/signer": "^25.0.0",
+        "@taquito/taquito": "^25.0.0",
         "dotenv": "^17.2.3"
     },
+    "overrides": {
+        "bn.js": "5.2.5"
+    },
     "devDependencies": {
+        "@taquito/utils": "^25.0.0",
         "@types/node": "^25.0.0",
         "tsx": "4.21.0",
         "typescript": "5.9.3"

--- a/dex/scripts/src/deploy-token-token.ts
+++ b/dex/scripts/src/deploy-token-token.ts
@@ -1,0 +1,213 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Parser } from "@taquito/michel-codec";
+import { Schema } from "@taquito/michelson-encoder";
+import { InMemorySigner } from "@taquito/signer";
+import { TezosToolkit } from "@taquito/taquito";
+import dotenv from "dotenv";
+import {
+  parseTokenTokenConfig,
+  type TokenDescriptor,
+  type TokenTokenDeploymentConfig,
+  type TokenTokenNetwork,
+} from "./token-token-config.js";
+import { buildTokenTokenInitialStorage } from "./token-token-storage.js";
+
+dotenv.config();
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+
+function parseNetwork(): TokenTokenNetwork {
+  const networkArg = process.argv.slice(2).find((arg) => arg.startsWith("--network="));
+  const network = networkArg?.split("=")[1] ?? "testnet";
+  if (network !== "testnet" && network !== "mainnet") {
+    throw new Error(`Invalid network ${network}; expected testnet or mainnet`);
+  }
+  return network;
+}
+
+function compiledContractPath(): string {
+  return path.join(
+    scriptDirectory,
+    "..",
+    "..",
+    "compiled_contracts",
+    "token_token_pool.tz",
+  );
+}
+
+function getStorageType(parsedScript: unknown): unknown {
+  if (!Array.isArray(parsedScript)) {
+    throw new Error("Compiled contract did not parse as a Michelson script");
+  }
+  const storageSection = parsedScript.find(
+    (section) =>
+      typeof section === "object" &&
+      section !== null &&
+      "prim" in section &&
+      section.prim === "storage",
+  ) as { args?: unknown[] } | undefined;
+  if (!storageSection?.args?.[0]) {
+    throw new Error("Compiled contract is missing its storage type");
+  }
+  return storageSection.args[0];
+}
+
+async function assertFA2Interface(
+  tezos: TezosToolkit,
+  label: string,
+  token: TokenDescriptor,
+): Promise<void> {
+  const contract = await tezos.contract.at(token.address);
+  const entrypoints = contract.entrypoints.entrypoints;
+  for (const requiredEntrypoint of ["transfer", "balance_of", "update_operators"]) {
+    if (!(requiredEntrypoint in entrypoints)) {
+      throw new Error(`${label} is missing the ${requiredEntrypoint} FA2 entrypoint`);
+    }
+  }
+}
+
+async function addPoolOperator(
+  tezos: TezosToolkit,
+  token: TokenDescriptor,
+  owner: string,
+  poolAddress: string,
+  confirmations: number,
+): Promise<string> {
+  const contract = await tezos.contract.at(token.address);
+  const operation = await contract.methodsObject
+    .update_operators([
+      {
+        add_operator: {
+          owner,
+          operator: poolAddress,
+          token_id: token.tokenId,
+        },
+      },
+    ])
+    .send();
+  await operation.confirmation(confirmations);
+  return operation.hash;
+}
+
+async function saveDeployment(
+  config: TokenTokenDeploymentConfig,
+  deployer: string,
+  poolAddress: string,
+  operations: Record<string, string>,
+): Promise<string> {
+  const deployment = {
+    network: config.network,
+    rpc: config.rpc,
+    timestamp: new Date().toISOString(),
+    deployer,
+    pool: poolAddress,
+    tokenA: config.tokenA,
+    tokenB: config.tokenB,
+    seedAmountA: config.seedAmountA,
+    seedAmountB: config.seedAmountB,
+    seedReceiver: config.seedReceiver ?? deployer,
+    feeRecipient: config.feeRecipient,
+    proposedAdmin: config.finalAdmin ?? null,
+    feeBps: { lp: 25, protocol: 5, total: 30 },
+    operations,
+  };
+  const outputDirectory = path.join(scriptDirectory, "..", "deployments", "token-token");
+  await fs.promises.mkdir(outputDirectory, { recursive: true });
+  const timestamp = Date.now();
+  const outputPath = path.join(outputDirectory, `${config.network}-${timestamp}.json`);
+  const latestPath = path.join(outputDirectory, `${config.network}-latest.json`);
+  const json = `${JSON.stringify(deployment, null, 2)}\n`;
+  await fs.promises.writeFile(outputPath, json, { mode: 0o600 });
+  await fs.promises.writeFile(latestPath, json, { mode: 0o600 });
+  return outputPath;
+}
+
+async function main(): Promise<void> {
+  const config = parseTokenTokenConfig(parseNetwork());
+  const tezos = new TezosToolkit(config.rpc);
+  tezos.setProvider({ signer: await InMemorySigner.fromSecretKey(config.privateKey) });
+
+  const deployer = await tezos.signer.publicKeyHash();
+  const seedReceiver = config.seedReceiver ?? deployer;
+  console.log(`Network: ${config.network}`);
+  console.log(`Deployer: ${deployer}`);
+  console.log(`Token A: ${config.tokenA.address} / ${config.tokenA.tokenId}`);
+  console.log(`Token B: ${config.tokenB.address} / ${config.tokenB.tokenId}`);
+  console.log("Immutable fees: 25 bp LP + 5 bp protocol");
+
+  await Promise.all([
+    assertFA2Interface(tezos, "TOKEN_A", config.tokenA),
+    assertFA2Interface(tezos, "TOKEN_B", config.tokenB),
+  ]);
+
+  if (config.network === "mainnet") {
+    console.log("Mainnet deployment begins in five seconds; press Ctrl+C to cancel.");
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+  }
+
+  const parser = new Parser();
+  const source = await fs.promises.readFile(compiledContractPath(), "utf8");
+  const parsedScript = parser.parseScript(source);
+  const storageSchema = new Schema(getStorageType(parsedScript) as never);
+  const initialStorage = storageSchema.Encode(
+    buildTokenTokenInitialStorage(config, deployer),
+  );
+
+  const originateOperation = await tezos.contract.originate({
+    code: parsedScript!,
+    init: initialStorage,
+  });
+  const pool = await originateOperation.contract(config.confirmations);
+  const operations: Record<string, string> = { originate: originateOperation.hash };
+  console.log(`Pool originated: ${pool.address}`);
+
+  operations.authorizeTokenA = await addPoolOperator(
+    tezos,
+    config.tokenA,
+    deployer,
+    pool.address,
+    config.confirmations,
+  );
+  operations.authorizeTokenB = await addPoolOperator(
+    tezos,
+    config.tokenB,
+    deployer,
+    pool.address,
+    config.confirmations,
+  );
+
+  const initializeOperation = await pool.methodsObject
+    .initialize({
+      amount_a: config.seedAmountA,
+      amount_b: config.seedAmountB,
+      receiver: seedReceiver,
+      deadline: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+    })
+    .send();
+  await initializeOperation.confirmation(config.confirmations);
+  operations.initialize = initializeOperation.hash;
+
+  if (config.finalAdmin && config.finalAdmin !== deployer) {
+    const proposal = await pool.methodsObject.propose_admin(config.finalAdmin).send();
+    await proposal.confirmation(config.confirmations);
+    operations.proposeAdmin = proposal.hash;
+    console.log(`Admin proposed: ${config.finalAdmin}`);
+    console.log("The proposed admin must call accept_admin to complete the handoff.");
+  }
+
+  const outputPath = await saveDeployment(
+    config,
+    deployer,
+    pool.address,
+    operations,
+  );
+  console.log(`Deployment record: ${outputPath}`);
+}
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`Token-to-token deployment failed: ${message}`);
+  process.exitCode = 1;
+});

--- a/dex/scripts/src/token-token-config.test.ts
+++ b/dex/scripts/src/token-token-config.test.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { Parser } from "@taquito/michel-codec";
+import { Schema } from "@taquito/michelson-encoder";
+import { b58Encode, PrefixV2 } from "@taquito/utils";
+import { parseTokenTokenConfig } from "./token-token-config.js";
+import { buildTokenTokenInitialStorage } from "./token-token-storage.js";
+
+function validEnv(): NodeJS.ProcessEnv {
+  return {
+    TESTNET_PRIVATE_KEY: "unencrypted:test-only-placeholder",
+    TOKEN_A_ADDRESS: "KT1TokenAPlaceholder",
+    TOKEN_A_ID: "0",
+    TOKEN_B_ADDRESS: "KT1TokenBPlaceholder",
+    TOKEN_B_ID: "1",
+    SEED_AMOUNT_A: "1000000",
+    SEED_AMOUNT_B: "2000000",
+    PROTOCOL_FEE_RECIPIENT: "KT1FeeRecipientPlaceholder",
+    TOKEN_TOKEN_POOL_METADATA_URI: "ipfs://pool-metadata-placeholder",
+    LP_TOKEN_METADATA_URI: "ipfs://lp-metadata-placeholder",
+    LP_TOKEN_DECIMALS: "6",
+  };
+}
+
+test("parses an asset-agnostic deployment config", () => {
+  const config = parseTokenTokenConfig("testnet", validEnv());
+  assert.equal(config.tokenA.tokenId, "0");
+  assert.equal(config.tokenB.tokenId, "1");
+  assert.equal(config.seedAmountA, "1000000");
+  assert.equal(config.confirmations, 2);
+});
+
+test("rejects identical FA2 assets", () => {
+  const env = validEnv();
+  env.TOKEN_B_ADDRESS = env.TOKEN_A_ADDRESS;
+  env.TOKEN_B_ID = env.TOKEN_A_ID;
+  assert.throws(
+    () => parseTokenTokenConfig("testnet", env),
+    /must identify different FA2 assets/,
+  );
+});
+
+test("rejects unsafe or fractional nat values", () => {
+  const env = validEnv();
+  env.SEED_AMOUNT_A = "1000.5";
+  assert.throws(
+    () => parseTokenTokenConfig("testnet", env),
+    /unsigned base-10 integer/,
+  );
+});
+
+test("rejects seed amounts that cannot fund the locked minimum", () => {
+  const env = validEnv();
+  env.SEED_AMOUNT_B = "1000";
+  assert.throws(
+    () => parseTokenTokenConfig("testnet", env),
+    /must exceed the 1,000-unit minimum/,
+  );
+});
+
+test("does not require a final admin address in source configuration", () => {
+  const config = parseTokenTokenConfig("testnet", validEnv());
+  assert.equal(config.finalAdmin, undefined);
+});
+
+test("encodes origination storage against the compiled Michelson schema", () => {
+  const env = validEnv();
+  env.TOKEN_A_ADDRESS = b58Encode(
+    new Uint8Array(20).fill(1),
+    PrefixV2.ContractHash,
+  );
+  env.TOKEN_B_ADDRESS = b58Encode(
+    new Uint8Array(20).fill(2),
+    PrefixV2.ContractHash,
+  );
+  env.PROTOCOL_FEE_RECIPIENT = b58Encode(
+    new Uint8Array(20).fill(3),
+    PrefixV2.Ed25519PublicKeyHash,
+  );
+  const deployer = b58Encode(
+    new Uint8Array(20).fill(4),
+    PrefixV2.Ed25519PublicKeyHash,
+  );
+  const config = parseTokenTokenConfig("testnet", env);
+
+  const source = fs.readFileSync(
+    path.join("..", "compiled_contracts", "token_token_pool.tz"),
+    "utf8",
+  );
+  const script = new Parser().parseScript(source);
+  assert.ok(Array.isArray(script));
+  const storageSection = script.find(
+    (section) =>
+      typeof section === "object" &&
+      section !== null &&
+      "prim" in section &&
+      section.prim === "storage",
+  ) as { args?: never[] } | undefined;
+  assert.ok(storageSection?.args?.[0]);
+
+  const schema = new Schema(storageSection.args[0]);
+  assert.doesNotThrow(() =>
+    schema.Encode(buildTokenTokenInitialStorage(config, deployer)),
+  );
+});
+
+test("requires an explicit mainnet origination confirmation", () => {
+  const env = validEnv();
+  env.MAINNET_PRIVATE_KEY = env.TESTNET_PRIVATE_KEY;
+  assert.throws(
+    () => parseTokenTokenConfig("mainnet", env),
+    /CONFIRM_MAINNET_DEPLOYMENT/,
+  );
+
+  env.CONFIRM_MAINNET_DEPLOYMENT = "ORIGINATE_TOKEN_TOKEN_POOL";
+  assert.equal(parseTokenTokenConfig("mainnet", env).network, "mainnet");
+});

--- a/dex/scripts/src/token-token-config.ts
+++ b/dex/scripts/src/token-token-config.ts
@@ -1,0 +1,122 @@
+export type TokenTokenNetwork = "testnet" | "mainnet";
+
+export interface TokenDescriptor {
+  address: string;
+  tokenId: string;
+}
+
+export interface TokenTokenDeploymentConfig {
+  network: TokenTokenNetwork;
+  rpc: string;
+  privateKey: string;
+  tokenA: TokenDescriptor;
+  tokenB: TokenDescriptor;
+  seedAmountA: string;
+  seedAmountB: string;
+  seedReceiver?: string;
+  finalAdmin?: string;
+  feeRecipient: string;
+  poolMetadataUri: string;
+  lpTokenMetadataUri: string;
+  lpTokenName: string;
+  lpTokenSymbol: string;
+  lpTokenDecimals: string;
+  confirmations: number;
+}
+
+const NAT_PATTERN = /^(0|[1-9][0-9]*)$/;
+
+function required(env: NodeJS.ProcessEnv, key: string): string {
+  const value = env[key]?.trim();
+  if (!value) {
+    throw new Error(`Required environment variable ${key} is not set or empty`);
+  }
+  return value;
+}
+
+function optional(env: NodeJS.ProcessEnv, key: string): string | undefined {
+  const value = env[key]?.trim();
+  return value || undefined;
+}
+
+function natural(env: NodeJS.ProcessEnv, key: string, allowZero = true): string {
+  const value = required(env, key);
+  if (!NAT_PATTERN.test(value)) {
+    throw new Error(`${key} must be an unsigned base-10 integer`);
+  }
+  if (!allowZero && BigInt(value) === 0n) {
+    throw new Error(`${key} must be greater than zero`);
+  }
+  return value;
+}
+
+function positiveInteger(env: NodeJS.ProcessEnv, key: string, fallback: number): number {
+  const raw = optional(env, key);
+  if (!raw) return fallback;
+  if (!NAT_PATTERN.test(raw) || BigInt(raw) === 0n) {
+    throw new Error(`${key} must be a positive integer`);
+  }
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value)) {
+    throw new Error(`${key} is outside the safe integer range`);
+  }
+  return value;
+}
+
+export function parseTokenTokenConfig(
+  network: TokenTokenNetwork,
+  env: NodeJS.ProcessEnv = process.env,
+): TokenTokenDeploymentConfig {
+  const networkPrefix = network === "mainnet" ? "MAINNET" : "TESTNET";
+  if (
+    network === "mainnet" &&
+    optional(env, "CONFIRM_MAINNET_DEPLOYMENT") !== "ORIGINATE_TOKEN_TOKEN_POOL"
+  ) {
+    throw new Error(
+      "Set CONFIRM_MAINNET_DEPLOYMENT=ORIGINATE_TOKEN_TOKEN_POOL to enable mainnet origination",
+    );
+  }
+  const rpc =
+    optional(env, `${networkPrefix}_RPC`) ??
+    (network === "mainnet"
+      ? "https://rpc.tzkt.io/mainnet"
+      : "https://rpc.tzkt.io/ghostnet");
+
+  const tokenA: TokenDescriptor = {
+    address: required(env, "TOKEN_A_ADDRESS"),
+    tokenId: natural(env, "TOKEN_A_ID"),
+  };
+  const tokenB: TokenDescriptor = {
+    address: required(env, "TOKEN_B_ADDRESS"),
+    tokenId: natural(env, "TOKEN_B_ID"),
+  };
+
+  if (tokenA.address === tokenB.address && tokenA.tokenId === tokenB.tokenId) {
+    throw new Error("TOKEN_A and TOKEN_B must identify different FA2 assets");
+  }
+
+  const seedAmountA = natural(env, "SEED_AMOUNT_A", false);
+  const seedAmountB = natural(env, "SEED_AMOUNT_B", false);
+  if (BigInt(seedAmountA) <= 1000n || BigInt(seedAmountB) <= 1000n) {
+    throw new Error("Each seed amount must exceed the 1,000-unit minimum liquidity lock");
+  }
+
+  return {
+    network,
+    rpc,
+    privateKey: required(env, `${networkPrefix}_PRIVATE_KEY`),
+    tokenA,
+    tokenB,
+    seedAmountA,
+    seedAmountB,
+    seedReceiver: optional(env, "SEED_RECEIVER"),
+    finalAdmin: optional(env, "FINAL_ADMIN"),
+    feeRecipient: required(env, "PROTOCOL_FEE_RECIPIENT"),
+    poolMetadataUri: required(env, "TOKEN_TOKEN_POOL_METADATA_URI"),
+    lpTokenMetadataUri: required(env, "LP_TOKEN_METADATA_URI"),
+    lpTokenName: optional(env, "LP_TOKEN_NAME") ?? "Token Pair Liquidity",
+    lpTokenSymbol: optional(env, "LP_TOKEN_SYMBOL") ?? "TPLP",
+    lpTokenDecimals: natural(env, "LP_TOKEN_DECIMALS"),
+    confirmations: positiveInteger(env, "CONFIRMATIONS", 2),
+  };
+}

--- a/dex/scripts/src/token-token-storage.ts
+++ b/dex/scripts/src/token-token-storage.ts
@@ -1,0 +1,48 @@
+import { MichelsonMap } from "@taquito/michelson-encoder";
+import type { TokenTokenDeploymentConfig } from "./token-token-config.js";
+
+function bytes(value: string): string {
+  return Buffer.from(value, "utf8").toString("hex");
+}
+
+export function buildTokenTokenInitialStorage(
+  config: TokenTokenDeploymentConfig,
+  deployer: string,
+): Record<string, unknown> {
+  const metadata = new MichelsonMap<string, string>();
+  metadata.set("", bytes(config.poolMetadataUri));
+
+  const tokenInfo = new MichelsonMap<string, string>();
+  tokenInfo.set("", bytes(config.lpTokenMetadataUri));
+  tokenInfo.set("name", bytes(config.lpTokenName));
+  tokenInfo.set("symbol", bytes(config.lpTokenSymbol));
+  tokenInfo.set("decimals", bytes(config.lpTokenDecimals));
+
+  const tokenMetadata = new MichelsonMap<number, Record<string, unknown>>();
+  tokenMetadata.set(0, { token_id: "0", token_info: tokenInfo });
+
+  return {
+    token_a: {
+      token_contract: config.tokenA.address,
+      token_id: config.tokenA.tokenId,
+    },
+    token_b: {
+      token_contract: config.tokenB.address,
+      token_id: config.tokenB.tokenId,
+    },
+    reserve_a: "0",
+    reserve_b: "0",
+    protocol_fees_a: "0",
+    protocol_fees_b: "0",
+    total_supply: "0",
+    ledger: new MichelsonMap(),
+    operators: new MichelsonMap(),
+    metadata,
+    token_metadata: tokenMetadata,
+    admin: deployer,
+    pending_admin: null,
+    fee_recipient: config.feeRecipient,
+    paused: false,
+    pending: null,
+  };
+}

--- a/dex/tests/token_token_pool.test.mligo
+++ b/dex/tests/token_token_pool.test.mligo
@@ -1,0 +1,593 @@
+#include "../contracts/token_token_pool.mligo"
+#import "../contracts/helpers/fa2_token.mligo" "FA2"
+
+module Test = Test.Next
+module Tezos = Tezos.Next
+module Contract = TokenTokenPool
+
+type pool_parameter = TokenTokenPool parameter_of
+type fa2_parameter = FA2 parameter_of
+type pool_typed_address = (pool_parameter, Contract.storage) typed_address
+type fa2_typed_address = (fa2_parameter, FA2.storage) typed_address
+
+let admin () = Test.Account.address 0n
+let trader () = Test.Account.address 1n
+let fee_recipient () = Test.Account.address 2n
+let successor_admin () = Test.Account.address 3n
+
+let future = ("1970-01-01T01:00:00Z" : timestamp)
+let initial_balance = 1000000000n
+let initial_reserve = 1000000n
+
+let clean () : unit =
+  Test.State.reset
+    4n
+    [1000000tez; 1000000tez; 1000000tez; 1000000tez]
+
+let deploy_token (owner : address) =
+  let token_storage : FA2.storage = FA2.make_storage owner initial_balance 0n in
+  Test.Originate.contract (contract_of FA2) token_storage 0tez
+
+let lp_token_metadata () : (nat, Contract.token_metadata_value) big_map =
+  Big_map.literal
+    [
+      (0n,
+       {
+         token_id = 0n;
+         token_info =
+           (Map.literal
+              [
+                ("name", Bytes.pack ("Token Pair Liquidity" : string));
+                ("symbol", Bytes.pack ("TPLP" : string));
+                ("decimals", Bytes.pack ("0" : string))
+              ]
+            : (string, bytes) map)
+       })
+    ]
+
+let deploy_pool token_a_address token_b_address =
+  let pool_storage : Contract.storage =
+    Contract.build_storage
+      {
+        token_a = {token_contract = token_a_address; token_id = 0n};
+        token_b = {token_contract = token_b_address; token_id = 0n};
+        admin = admin ();
+        fee_recipient = fee_recipient ();
+        metadata = (Big_map.empty : (string, bytes) big_map);
+        token_metadata = lp_token_metadata ()
+      } in
+  Test.Originate.contract (contract_of Contract) pool_storage 0tez
+
+let add_token_operator
+  (token_taddr : fa2_typed_address)
+  (owner : address)
+  (operator : address)
+: unit =
+  let update : FA2.update_operators =
+    [Add_operator {owner = owner; operator = operator; token_id = 0n}] in
+  let _ : nat =
+    Test.Contract.transfer_exn
+      (Test.Typed_address.get_entrypoint "update_operators" token_taddr)
+      update
+      0tez in
+  ()
+
+let token_transfer
+  (token_taddr : fa2_typed_address)
+  (from_ : address)
+  (to_ : address)
+  (amount : nat)
+: unit =
+  let transfer : FA2.transfer =
+    [
+      {
+        from_ = from_;
+        txs = [{to_ = to_; token_id = 0n; amount = amount}]
+      }
+    ] in
+  let _ : nat =
+    Test.Contract.transfer_exn
+      (Test.Typed_address.get_entrypoint "transfer" token_taddr)
+      transfer
+      0tez in
+  ()
+
+let token_balance (token_taddr : fa2_typed_address) (owner : address) : nat =
+  let token_storage : FA2.storage = Test.Typed_address.get_storage token_taddr in
+  match Big_map.find_opt owner token_storage.ledger with
+  | Some balance -> balance
+  | None -> 0n
+
+let pool_balance (pool_taddr : pool_typed_address) (owner : address) : nat =
+  let pool_storage : Contract.storage = Test.Typed_address.get_storage pool_taddr in
+  match Big_map.find_opt owner pool_storage.ledger with
+  | Some balance -> balance
+  | None -> 0n
+
+let setup_initialized_pool () =
+  let () = clean () in
+  let () = Test.State.set_source (admin ()) in
+  let token_a = deploy_token (admin ()) in
+  let token_b = deploy_token (admin ()) in
+  let token_a_address = Test.Typed_address.to_address token_a.taddr in
+  let token_b_address = Test.Typed_address.to_address token_b.taddr in
+  let pool = deploy_pool token_a_address token_b_address in
+  let pool_address = Test.Typed_address.to_address pool.taddr in
+  let () = add_token_operator token_a.taddr (admin ()) pool_address in
+  let () = add_token_operator token_b.taddr (admin ()) pool_address in
+  let initialize_param : Contract.initialize_param =
+    {
+      amount_a = initial_reserve;
+      amount_b = initial_reserve;
+      receiver = admin ();
+      deadline = future
+    } in
+  let _ : nat =
+    Test.Contract.transfer_exn
+      (Test.Typed_address.get_entrypoint "initialize" pool.taddr)
+      initialize_param
+      0tez in
+  (pool, token_a, token_b)
+
+let fund_trader_and_authorize
+  (pool_taddr : pool_typed_address)
+  (token_a_taddr : fa2_typed_address)
+  (token_b_taddr : fa2_typed_address)
+: unit =
+  let pool_address = Test.Typed_address.to_address pool_taddr in
+  let () = Test.State.set_source (admin ()) in
+  let () = token_transfer token_a_taddr (admin ()) (trader ()) 5000000n in
+  let () = token_transfer token_b_taddr (admin ()) (trader ()) 5000000n in
+  let () = Test.State.set_source (trader ()) in
+  let () = add_token_operator token_a_taddr (trader ()) pool_address in
+  add_token_operator token_b_taddr (trader ()) pool_address
+
+let assert_string_failure
+  (test_name : string)
+  (expected : string)
+  (result : test_exec_result)
+: unit =
+  match result with
+  | Success _ -> failwith (test_name ^ ": expected failure")
+  | Fail failure ->
+      (match failure with
+       | Rejected (actual, _) ->
+           let expected = Test.Michelson.eval (expected : string) in
+           if Test.Compare.eq actual expected
+           then ()
+           else failwith (test_name ^ ": wrong failure")
+       | _ -> failwith (test_name ^ ": unexpected failure type"))
+
+let assert_nat (test_name : string) (actual : nat) (expected : nat) : unit =
+  if actual = expected
+  then ()
+  else
+    failwith
+      (test_name ^ ": expected " ^ Test.String.show expected
+       ^ ", got " ^ Test.String.show actual)
+
+let assert_pool_solvency
+  (test_name : string)
+  (pool_taddr : pool_typed_address)
+  (token_a_taddr : fa2_typed_address)
+  (token_b_taddr : fa2_typed_address)
+: unit =
+  let pool_storage : Contract.storage = Test.Typed_address.get_storage pool_taddr in
+  let pool_address = Test.Typed_address.to_address pool_taddr in
+  let held_a = token_balance token_a_taddr pool_address in
+  let held_b = token_balance token_b_taddr pool_address in
+  let () =
+    assert_nat
+      (test_name ^ ": token A solvency")
+      held_a
+      (pool_storage.reserve_a + pool_storage.protocol_fees_a) in
+  assert_nat
+    (test_name ^ ": token B solvency")
+    held_b
+    (pool_storage.reserve_b + pool_storage.protocol_fees_b)
+
+(* ------------------------------------------------------------------------- *)
+(* Initialization and locked minimum liquidity                              *)
+(* ------------------------------------------------------------------------- *)
+
+let test_initialize_verifies_both_assets =
+  let (pool, token_a, token_b) = setup_initialized_pool () in
+  let pool_storage : Contract.storage = Test.Typed_address.get_storage pool.taddr in
+  let pool_address = Test.Typed_address.to_address pool.taddr in
+  let () = assert_nat "initialize reserve A" pool_storage.reserve_a initial_reserve in
+  let () = assert_nat "initialize reserve B" pool_storage.reserve_b initial_reserve in
+  let () = assert_nat "initialize total supply" pool_storage.total_supply initial_reserve in
+  let () =
+    assert_nat
+      "initialize provider shares"
+      (pool_balance pool.taddr (admin ()))
+      (abs (initial_reserve - Contract.minimum_liquidity)) in
+  let () =
+    assert_nat
+      "initialize locked shares"
+      (pool_balance pool.taddr pool_address)
+      Contract.minimum_liquidity in
+  assert_pool_solvency "initialize" pool.taddr token_a.taddr token_b.taddr
+
+let test_initialize_only_once =
+  let (pool, _, _) = setup_initialized_pool () in
+  let param : Contract.initialize_param =
+    {
+      amount_a = initial_reserve;
+      amount_b = initial_reserve;
+      receiver = admin ();
+      deadline = future
+    } in
+  let result =
+    Test.Contract.transfer
+      (Test.Typed_address.get_entrypoint "initialize" pool.taddr)
+      param
+      0tez in
+  assert_string_failure "initialize twice" Contract.err_initialized result
+
+(* ------------------------------------------------------------------------- *)
+(* Swaps, immutable fees, invariant growth, and protocol accounting          *)
+(* ------------------------------------------------------------------------- *)
+
+let test_bidirectional_swaps_fee_split_and_invariant =
+  let (pool, token_a, token_b) = setup_initialized_pool () in
+  let () = fund_trader_and_authorize pool.taddr token_a.taddr token_b.taddr in
+  let amount_in = 100000n in
+  let amount_out = Contract.quote_output amount_in initial_reserve initial_reserve in
+  let protocol_fee = Contract.protocol_fee amount_in in
+  let trader_b_before = token_balance token_b.taddr (trader ()) in
+  let swap_param : Contract.swap_param =
+    {
+      direction = A_to_b;
+      amount_in = amount_in;
+      min_amount_out = amount_out;
+      receiver = trader ();
+      deadline = future
+    } in
+  let _ : nat =
+    Test.Contract.transfer_exn
+      (Test.Typed_address.get_entrypoint "swap" pool.taddr)
+      swap_param
+      0tez in
+  let pool_storage : Contract.storage = Test.Typed_address.get_storage pool.taddr in
+  let old_k = initial_reserve * initial_reserve in
+  let new_k = pool_storage.reserve_a * pool_storage.reserve_b in
+  let () =
+    Assert.Error.assert (new_k >= old_k) "swap invariant must not decrease" in
+  let () =
+    assert_nat
+      "swap reserve A"
+      pool_storage.reserve_a
+      (initial_reserve + abs (amount_in - protocol_fee)) in
+  let () =
+    assert_nat
+      "swap reserve B"
+      pool_storage.reserve_b
+      (abs (initial_reserve - amount_out)) in
+  let () = assert_nat "swap protocol fee A" pool_storage.protocol_fees_a protocol_fee in
+  let () =
+    assert_nat
+      "swap recipient output"
+      (token_balance token_b.taddr (trader ()))
+      (trader_b_before + amount_out) in
+  let reverse_amount_in = 200000n in
+  let reverse_amount_out =
+    Contract.quote_output
+      reverse_amount_in
+      pool_storage.reserve_b
+      pool_storage.reserve_a in
+  let reverse_param : Contract.swap_param =
+    {
+      direction = B_to_a;
+      amount_in = reverse_amount_in;
+      min_amount_out = reverse_amount_out;
+      receiver = trader ();
+      deadline = future
+    } in
+  let _ : nat =
+    Test.Contract.transfer_exn
+      (Test.Typed_address.get_entrypoint "swap" pool.taddr)
+      reverse_param
+      0tez in
+  let final_storage : Contract.storage = Test.Typed_address.get_storage pool.taddr in
+  let final_k = final_storage.reserve_a * final_storage.reserve_b in
+  let () = Assert.Error.assert (final_k >= new_k) "reverse swap invariant decreased" in
+  let () =
+    assert_nat
+      "reverse swap protocol fee B"
+      final_storage.protocol_fees_b
+      (Contract.protocol_fee reverse_amount_in) in
+  assert_pool_solvency "bidirectional swap" pool.taddr token_a.taddr token_b.taddr
+
+let test_fee_constants_are_25_and_5_basis_points =
+  let () = assert_nat "LP fee" Contract.lp_fee_bps 25n in
+  let () = assert_nat "protocol fee" Contract.protocol_fee_bps 5n in
+  assert_nat "total fee" Contract.total_fee_bps 30n
+
+let test_quote_rounding_preserves_constant_product =
+  let reserve_in = 123456789n in
+  let reserve_out = 987654321n in
+  let check_amount (amount_in : nat) : unit =
+    let amount_out = Contract.quote_output amount_in reserve_in reserve_out in
+    let protocol_fee = Contract.protocol_fee amount_in in
+    let new_reserve_in = reserve_in + abs (amount_in - protocol_fee) in
+    let new_reserve_out = abs (reserve_out - amount_out) in
+    Assert.Error.assert
+      (new_reserve_in * new_reserve_out >= reserve_in * reserve_out)
+      "quote invariant decreased" in
+  let () = check_amount 1n in
+  let () = check_amount 10n in
+  let () = check_amount 9999n in
+  let () = check_amount 10000n in
+  let () = check_amount 1234567n in
+  check_amount 50000000n
+
+(* ------------------------------------------------------------------------- *)
+(* Liquidity lifecycle                                                       *)
+(* ------------------------------------------------------------------------- *)
+
+let test_add_and_remove_liquidity =
+  let (pool, token_a, token_b) = setup_initialized_pool () in
+  let () = fund_trader_and_authorize pool.taddr token_a.taddr token_b.taddr in
+  let () = Test.State.set_source (trader ()) in
+  let add_param : Contract.add_liquidity_param =
+    {
+      max_amount_a = 100000n;
+      max_amount_b = 100000n;
+      min_shares = 100000n;
+      receiver = trader ();
+      deadline = future
+    } in
+  let _ : nat =
+    Test.Contract.transfer_exn
+      (Test.Typed_address.get_entrypoint "add_liquidity" pool.taddr)
+      add_param
+      0tez in
+  let () = assert_nat "added LP shares" (pool_balance pool.taddr (trader ())) 100000n in
+  let remove_param : Contract.remove_liquidity_param =
+    {
+      shares = 100000n;
+      min_amount_a = 100000n;
+      min_amount_b = 100000n;
+      receiver = trader ();
+      deadline = future
+    } in
+  let _ : nat =
+    Test.Contract.transfer_exn
+      (Test.Typed_address.get_entrypoint "remove_liquidity" pool.taddr)
+      remove_param
+      0tez in
+  let pool_storage : Contract.storage = Test.Typed_address.get_storage pool.taddr in
+  let () = assert_nat "removed LP shares" (pool_balance pool.taddr (trader ())) 0n in
+  let () = assert_nat "lifecycle reserve A" pool_storage.reserve_a initial_reserve in
+  let () = assert_nat "lifecycle reserve B" pool_storage.reserve_b initial_reserve in
+  assert_pool_solvency
+    "liquidity lifecycle"
+    pool.taddr
+    token_a.taddr
+    token_b.taddr
+
+let test_pause_keeps_withdrawals_available =
+  let (pool, token_a, token_b) = setup_initialized_pool () in
+  let () = Test.State.set_source (admin ()) in
+  let _ : nat =
+    Test.Contract.transfer_exn
+      (Test.Typed_address.get_entrypoint "set_paused" pool.taddr)
+      true
+      0tez in
+  let swap_param : Contract.swap_param =
+    {
+      direction = A_to_b;
+      amount_in = 1000n;
+      min_amount_out = 1n;
+      receiver = admin ();
+      deadline = future
+    } in
+  let swap_result =
+    Test.Contract.transfer
+      (Test.Typed_address.get_entrypoint "swap" pool.taddr)
+      swap_param
+      0tez in
+  let () = assert_string_failure "paused swap" Contract.err_paused swap_result in
+  let remove_param : Contract.remove_liquidity_param =
+    {
+      shares = 1000n;
+      min_amount_a = 1000n;
+      min_amount_b = 1000n;
+      receiver = admin ();
+      deadline = future
+    } in
+  let _ : nat =
+    Test.Contract.transfer_exn
+      (Test.Typed_address.get_entrypoint "remove_liquidity" pool.taddr)
+      remove_param
+      0tez in
+  assert_pool_solvency
+    "paused withdrawal"
+    pool.taddr
+    token_a.taddr
+    token_b.taddr
+
+(* ------------------------------------------------------------------------- *)
+(* Fee claim and two-step management handoff                                 *)
+(* ------------------------------------------------------------------------- *)
+
+let test_fee_recipient_claims_verified_fee_balance =
+  let (pool, token_a, token_b) = setup_initialized_pool () in
+  let () = fund_trader_and_authorize pool.taddr token_a.taddr token_b.taddr in
+  let () = Test.State.set_source (trader ()) in
+  let amount_in = 100000n in
+  let swap_param : Contract.swap_param =
+    {
+      direction = A_to_b;
+      amount_in = amount_in;
+      min_amount_out = 1n;
+      receiver = trader ();
+      deadline = future
+    } in
+  let _ : nat =
+    Test.Contract.transfer_exn
+      (Test.Typed_address.get_entrypoint "swap" pool.taddr)
+      swap_param
+      0tez in
+  let expected_fee = Contract.protocol_fee amount_in in
+  let fee_balance_before = token_balance token_a.taddr (fee_recipient ()) in
+  let () = Test.State.set_source (fee_recipient ()) in
+  let _ : nat =
+    Test.Contract.transfer_exn
+      (Test.Typed_address.get_entrypoint "claim_protocol_fees" pool.taddr)
+      ()
+      0tez in
+  let pool_storage : Contract.storage = Test.Typed_address.get_storage pool.taddr in
+  let () = assert_nat "claimed fee storage" pool_storage.protocol_fees_a 0n in
+  let () =
+    assert_nat
+      "claimed fee recipient balance"
+      (token_balance token_a.taddr (fee_recipient ()))
+      (fee_balance_before + expected_fee) in
+  assert_pool_solvency "fee claim" pool.taddr token_a.taddr token_b.taddr
+
+let test_admin_handoff_requires_acceptance =
+  let (pool, _, _) = setup_initialized_pool () in
+  let () = Test.State.set_source (admin ()) in
+  let _ : nat =
+    Test.Contract.transfer_exn
+      (Test.Typed_address.get_entrypoint "propose_admin" pool.taddr)
+      (successor_admin ())
+      0tez in
+  let interim : Contract.storage = Test.Typed_address.get_storage pool.taddr in
+  let () =
+    Assert.Error.assert (interim.admin = admin ()) "admin changed before acceptance" in
+  let () = Test.State.set_source (successor_admin ()) in
+  let _ : nat =
+    Test.Contract.transfer_exn
+      (Test.Typed_address.get_entrypoint "accept_admin" pool.taddr)
+      ()
+      0tez in
+  let final_storage : Contract.storage = Test.Typed_address.get_storage pool.taddr in
+  let no_pending_admin =
+    match final_storage.pending_admin with
+    | None -> true
+    | Some _ -> false in
+  Assert.Error.assert
+    (final_storage.admin = successor_admin () && no_pending_admin)
+    "admin handoff failed"
+
+(* ------------------------------------------------------------------------- *)
+(* Callback authentication and bounded LP-token interface                    *)
+(* ------------------------------------------------------------------------- *)
+
+let test_unsolicited_callback_is_rejected =
+  let (pool, _, _) = setup_initialized_pool () in
+  let () = Test.State.set_source (trader ()) in
+  let response : Contract.balance_response =
+    {
+      request = {owner = Test.Typed_address.to_address pool.taddr; token_id = 0n};
+      balance = initial_reserve
+    } in
+  let result =
+    Test.Contract.transfer
+      (Test.Typed_address.get_entrypoint "receive_first_before" pool.taddr)
+      [response]
+      0tez in
+  assert_string_failure
+    "unsolicited callback"
+    Contract.err_invalid_callback
+    result
+
+let test_malformed_balance_delta_is_rejected =
+  let () = clean () in
+  let () = Test.State.set_source (trader ()) in
+  let asset_a : Contract.asset = {token_contract = trader (); token_id = 0n} in
+  let asset_b : Contract.asset = {token_contract = admin (); token_id = 1n} in
+  let first_leg : Contract.transfer_leg =
+    {
+      asset = asset_a;
+      from_ = trader ();
+      to_ = admin ();
+      amount = 100n;
+      mode = Inbound
+    } in
+  let pending : Contract.pending_action =
+    {
+      final_action =
+        Finalize_swap
+          {
+            direction = A_to_b;
+            amount_in = 100n;
+            amount_out = 90n;
+            protocol_fee = 0n
+          };
+      first_leg = first_leg;
+      second_leg = None;
+      phase = First_after;
+      observed_before = Some 1000n;
+      deadline = Some future
+    } in
+  let base_storage : Contract.storage =
+    Contract.build_storage
+      {
+        token_a = asset_a;
+        token_b = asset_b;
+        admin = admin ();
+        fee_recipient = fee_recipient ();
+        metadata = (Big_map.empty : (string, bytes) big_map);
+        token_metadata = lp_token_metadata ()
+      } in
+  let storage : Contract.storage =
+    {
+      base_storage with
+      reserve_a = 1000n;
+      reserve_b = 1000n;
+      total_supply = 1000n;
+      pending = Some pending
+    } in
+  let pool = Test.Originate.contract (contract_of Contract) storage 0tez in
+  let response : Contract.balance_response =
+    {
+      request = {owner = Test.Typed_address.to_address pool.taddr; token_id = 0n};
+      balance = 1099n
+    } in
+  let result =
+    Test.Contract.transfer
+      (Test.Typed_address.get_entrypoint "receive_first_after" pool.taddr)
+      [response]
+      0tez in
+  assert_string_failure
+    "malformed transfer delta"
+    Contract.err_invalid_balance_delta
+    result
+
+let test_lp_transfer_is_single_call_and_locked_minimum_cannot_move =
+  let (pool, _, _) = setup_initialized_pool () in
+  let () = Test.State.set_source (admin ()) in
+  let transfer : Contract.fa2_transfer =
+    [
+      {
+        from_ = admin ();
+        txs = [{to_ = trader (); token_id = 0n; amount = 1000n}]
+      }
+    ] in
+  let _ : nat =
+    Test.Contract.transfer_exn
+      (Test.Typed_address.get_entrypoint "transfer" pool.taddr)
+      transfer
+      0tez in
+  let () = assert_nat "LP transfer recipient" (pool_balance pool.taddr (trader ())) 1000n in
+  let batch : Contract.fa2_transfer =
+    [
+      {
+        from_ = admin ();
+        txs = [{to_ = trader (); token_id = 0n; amount = 1n}]
+      };
+      {
+        from_ = admin ();
+        txs = [{to_ = trader (); token_id = 0n; amount = 1n}]
+      }
+    ] in
+  let batch_result =
+    Test.Contract.transfer
+      (Test.Typed_address.get_entrypoint "transfer" pool.taddr)
+      batch
+      0tez in
+  assert_string_failure "LP transfer batch bound" Contract.err_invalid_callback batch_result


### PR DESCRIPTION
## Summary

- add a standalone, asset-agnostic FA2-to-FA2 constant-product pool
- fix fees at 25 bp for liquidity providers and 5 bp for the protocol
- integrate LP accounting and permanently lock the minimum initial liquidity
- verify every underlying transfer against authenticated before/after pool balances
- add pause-safe withdrawals, separate protocol-fee accounting, and two-step administrator handoff
- add environment-only deployment tooling with an offline Michelson storage-encoding test and an explicit mainnet confirmation guard
- add scoped CI, deployment documentation, and an internal security review

## Why

The repository needs a token-to-token pool that does not inherit unrelated native-XTZ, baker, auction, reward-bucket, flash-loan, or multi-pair custody responsibilities. This implementation isolates one immutable FA2 pair per deployment and keeps all live token, administrator, fee-recipient, and metadata values outside source control.

## Validation

- LIGO 1.11.5 compilation reproduced the checked-in Michelson byte-for-byte
- compiled artifact SHA-256: `e80be7e08aed3782c338472d1faa578d73719414f2b80254a10df5c7300f6268`
- encoded contract size: 18,999 bytes
- 12 end-to-end LIGO tests pass
- TypeScript type checking passes
- 7 deployment/configuration tests pass, including compiled-schema storage encoding
- `npm ci --ignore-scripts` succeeds
- `npm audit --omit=dev --audit-level=moderate` reports zero vulnerabilities for the deployment package

## Review and deployment gates

This remains a draft pending independent source and Michelson review. Before mainnet deployment:

- reproduce and approve the exact compiled artifact
- allowlist the exact two non-taxed FA2 contracts, token IDs, callback behavior, and administrative controls
- rehearse initialization, swaps in both directions, deposits, withdrawals, fee claims, pause behavior, and administrator acceptance on testnet
- confirm the final administrator and immutable fee recipient on-chain
- confirm UI/router pool allowlisting, deadline handling, and minimum-output handling

The integrated LP entrypoints intentionally accept singleton requests rather than advertising batch-complete FA2 behavior.