### PR TITLE
Add branded TEZEX 404 page

### DIFF
--- a/V2/tezex/public/404.html
+++ b/V2/tezex/public/404.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#090909" />
+    <meta name="robots" content="noindex" />
+    <link rel="icon" href="/assets/favicon.ico" />
+    <title>Page not found | TEZEX</title>
+    <script>
+      (function () {
+        var path = window.location.pathname;
+        var isAsset = /\.[a-z0-9]+$/i.test(path);
+        if (path !== "/" && !isAsset) {
+          window.location.replace("/#" + path + window.location.search);
+        }
+      })();
+    </script>
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        min-height: 100%;
+        margin: 0;
+      }
+      body {
+        display: grid;
+        place-items: center;
+        padding: 32px;
+        color: #f7f7f5;
+        background: #090909;
+        font-family: Arial, Helvetica, sans-serif;
+      }
+      main {
+        width: min(100%, 760px);
+      }
+      .brand {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        margin-bottom: 72px;
+        font-size: 24px;
+        font-weight: 600;
+        letter-spacing: 0.3em;
+      }
+      .brand img {
+        width: 42px;
+        height: 42px;
+      }
+      .eyebrow {
+        margin: 0 0 20px;
+        color: #858585;
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-size: 13px;
+        font-weight: 600;
+        letter-spacing: 0.18em;
+      }
+      h1 {
+        margin: 0;
+        font-size: clamp(52px, 10vw, 104px);
+        letter-spacing: -0.055em;
+        line-height: 0.96;
+      }
+      p {
+        max-width: 520px;
+        margin: 28px 0 44px;
+        color: #858585;
+        font-size: 19px;
+        line-height: 1.5;
+      }
+      a {
+        display: inline-flex;
+        min-height: 56px;
+        align-items: center;
+        gap: 18px;
+        padding: 0 28px;
+        border-radius: 999px;
+        color: #090909;
+        background: #f7f7f5;
+        font-size: 13px;
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-decoration: none;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <div class="brand">
+        <img src="/assets/favicon.ico" alt="" />
+        <span>TEZEX</span>
+      </div>
+      <p class="eyebrow">ERROR 404</p>
+      <h1>Page not found.</h1>
+      <p>The address may have changed, or the page may no longer exist.</p>
+      <a href="/#/home/swap"
+        >RETURN TO SWAP <span aria-hidden="true">→</span></a
+      >
+    </main>
+  </body>
+</html>

--- a/V2/tezex/src/components/ui/views/layout/index.tsx
+++ b/V2/tezex/src/components/ui/views/layout/index.tsx
@@ -25,6 +25,10 @@ export interface ILayout {
 export const Layout: FC<ILayout> = (props) => {
   const styles = useStyles(style);
   const location = useLocation();
+  const isStezRoute = location.pathname.startsWith("/stez");
+  const isTzktDataRoute =
+    location.pathname.startsWith("/home") ||
+    location.pathname.startsWith("/analytics");
   const [openMenu, setOpenMenu] = useState(false);
   const toggleMenu = useCallback(() => {
     setOpenMenu(!openMenu);
@@ -67,27 +71,28 @@ export const Layout: FC<ILayout> = (props) => {
         <Box sx={styles.mainWindow}>
           <MainWindow>{props.children}</MainWindow>
 
-          {/* Bottom space for bars or notification */}
-          <Box sx={styles.bottomSpace}>
-            <Typography sx={styles.bottomSpaceText}>
-              {location.pathname.startsWith("/stez") ? (
-                "sTEZ data read from the selected Tezos RPC"
-              ) : (
-                <>
-                  Data provided by
-                  <Link
-                    href="https://tzkt.io"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    sx={styles.bottomSpaceLink}
-                  >
-                    TzKT
-                  </Link>
-                  API
-                </>
-              )}
-            </Typography>
-          </Box>
+          {(isStezRoute || isTzktDataRoute) && (
+            <Box sx={styles.bottomSpace}>
+              <Typography sx={styles.bottomSpaceText}>
+                {isStezRoute ? (
+                  "sTEZ data read from the selected Tezos RPC"
+                ) : (
+                  <>
+                    Data provided by
+                    <Link
+                      href="https://tzkt.io"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      sx={styles.bottomSpaceLink}
+                    >
+                      TzKT
+                    </Link>
+                    API
+                  </>
+                )}
+              </Typography>
+            </Box>
+          )}
         </Box>
       </Box>
 

--- a/V2/tezex/src/index.tsx
+++ b/V2/tezex/src/index.tsx
@@ -6,13 +6,14 @@ import App from "./App";
 import reportWebVitals from "./reportWebVitals";
 import { SessionProvider } from "./contexts/session";
 import ReactDOM from "react-dom/client";
-import { createHashRouter, RouterProvider } from "react-router-dom";
+import { createHashRouter, Navigate, RouterProvider } from "react-router-dom";
 
 import { AppConfig } from "./types/general";
 import appConfig from "./config/app.json";
 import { Home } from "./pages/Home";
 import { Analytics } from "./pages/Analytics";
 import { Stez } from "./pages/Stez";
+import { NotFound } from "./pages/NotFound";
 import { ColorModeProvider } from "./contexts/color-mode";
 
 const router = createHashRouter([
@@ -20,6 +21,10 @@ const router = createHashRouter([
     path: "/",
     element: <App />,
     children: [
+      {
+        index: true,
+        element: <Navigate to="/home/swap" replace />,
+      },
       {
         path: "home/swap",
         element: <Home path="swap" />,
@@ -39,6 +44,10 @@ const router = createHashRouter([
       {
         path: "stez",
         element: <Stez />,
+      },
+      {
+        path: "*",
+        element: <NotFound />,
       },
     ],
   },

--- a/V2/tezex/src/pages/NotFound/index.test.tsx
+++ b/V2/tezex/src/pages/NotFound/index.test.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+import { NotFound } from ".";
+
+describe("NotFound", () => {
+  it("offers a clear route back into TEZEX", () => {
+    render(
+      <MemoryRouter initialEntries={["/missing-page"]}>
+        <NotFound />
+      </MemoryRouter>
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Empty sector." })
+    ).toBeInTheDocument();
+    expect(screen.getByText("/missing-page")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "BACK TO SWAP" })).toHaveAttribute(
+      "href",
+      "/home/swap"
+    );
+    expect(
+      screen.getByRole("img", {
+        name: "Survey reticle centred on empty sky",
+      })
+    ).toBeInTheDocument();
+  });
+});

--- a/V2/tezex/src/pages/NotFound/index.tsx
+++ b/V2/tezex/src/pages/NotFound/index.tsx
@@ -1,0 +1,152 @@
+import React, { FC } from "react";
+import { Link, useLocation } from "react-router-dom";
+
+import "./style.css";
+
+interface Star {
+  x: number;
+  y: number;
+  radius: number;
+  opacity: number;
+}
+
+const STARS: Star[] = (() => {
+  let seed = 20260730;
+  const stars: Star[] = [];
+  const random = () => {
+    seed = (seed * 1664525 + 1013904223) % 4294967296;
+    return seed / 4294967296;
+  };
+
+  for (let index = 0; index < 90; index += 1) {
+    const depth = random();
+    stars.push({
+      x: Number((random() * 100).toFixed(2)),
+      y: Number((random() * 100).toFixed(2)),
+      radius: Number(((0.4 + depth * 1.5) * 0.09).toFixed(3)),
+      opacity: Number((0.18 + depth * 0.55).toFixed(2)),
+    });
+  }
+
+  return stars;
+})();
+
+const SurveyReticle: FC = () => (
+  <svg
+    className="not-found__scope"
+    viewBox="0 0 240 240"
+    fill="none"
+    role="img"
+    aria-label="Survey reticle centred on empty sky"
+  >
+    <path
+      className="not-found__scope-frame"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      d="M22 62V22h40 M178 22h40v40 M218 178v40h-40 M62 218H22v-40"
+    />
+    <circle
+      className="not-found__scope-ring"
+      cx="120"
+      cy="120"
+      r="66"
+      strokeWidth="1"
+      strokeDasharray="1 7"
+    />
+    <g
+      className="not-found__scope-ticks"
+      strokeWidth="1.4"
+      strokeLinecap="round"
+    >
+      <line x1="120" y1="40" x2="120" y2="54" />
+      <line x1="120" y1="186" x2="120" y2="200" />
+      <line x1="40" y1="120" x2="54" y2="120" />
+      <line x1="186" y1="120" x2="200" y2="120" />
+    </g>
+    <g
+      className="not-found__scope-hairs"
+      strokeWidth="1.2"
+      strokeLinecap="round"
+    >
+      <line x1="120" y1="86" x2="120" y2="110" />
+      <line x1="120" y1="130" x2="120" y2="154" />
+      <line x1="86" y1="120" x2="110" y2="120" />
+      <line x1="130" y1="120" x2="154" y2="120" />
+    </g>
+    <g className="not-found__scope-sweep">
+      <line
+        x1="120"
+        y1="120"
+        x2="120"
+        y2="56"
+        stroke="currentColor"
+        strokeWidth="1.2"
+        strokeLinecap="round"
+        opacity=".55"
+      />
+    </g>
+  </svg>
+);
+
+export const NotFound: FC = () => {
+  const location = useLocation();
+
+  return (
+    <main className="not-found" aria-labelledby="not-found-title">
+      <svg
+        className="not-found__sky"
+        viewBox="0 0 100 100"
+        preserveAspectRatio="xMidYMid slice"
+        aria-hidden="true"
+      >
+        {STARS.map((star, index) => (
+          <circle
+            key={index}
+            cx={star.x}
+            cy={star.y}
+            r={star.radius}
+            fill="currentColor"
+            opacity={star.opacity}
+          />
+        ))}
+      </svg>
+
+      <div className="not-found__content">
+        <SurveyReticle />
+
+        <p className="not-found__status">NO OBJECT AT THIS COORDINATE</p>
+        <h1 id="not-found-title">Empty sector.</h1>
+        <p className="not-found__description">
+          The survey came back clean. There&apos;s no page at this address — it
+          may have moved to another orbit, or it was never charted.
+        </p>
+
+        <div className="not-found__telemetry" aria-label="Request telemetry">
+          <div className="not-found__telemetry-row">
+            <span>REQUESTED</span>
+            <strong>{location.pathname}</strong>
+          </div>
+          <div className="not-found__telemetry-row">
+            <span>RESPONSE</span>
+            <strong>404 — NOT FOUND</strong>
+          </div>
+          <div className="not-found__telemetry-row">
+            <span>SURVEY</span>
+            <strong>complete · 0 results</strong>
+          </div>
+        </div>
+
+        <div className="not-found__actions">
+          <Link className="not-found__button is-primary" to="/home/swap">
+            BACK TO SWAP
+          </Link>
+          <Link className="not-found__button is-secondary" to="/analytics">
+            VIEW ANALYTICS
+          </Link>
+        </div>
+      </div>
+
+      <p className="not-found__footer">TEZEX · DEEP FIELD SURVEY</p>
+    </main>
+  );
+};

--- a/V2/tezex/src/pages/NotFound/style.css
+++ b/V2/tezex/src/pages/NotFound/style.css
@@ -1,0 +1,304 @@
+.not-found {
+  --not-found-deep: #0d0f13;
+  --not-found-reticle: #5c6470;
+  position: relative;
+  min-height: calc(100svh - 76px);
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  justify-content: center;
+  overflow: hidden;
+  padding: 42px 20px 28px;
+  color: var(--tezex-text);
+  background: var(--tezex-bg);
+}
+
+:root[data-theme="light"] .not-found {
+  --not-found-deep: #efefec;
+  --not-found-reticle: #9aa0a8;
+}
+
+.not-found__sky {
+  position: absolute;
+  z-index: 0;
+  inset: -4%;
+  width: 108%;
+  height: 108%;
+  color: var(--tezex-text);
+  pointer-events: none;
+}
+
+.not-found__content,
+.not-found__footer {
+  position: relative;
+  z-index: 1;
+}
+
+.not-found__content {
+  width: min(100%, 430px);
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  justify-content: center;
+  animation: not-found-enter 340ms cubic-bezier(0.22, 0.8, 0.24, 1) both;
+}
+
+.not-found__scope {
+  width: min(360px, 78vw);
+  color: var(--not-found-reticle);
+}
+
+.not-found__scope-frame,
+.not-found__scope-hairs {
+  stroke: var(--not-found-reticle);
+}
+
+.not-found__scope-ticks {
+  stroke: var(--not-found-reticle);
+  opacity: 0.75;
+}
+
+.not-found__scope-ring {
+  stroke: var(--not-found-reticle);
+  opacity: 0.5;
+  transform-origin: 120px 120px;
+}
+
+.not-found__scope-sweep {
+  color: var(--not-found-reticle);
+  transform-origin: 120px 120px;
+}
+
+.not-found__status {
+  margin: 24px 0 0;
+  color: var(--tezex-muted);
+  font-family: "Red Hat Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.23em;
+  text-align: center;
+}
+
+.not-found h1 {
+  margin: 12px 0 0;
+  color: var(--tezex-text);
+  font-size: 27px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+  text-align: center;
+}
+
+.not-found__description {
+  max-width: 420px;
+  margin: 12px 0 0;
+  color: var(--tezex-muted);
+  font-family: "Red Hat Mono", monospace;
+  font-size: 12.5px;
+  line-height: 1.8;
+  text-align: center;
+}
+
+.not-found__telemetry {
+  width: min(430px, 92vw);
+  margin-top: 28px;
+  padding: 6px 16px;
+  border: 1px solid var(--tezex-line);
+  border-radius: 16px;
+  background: var(--not-found-deep);
+}
+
+.not-found__telemetry-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 9px 0;
+  border-bottom: 1px dashed var(--tezex-line);
+  font-family: "Red Hat Mono", monospace;
+  font-size: 11.5px;
+}
+
+.not-found__telemetry-row:last-child {
+  border-bottom: 0;
+}
+
+.not-found__telemetry-row span {
+  color: var(--tezex-muted);
+  letter-spacing: 0.08em;
+  white-space: nowrap;
+}
+
+.not-found__telemetry-row strong {
+  overflow-wrap: anywhere;
+  color: var(--tezex-text);
+  font-weight: 500;
+  text-align: right;
+}
+
+.not-found__actions {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  margin-top: 26px;
+}
+
+.not-found__button {
+  display: inline-flex;
+  min-height: 46px;
+  align-items: center;
+  justify-content: center;
+  padding: 0 26px;
+  border: 1.5px solid var(--tezex-text);
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-decoration: none;
+  transition: color 180ms ease, background-color 180ms ease,
+    transform 180ms ease;
+}
+
+.not-found__button.is-primary {
+  color: var(--tezex-bg);
+  background: var(--tezex-text);
+}
+
+.not-found__button.is-secondary {
+  color: var(--tezex-text);
+  background: transparent;
+}
+
+.not-found__button:hover {
+  transform: translateY(-1px);
+}
+
+.not-found__button.is-primary:hover {
+  color: var(--tezex-text);
+  background: transparent;
+}
+
+.not-found__button.is-secondary:hover {
+  color: var(--tezex-bg);
+  background: var(--tezex-text);
+}
+
+.not-found__button:focus-visible {
+  outline: 2px solid var(--tezex-text);
+  outline-offset: 3px;
+}
+
+.not-found__footer {
+  margin: 42px 0 0;
+  color: var(--tezex-faint);
+  font-family: "Red Hat Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.09em;
+  text-align: center;
+}
+
+@media (max-width: 700px) {
+  .not-found {
+    min-height: calc(100svh - 68px);
+    justify-content: flex-start;
+    padding: 26px 14px 24px;
+  }
+
+  .not-found__scope {
+    width: min(286px, 74vw);
+  }
+
+  .not-found__status {
+    margin-top: 14px;
+    font-size: 10px;
+  }
+
+  .not-found h1 {
+    margin-top: 10px;
+    font-size: 22px;
+  }
+
+  .not-found__description {
+    font-size: 12px;
+  }
+
+  .not-found__telemetry {
+    margin-top: 24px;
+  }
+
+  .not-found__actions {
+    width: 100%;
+  }
+
+  .not-found__button {
+    flex: 1 1 0;
+    min-width: 0;
+    padding: 0 14px;
+    font-size: 12px;
+  }
+
+  .not-found__footer {
+    margin-top: 34px;
+    font-size: 10px;
+  }
+}
+
+@media (max-width: 360px) {
+  .not-found__actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .not-found__sky {
+    animation: not-found-drift 120s ease-in-out infinite alternate;
+  }
+
+  .not-found__scope-sweep {
+    animation: not-found-sweep 7s linear infinite;
+  }
+
+  .not-found__scope-ring {
+    animation: not-found-breathe 7s ease-in-out infinite;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .not-found__content,
+  .not-found__button {
+    animation: none;
+    transition: none;
+  }
+}
+
+@keyframes not-found-enter {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes not-found-drift {
+  to {
+    transform: translate3d(-2.5%, 1.6%, 0);
+  }
+}
+
+@keyframes not-found-sweep {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes not-found-breathe {
+  0%,
+  100% {
+    opacity: 0.25;
+  }
+  50% {
+    opacity: 0.6;
+  }
+}


### PR DESCRIPTION
## What changed
- add the branded deep-field 404 experience for unknown application routes
- redirect direct missing URLs into the application fallback
- keep route-specific data attribution off error pages
- add regression coverage for the recovery actions

## Why
Unknown and direct URLs currently expose a generic router error. This gives people a clear, branded path back to the swap or analytics experience.

## Validation
- `npm run verify`
- 21 test suites and 64 tests passed
- production build completed successfully
- desktop and mobile visual QA completed