### PR TITLE
Harden LQT minimum liquidity lifecycle

### DIFF
--- a/.github/workflows/dex-contract-ci.yml
+++ b/.github/workflows/dex-contract-ci.yml
@@ -39,6 +39,18 @@ jobs:
             -v "$RUNNER_TEMP/tezex-contracts:/out" \
             -w /project \
             ligolang/ligo:1.11.5 \
+            compile contract dex/contracts/dexter.mligo -o /out/pool.tz -D DEPLOY
+          docker run --rm \
+            -v "$PWD:/project" \
+            -v "$RUNNER_TEMP/tezex-contracts:/out" \
+            -w /project \
+            ligolang/ligo:1.11.5 \
+            compile contract dex/contracts/helpers/dexter_fa2.mligo -o /out/pool_fa2.tz -D DEPLOY
+          docker run --rm \
+            -v "$PWD:/project" \
+            -v "$RUNNER_TEMP/tezex-contracts:/out" \
+            -w /project \
+            ligolang/ligo:1.11.5 \
             compile contract dex/contracts/dexter_mod.mligo -o /out/pool_mod.tz -D DEPLOY
           docker run --rm \
             -v "$PWD:/project" \
@@ -50,10 +62,14 @@ jobs:
       - name: Verify checked-in Michelson artifacts
         run: |
           cmp "$RUNNER_TEMP/tezex-contracts/lqt.tz" dex/compiled_contracts/lqt.tz
+          cmp "$RUNNER_TEMP/tezex-contracts/pool.tz" dex/compiled_contracts/pool.tz
+          cmp "$RUNNER_TEMP/tezex-contracts/pool_fa2.tz" dex/compiled_contracts/pool_fa2.tz
           cmp "$RUNNER_TEMP/tezex-contracts/pool_mod.tz" dex/compiled_contracts/pool_mod.tz
           cmp "$RUNNER_TEMP/tezex-contracts/pool_fa2_mod.tz" dex/compiled_contracts/pool_fa2_mod.tz
           sha256sum \
             dex/compiled_contracts/lqt.tz \
+            dex/compiled_contracts/pool.tz \
+            dex/compiled_contracts/pool_fa2.tz \
             dex/compiled_contracts/pool_mod.tz \
             dex/compiled_contracts/pool_fa2_mod.tz
 
@@ -62,6 +78,18 @@ jobs:
           docker run --rm -v "$PWD:/project" -w /project
           ligolang/ligo:1.11.5
           run test dex/tests/lqt_fa12.test.mligo
+
+      - name: Test base FA1.2 pool
+        run: >-
+          docker run --rm -v "$PWD:/project" -w /project
+          ligolang/ligo:1.11.5
+          run test dex/tests/dexter_v2.test.mligo
+
+      - name: Test base FA2 pool
+        run: >-
+          docker run --rm -v "$PWD:/project" -w /project
+          ligolang/ligo:1.11.5
+          run test dex/tests/dexter_fa2.test.mligo
 
       - name: Test modified FA1.2 pool
         run: >-

--- a/.github/workflows/dex-contract-ci.yml
+++ b/.github/workflows/dex-contract-ci.yml
@@ -1,0 +1,103 @@
+name: DEX contract release gate
+
+on:
+  pull_request:
+    paths:
+      - "dex/**"
+      - ".github/workflows/dex-contract-ci.yml"
+  push:
+    branches:
+      - trunk
+    paths:
+      - "dex/**"
+      - ".github/workflows/dex-contract-ci.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  contracts:
+    name: Compile and test contracts
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Compile release contracts
+        run: |
+          mkdir -p "$RUNNER_TEMP/tezex-contracts"
+          docker run --rm \
+            -v "$PWD:/project" \
+            -v "$RUNNER_TEMP/tezex-contracts:/out" \
+            -w /project \
+            ligolang/ligo:1.11.5 \
+            compile contract dex/contracts/lqt_fa12.mligo -o /out/lqt.tz
+          docker run --rm \
+            -v "$PWD:/project" \
+            -v "$RUNNER_TEMP/tezex-contracts:/out" \
+            -w /project \
+            ligolang/ligo:1.11.5 \
+            compile contract dex/contracts/dexter_mod.mligo -o /out/pool_mod.tz -D DEPLOY
+          docker run --rm \
+            -v "$PWD:/project" \
+            -v "$RUNNER_TEMP/tezex-contracts:/out" \
+            -w /project \
+            ligolang/ligo:1.11.5 \
+            compile contract dex/contracts/helpers/dexter_mod_fa2.mligo -o /out/pool_fa2_mod.tz -D DEPLOY
+
+      - name: Verify checked-in Michelson artifacts
+        run: |
+          cmp "$RUNNER_TEMP/tezex-contracts/lqt.tz" dex/compiled_contracts/lqt.tz
+          cmp "$RUNNER_TEMP/tezex-contracts/pool_mod.tz" dex/compiled_contracts/pool_mod.tz
+          cmp "$RUNNER_TEMP/tezex-contracts/pool_fa2_mod.tz" dex/compiled_contracts/pool_fa2_mod.tz
+          sha256sum \
+            dex/compiled_contracts/lqt.tz \
+            dex/compiled_contracts/pool_mod.tz \
+            dex/compiled_contracts/pool_fa2_mod.tz
+
+      - name: Test LQT contract
+        run: >-
+          docker run --rm -v "$PWD:/project" -w /project
+          ligolang/ligo:1.11.5
+          run test dex/tests/lqt_fa12.test.mligo
+
+      - name: Test modified FA1.2 pool
+        run: >-
+          docker run --rm -v "$PWD:/project" -w /project
+          ligolang/ligo:1.11.5
+          run test dex/tests/dexter_mod.test.mligo
+
+      - name: Test modified FA2 pool
+        run: >-
+          docker run --rm -v "$PWD:/project" -w /project
+          ligolang/ligo:1.11.5
+          run test dex/tests/dexter_mod_fa2.test.mligo
+
+  deployment-scripts:
+    name: Test deployment scripts
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: dex/scripts
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: dex/scripts/package-lock.json
+
+      - name: Install locked dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Type-check
+        run: npm run typecheck
+
+      - name: Run tests
+        run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,7 @@ dist
 
 .vscode
 .idea
+.ligo/
 
 build/
 tmp/

--- a/dex/LQT_SECURITY_REVIEW.md
+++ b/dex/LQT_SECURITY_REVIEW.md
@@ -1,0 +1,56 @@
+# LQT and minimum-liquidity security review
+
+Date: 2026-07-30
+
+Scope: `dex/contracts/lqt_fa12.mligo`, the modified FA1.2/FA2 pool liquidity lifecycle, compiled artifacts, tests, and deployment allocation
+
+Compiler: LIGO 1.11.5
+
+## Reproducible release artifacts
+
+| Artifact | SHA-256 |
+| --- | --- |
+| `compiled_contracts/lqt.tz` | `2df971245f3d468ee2668e1ed48797852eedd280348c753e9f2cd1d1bdf23921` |
+| `compiled_contracts/pool_mod.tz` | `1558821ba6bbdb4cee16363e7a4c95d85b02c80d396b08f09c6988eb7df0eab8` |
+| `compiled_contracts/pool_fa2_mod.tz` | `b75892d1c94b13adf5b6f7ad8ce2fe7e135adc30632f01e6f26f60c0c7868519` |
+
+The contract CI rebuilds these files with the pinned compiler and compares the generated Michelson byte-for-byte with the checked-in release artifacts. Modified pools are compiled with the `DEPLOY` define so their native XTZ receiver is emitted as `%default`.
+
+## Summary
+
+This remediation completes the remaining liquidity-token lifecycle work for the modified XTZ-to-token pools. Initial LQT supply must exceed 1,000 units. Exactly 1,000 units are assigned to the DEX address at LQT origination, and the modified pool refuses any withdrawal that would reduce total supply below that floor.
+
+The floor preserves a nonzero proportional reserve position after the final ordinary provider exits. It also allows later liquidity additions to use the remaining reserve ratio instead of leaving a zero-reserve contract that cannot safely restart.
+
+## Security decisions
+
+| ID | Risk | Resolution |
+| --- | --- | --- |
+| LQT-01 | The final provider burns all LQT and leaves an unrecoverable zero-reserve pool. | Modified pools enforce a 1,000-unit minimum, and deployment assigns those units to the DEX address. |
+| LQT-02 | A malformed administrative burn reflects a negative total supply through `abs`, increasing or corrupting supply. | Both the target balance and total supply now use checked `is_nat` subtraction and fail on underflow. |
+| LQT-03 | XTZ attached to an FA1.2 entrypoint becomes trapped. | Every LQT entrypoint rejects nonzero transferred XTZ. |
+| LQT-04 | Deployment announces a locked floor without actually allocating it. | Post-deployment verification reads both the DEX-held locked balance and provider balance from the originated LQT ledger. |
+| LQT-05 | Seeds are too small to create both locked and ordinary liquidity. | Deployment fails before origination unless calculated initial LQT is greater than 1,000. |
+
+## Invariants
+
+For an active modified pool:
+
+```text
+lqtTotal >= 1,000
+actual LQT total_supply = pool lqtTotal
+initial DEX LQT balance = 1,000
+initial provider LQT balance = total_supply - 1,000
+```
+
+After any successful withdrawal:
+
+```text
+new lqtTotal >= 1,000
+new XTZ reserve > 0
+new token reserve > 0
+```
+
+## Residual requirements
+
+The LQT administrator must remain the corresponding immutable DEX contract. The exact source and Michelson artifacts still require independent review and testnet lifecycle rehearsal before mainnet deployment. Deployment-specific addresses and roles remain environment or release-manifest values and are not compiled into the contracts.

--- a/dex/LQT_SECURITY_REVIEW.md
+++ b/dex/LQT_SECURITY_REVIEW.md
@@ -11,8 +11,8 @@ Compiler: LIGO 1.11.5
 | Artifact | SHA-256 |
 | --- | --- |
 | `compiled_contracts/lqt.tz` | `2df971245f3d468ee2668e1ed48797852eedd280348c753e9f2cd1d1bdf23921` |
-| `compiled_contracts/pool_mod.tz` | `1558821ba6bbdb4cee16363e7a4c95d85b02c80d396b08f09c6988eb7df0eab8` |
-| `compiled_contracts/pool_fa2_mod.tz` | `b75892d1c94b13adf5b6f7ad8ce2fe7e135adc30632f01e6f26f60c0c7868519` |
+| `compiled_contracts/pool_mod.tz` | `036cd191ae1a7c4a9594604b6d7a57045c8ae091e1256a32a8ba9a0d858cfd0e` |
+| `compiled_contracts/pool_fa2_mod.tz` | `6b69085ee3bf86c7c9cda562748bf3ddd8e8890fbbdb6dea3d1d5fc36e82cec9` |
 
 The contract CI rebuilds these files with the pinned compiler and compares the generated Michelson byte-for-byte with the checked-in release artifacts. Modified pools are compiled with the `DEPLOY` define so their native XTZ receiver is emitted as `%default`.
 

--- a/dex/README.md
+++ b/dex/README.md
@@ -55,6 +55,8 @@ pass.
 - Minted when liquidity is added
 - Burned when liquidity is removed
 - Represents proportional ownership of the pool
+- Rejects attached XTZ and fails closed if a burn would underflow total supply
+- Modified pools enforce an immutable 1,000-unit permanent liquidity floor
 
 ## Prerequisites
 
@@ -115,8 +117,11 @@ math using the following formula, rounded down:
 ```
 lqt = sqrt(xtz_seed * token_seed)
 ``` 
-This amount will be minted to the final **MANAGER** address (see .env.example).
-Consider burning some initial liquidity (sending to a null address) to ensure the pool is never fully depleted.
+For every deployment, 1,000 LQT units are assigned to the DEX address and are
+permanently excluded from ordinary withdrawals. The remainder is assigned to
+the final **MANAGER** address (see `.env.example`). Initial LQT must therefore
+exceed 1,000 units. Modified pools also enforce the floor in `removeLiquidity`
+and expose it through `get_minimum_lqt`.
 
 
 This will:
@@ -126,8 +131,8 @@ This will:
 4. In one atomic operation group, link the LQT address, fund both reserves,
    synchronize the token pool, activate a modified pool, and transfer DEX
    management from the deployment signer to `MANAGER`
-5. Verify the resulting on-chain addresses, reserves, balances, LQT supply, and
-   activation state
+5. Verify the resulting on-chain addresses, reserves, balances, LQT supply,
+   permanent locked balance, provider balance, and activation state
 6. Save the exact integer configuration and initialization operation hash to
    `deployments/testnet-latest.json`
 

--- a/dex/compiled_contracts/lqt.tz
+++ b/dex/compiled_contracts/lqt.tz
@@ -14,9 +14,26 @@
                       (pair (nat %total_supply)
                             (pair (big_map %metadata string bytes)
                                   (big_map %token_metadata nat (pair (nat %token_id) (map %token_info string bytes)))))))) ;
-  code { UNPAIR ;
+  code { LAMBDA
+           unit
+           unit
+           { DROP ;
+             PUSH string "LQT_NON_PAYABLE" ;
+             PUSH mutez 0 ;
+             AMOUNT ;
+             COMPARE ;
+             EQ ;
+             IF { DROP } { FAILWITH } ;
+             UNIT } ;
+         SWAP ;
+         UNPAIR ;
          IF_LEFT
-           { DUP 2 ;
+           { UNIT ;
+             DIG 3 ;
+             SWAP ;
+             EXEC ;
+             DROP ;
+             DUP 2 ;
              NIL operation ;
              DIG 2 ;
              CDR ;
@@ -26,7 +43,12 @@
              TRANSFER_TOKENS ;
              CONS }
            { IF_LEFT
-               { DUP 2 ;
+               { UNIT ;
+                 DIG 3 ;
+                 SWAP ;
+                 EXEC ;
+                 DROP ;
+                 DUP 2 ;
                  NIL operation ;
                  DUP 3 ;
                  CDR ;
@@ -40,7 +62,12 @@
                  TRANSFER_TOKENS ;
                  CONS }
                { IF_LEFT
-                   { DUP 2 ;
+                   { UNIT ;
+                     DIG 3 ;
+                     SWAP ;
+                     EXEC ;
+                     DROP ;
+                     DUP 2 ;
                      NIL operation ;
                      DUP 3 ;
                      CDR ;
@@ -54,7 +81,12 @@
                      TRANSFER_TOKENS ;
                      CONS }
                    { IF_LEFT
-                       { DUP 2 ;
+                       { UNIT ;
+                         DIG 3 ;
+                         SWAP ;
+                         EXEC ;
+                         DROP ;
+                         DUP 2 ;
                          GET 5 ;
                          SENDER ;
                          COMPARE ;
@@ -78,7 +110,8 @@
                          DUP 4 ;
                          GET 7 ;
                          ADD ;
-                         ABS ;
+                         ISNAT ;
+                         IF_NONE { PUSH string "LQT_SUPPLY_UNDERFLOW" ; FAILWITH } {} ;
                          DIG 3 ;
                          DUP ;
                          CAR ;
@@ -93,7 +126,12 @@
                          SWAP ;
                          UPDATE 7 }
                        { IF_LEFT
-                           { DUP 2 ;
+                           { UNIT ;
+                             DIG 3 ;
+                             SWAP ;
+                             EXEC ;
+                             DROP ;
+                             DUP 2 ;
                              GET 3 ;
                              DUP 2 ;
                              CAR ;
@@ -124,7 +162,12 @@
                              DIG 3 ;
                              UPDATE ;
                              UPDATE 3 }
-                           { DUP 2 ;
+                           { UNIT ;
+                             DIG 3 ;
+                             SWAP ;
+                             EXEC ;
+                             DROP ;
+                             DUP 2 ;
                              GET 3 ;
                              DUP 3 ;
                              CAR ;

--- a/dex/compiled_contracts/pool_fa2_mod.tz
+++ b/dex/compiled_contracts/pool_fa2_mod.tz
@@ -170,11 +170,11 @@
                                    COMPARE ;
                                    NEQ ;
                                    IF { PUSH nat 50 ; FAILWITH }
-                                      { PUSH nat 0 ;
+                                      { PUSH nat 1000 ;
                                         DUP 2 ;
                                         GET 5 ;
                                         COMPARE ;
-                                        EQ ;
+                                        LE ;
                                         PUSH nat 0 ;
                                         DUP 3 ;
                                         CAR ;
@@ -244,11 +244,11 @@
                                                       GET 3 ;
                                                       COMPARE ;
                                                       NEQ ;
-                                                      PUSH nat 0 ;
+                                                      PUSH nat 1000 ;
                                                       DUP 6 ;
                                                       GET 4 ;
                                                       COMPARE ;
-                                                      EQ ;
+                                                      LE ;
                                                       PUSH nat 0 ;
                                                       DUP 7 ;
                                                       GET 3 ;
@@ -295,11 +295,11 @@
                                  DUP 6 ;
                                  GET 11 ;
                                  IF { PUSH nat 2 ; FAILWITH }
-                                    { PUSH nat 0 ;
+                                    { PUSH nat 1000 ;
                                       DUP 7 ;
                                       GET 5 ;
                                       COMPARE ;
-                                      GT ;
+                                      GE ;
                                       PUSH nat 0 ;
                                       DUP 8 ;
                                       CAR ;
@@ -595,11 +595,11 @@
                                                              DUP 5 ;
                                                              GET 11 ;
                                                              IF { PUSH nat 2 ; FAILWITH }
-                                                                { PUSH nat 0 ;
+                                                                { PUSH nat 1000 ;
                                                                   DUP 6 ;
                                                                   GET 5 ;
                                                                   COMPARE ;
-                                                                  GT ;
+                                                                  GE ;
                                                                   PUSH nat 0 ;
                                                                   DUP 7 ;
                                                                   CAR ;
@@ -732,11 +732,11 @@
                                                                  DUP 4 ;
                                                                  GET 11 ;
                                                                  IF { PUSH nat 2 ; FAILWITH }
-                                                                    { PUSH nat 0 ;
+                                                                    { PUSH nat 1000 ;
                                                                       DUP 5 ;
                                                                       GET 5 ;
                                                                       COMPARE ;
-                                                                      GT ;
+                                                                      GE ;
                                                                       PUSH nat 0 ;
                                                                       DUP 6 ;
                                                                       CAR ;
@@ -855,11 +855,11 @@
                                                                      DUP 6 ;
                                                                      GET 11 ;
                                                                      IF { PUSH nat 2 ; FAILWITH }
-                                                                        { PUSH nat 0 ;
+                                                                        { PUSH nat 1000 ;
                                                                           DUP 7 ;
                                                                           GET 5 ;
                                                                           COMPARE ;
-                                                                          GT ;
+                                                                          GE ;
                                                                           PUSH nat 0 ;
                                                                           DUP 8 ;
                                                                           CAR ;
@@ -923,6 +923,11 @@
                                                                                                    SUB ;
                                                                                                    ISNAT ;
                                                                                                    IF_NONE { PUSH nat 14 ; FAILWITH } {} ;
+                                                                                                   PUSH nat 1000 ;
+                                                                                                   DUP 2 ;
+                                                                                                   COMPARE ;
+                                                                                                   LT ;
+                                                                                                   IF { PUSH nat 51 ; FAILWITH } {} ;
                                                                                                    DUP 2 ;
                                                                                                    DUP 7 ;
                                                                                                    CAR ;
@@ -1006,11 +1011,11 @@
                                                                      DUP 5 ;
                                                                      GET 11 ;
                                                                      IF { PUSH nat 2 ; FAILWITH }
-                                                                        { PUSH nat 0 ;
+                                                                        { PUSH nat 1000 ;
                                                                           DUP 6 ;
                                                                           GET 5 ;
                                                                           COMPARE ;
-                                                                          GT ;
+                                                                          GE ;
                                                                           PUSH nat 0 ;
                                                                           DUP 7 ;
                                                                           CAR ;
@@ -1138,15 +1143,16 @@
          IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
          PAIR } ;
   view "get_lqt_total" unit nat { GET 7 } ;
+  view "get_minimum_lqt" unit nat { DROP ; PUSH nat 1000 } ;
   view "is_active"
        unit
        bool
        { CDR ;
-         PUSH nat 0 ;
+         PUSH nat 1000 ;
          DUP 2 ;
          GET 5 ;
          COMPARE ;
-         GT ;
+         GE ;
          PUSH nat 0 ;
          DUP 3 ;
          CAR ;

--- a/dex/compiled_contracts/pool_mod.tz
+++ b/dex/compiled_contracts/pool_mod.tz
@@ -161,11 +161,11 @@
                                    COMPARE ;
                                    NEQ ;
                                    IF { PUSH nat 50 ; FAILWITH }
-                                      { PUSH nat 0 ;
+                                      { PUSH nat 1000 ;
                                         DUP 2 ;
                                         GET 5 ;
                                         COMPARE ;
-                                        EQ ;
+                                        LE ;
                                         PUSH nat 0 ;
                                         DUP 3 ;
                                         CAR ;
@@ -235,11 +235,11 @@
                                                       GET 3 ;
                                                       COMPARE ;
                                                       NEQ ;
-                                                      PUSH nat 0 ;
+                                                      PUSH nat 1000 ;
                                                       DUP 6 ;
                                                       GET 4 ;
                                                       COMPARE ;
-                                                      EQ ;
+                                                      LE ;
                                                       PUSH nat 0 ;
                                                       DUP 7 ;
                                                       GET 3 ;
@@ -286,11 +286,11 @@
                                  DUP 6 ;
                                  GET 11 ;
                                  IF { PUSH nat 2 ; FAILWITH }
-                                    { PUSH nat 0 ;
+                                    { PUSH nat 1000 ;
                                       DUP 7 ;
                                       GET 5 ;
                                       COMPARE ;
-                                      GT ;
+                                      GE ;
                                       PUSH nat 0 ;
                                       DUP 8 ;
                                       CAR ;
@@ -554,11 +554,11 @@
                                                              DUP 5 ;
                                                              GET 11 ;
                                                              IF { PUSH nat 2 ; FAILWITH }
-                                                                { PUSH nat 0 ;
+                                                                { PUSH nat 1000 ;
                                                                   DUP 6 ;
                                                                   GET 5 ;
                                                                   COMPARE ;
-                                                                  GT ;
+                                                                  GE ;
                                                                   PUSH nat 0 ;
                                                                   DUP 7 ;
                                                                   CAR ;
@@ -683,11 +683,11 @@
                                                                  DUP 4 ;
                                                                  GET 11 ;
                                                                  IF { PUSH nat 2 ; FAILWITH }
-                                                                    { PUSH nat 0 ;
+                                                                    { PUSH nat 1000 ;
                                                                       DUP 5 ;
                                                                       GET 5 ;
                                                                       COMPARE ;
-                                                                      GT ;
+                                                                      GE ;
                                                                       PUSH nat 0 ;
                                                                       DUP 6 ;
                                                                       CAR ;
@@ -798,11 +798,11 @@
                                                                      DUP 6 ;
                                                                      GET 11 ;
                                                                      IF { PUSH nat 2 ; FAILWITH }
-                                                                        { PUSH nat 0 ;
+                                                                        { PUSH nat 1000 ;
                                                                           DUP 7 ;
                                                                           GET 5 ;
                                                                           COMPARE ;
-                                                                          GT ;
+                                                                          GE ;
                                                                           PUSH nat 0 ;
                                                                           DUP 8 ;
                                                                           CAR ;
@@ -866,6 +866,11 @@
                                                                                                    SUB ;
                                                                                                    ISNAT ;
                                                                                                    IF_NONE { PUSH nat 14 ; FAILWITH } {} ;
+                                                                                                   PUSH nat 1000 ;
+                                                                                                   DUP 2 ;
+                                                                                                   COMPARE ;
+                                                                                                   LT ;
+                                                                                                   IF { PUSH nat 51 ; FAILWITH } {} ;
                                                                                                    DUP 2 ;
                                                                                                    DUP 7 ;
                                                                                                    CAR ;
@@ -941,11 +946,11 @@
                                                                      DUP 5 ;
                                                                      GET 11 ;
                                                                      IF { PUSH nat 2 ; FAILWITH }
-                                                                        { PUSH nat 0 ;
+                                                                        { PUSH nat 1000 ;
                                                                           DUP 6 ;
                                                                           GET 5 ;
                                                                           COMPARE ;
-                                                                          GT ;
+                                                                          GE ;
                                                                           PUSH nat 0 ;
                                                                           DUP 7 ;
                                                                           CAR ;
@@ -1065,15 +1070,16 @@
          IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
          PAIR } ;
   view "get_lqt_total" unit nat { GET 7 } ;
+  view "get_minimum_lqt" unit nat { DROP ; PUSH nat 1000 } ;
   view "is_active"
        unit
        bool
        { CDR ;
-         PUSH nat 0 ;
+         PUSH nat 1000 ;
          DUP 2 ;
          GET 5 ;
          COMPARE ;
-         GT ;
+         GE ;
          PUSH nat 0 ;
          DUP 3 ;
          CAR ;

--- a/dex/contracts/dexter_mod.mligo
+++ b/dex/contracts/dexter_mod.mligo
@@ -173,6 +173,7 @@ module Dexter = struct
   [@inline] let error_LQT_CONTRACT_MUST_HAVE_A_GET_TOTAL_SUPPLY_ENTRYPOINT = 48n
   [@inline] let error_INVALID_ACTIVATION_CALLBACK = 49n
   [@inline] let error_LQT_TOTAL_MISMATCH = 50n
+  [@inline] let error_MINIMUM_LQT_MUST_REMAIN_LOCKED = 51n
 
   // =============================================================================
   // Functions
@@ -229,6 +230,7 @@ module Dexter = struct
   [@inline] let protocol_fee_bp : nat = 5n
   [@inline] let total_fee_bp : nat = 30n
   [@inline] let swap_fee_numerator : nat = 997n
+  [@inline] let minimum_lqt : nat = 1000n
 
   [@inline]
   let compute_protocol_fee (amount_nat : nat) : nat =
@@ -239,7 +241,7 @@ module Dexter = struct
       storage.active
       && storage.xtzPool > 0mutez
       && storage.tokenPool > 0n
-      && storage.lqtTotal > 0n
+      && storage.lqtTotal >= minimum_lqt
 
   // =============================================================================
   // Entrypoint Functions
@@ -321,6 +323,10 @@ module Dexter = struct
                   // This check should be unecessary, the fa12 logic normally takes care of it
                   | None -> (failwith error_CANNOT_BURN_MORE_THAN_THE_TOTAL_AMOUNT_OF_LQT : nat)
                   | Some n -> n in
+              let () =
+                  if new_lqtTotal < minimum_lqt
+                  then failwith error_MINIMUM_LQT_MUST_REMAIN_LOCKED
+                  else () in
               // Calculate tokenPool, convert int to nat
               let new_tokenPool = match is_a_nat (storage.tokenPool - tokens_withdrawn) with
                   | None -> (failwith error_TOKEN_POOL_MINUS_TOKENS_WITHDRAWN_IS_NEGATIVE : nat)
@@ -625,7 +631,7 @@ module Dexter = struct
         else if
             param.expectedXtzPool = 0mutez
             or param.expectedTokenPool = 0n
-            or param.expectedLqtTotal = 0n
+            or param.expectedLqtTotal <= minimum_lqt
             or storage.xtzPool <> param.expectedXtzPool
             (* Token contracts can transfer directly to this address while the
                pool is inactive. Treat the configured token seed as a minimum
@@ -680,7 +686,7 @@ module Dexter = struct
         else if
           storage.xtzPool = 0mutez
           or storage.tokenPool = 0n
-          or storage.lqtTotal = 0n
+          or storage.lqtTotal <= minimum_lqt
         then
             (failwith error_INVALID_INITIAL_RESERVES : result)
         else
@@ -743,6 +749,10 @@ module Dexter = struct
   [@view]
   let get_lqt_total (_ : unit) (storage : storage) : nat =
       storage.lqtTotal
+
+  [@view]
+  let get_minimum_lqt (_ : unit) (_storage : storage) : nat =
+      minimum_lqt
 
   [@view]
   let is_active (_ : unit) (storage : storage) : bool =

--- a/dex/contracts/lqt_fa12.mligo
+++ b/dex/contracts/lqt_fa12.mligo
@@ -77,11 +77,18 @@ module LQT = struct
 
   type result = operation list * storage
 
+  let err_non_payable = "LQT_NON_PAYABLE"
+  let err_supply_underflow = "LQT_SUPPLY_UNDERFLOW"
+
+  let assert_non_payable () : unit =
+    Assert.Error.assert (Tezos.get_amount () = 0mutez) err_non_payable
+
   [@inline]
   let maybe (n : nat) : nat option = if n = 0n then (None : nat option) else Some n
 
   [@entry]
   let transfer (param : transfer) (storage : storage) : result =
+    let () = assert_non_payable () in
     let allowances = storage.allowances in
     let tokens = storage.tokens in
     let allowances =
@@ -123,6 +130,7 @@ module LQT = struct
 
   [@entry]
   let approve (param : approve) (storage : storage) : result =
+    let () = assert_non_payable () in
     let allowances = storage.allowances in
     let allowance_key =
       {
@@ -144,6 +152,7 @@ module LQT = struct
   [@entry]
   let mintOrBurn (param : mintOrBurn) (storage : storage) : result =
     begin
+      let () = assert_non_payable () in
       if Tezos.get_sender () <> storage.admin
       then failwith "OnlyAdmin"
       else ();
@@ -157,12 +166,16 @@ module LQT = struct
           None -> (failwith "Cannot burn more than the target's balance." : nat)
         | Some bal -> bal in
       let tokens = Big_map.update param.target (maybe new_balance) storage.tokens in
-      let total_supply = abs (storage.total_supply + param.quantity) in
+      let total_supply =
+        match is_nat (storage.total_supply + param.quantity) with
+          None -> (failwith err_supply_underflow : nat)
+        | Some supply -> supply in
       (([] : operation list), {storage with tokens = tokens; total_supply = total_supply})
     end
 
   [@entry]
   let getAllowance (param : getAllowance) (storage : storage) : result =
+    let () = assert_non_payable () in
     let value =
       match Big_map.find_opt param.request storage.allowances with
         Some value -> value
@@ -171,6 +184,7 @@ module LQT = struct
 
   [@entry]
   let getBalance (param : getBalance) (storage : storage) : result =
+    let () = assert_non_payable () in
     let value =
       match Big_map.find_opt param.owner storage.tokens with
         Some value -> value
@@ -179,6 +193,7 @@ module LQT = struct
 
   [@entry]
   let getTotalSupply (param : getTotalSupply) (storage : storage) : result =
+    let () = assert_non_payable () in
     let total = storage.total_supply in
     ([Tezos.transaction total 0mutez param.callback], storage)
   end

--- a/dex/scripts/src/amounts.test.ts
+++ b/dex/scripts/src/amounts.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+    allocateInitialLqt,
     calculateInitialLqt,
     formatMutez,
     integerSquareRoot,
@@ -24,6 +25,16 @@ test("calculateInitialLqt remains exact above Number.MAX_SAFE_INTEGER", () => {
         calculateInitialLqt("1000000000000000000", "250000000000000000"),
         "500000000000000000"
     );
+});
+
+test("allocateInitialLqt reserves the permanent floor", () => {
+    assert.deepEqual(allocateInitialLqt("14142135"), {
+        total: "14142135",
+        provider: "14141135",
+        locked: "1000",
+    });
+    assert.throws(() => allocateInitialLqt("1000"), /must exceed/);
+    assert.throws(() => allocateInitialLqt("999"), /must exceed/);
 });
 
 test("parseNat rejects partial, signed, fractional, and exponential inputs", () => {

--- a/dex/scripts/src/amounts.ts
+++ b/dex/scripts/src/amounts.ts
@@ -1,5 +1,13 @@
 const NAT_PATTERN = /^(0|[1-9][0-9]*)$/;
 
+export const MINIMUM_LQT = 1000n;
+
+export interface InitialLqtAllocation {
+    total: string;
+    provider: string;
+    locked: string;
+}
+
 export function parseNat(value: string, name: string): string {
     const normalized = value.trim();
     if (!NAT_PATTERN.test(normalized)) {
@@ -40,6 +48,20 @@ export function calculateInitialLqt(xtz: string, token: string): string {
     const product = BigInt(parseNat(xtz, "SEED_XTZ"))
         * BigInt(parseNat(token, "SEED_TOKEN"));
     return integerSquareRoot(product).toString();
+}
+
+export function allocateInitialLqt(total: string): InitialLqtAllocation {
+    const parsedTotal = BigInt(parseNat(total, "initial LQT total"));
+    if (parsedTotal <= MINIMUM_LQT) {
+        throw new Error(
+            `Initial LQT total must exceed the permanent ${MINIMUM_LQT}-unit floor`
+        );
+    }
+    return {
+        total: parsedTotal.toString(),
+        provider: (parsedTotal - MINIMUM_LQT).toString(),
+        locked: MINIMUM_LQT.toString(),
+    };
 }
 
 export function formatMutez(value: string): string {

--- a/dex/scripts/src/deploy.ts
+++ b/dex/scripts/src/deploy.ts
@@ -21,6 +21,7 @@ import { Parser } from "@taquito/michel-codec";
 import { MichelsonMap, Schema } from "@taquito/michelson-encoder";
 import { getTokenBalance, prepareTokenTransfer } from "./util.js";
 import {
+    allocateInitialLqt,
     calculateInitialLqt,
     formatMutez,
     toSafeNumber,
@@ -59,6 +60,7 @@ async function deployLQT(tezos: TezosToolkit, dexAddress: string, config: FullCo
         config.seedAmount.xtz,
         config.seedAmount.token
     );
+    const lqtAllocation = allocateInitialLqt(lqtTotal);
 
     let metadata: MichelsonMap<string, string> = new MichelsonMap();
     metadata.set("", Buffer.from(config.metadata_uri!).toString("hex"));
@@ -69,7 +71,8 @@ async function deployLQT(tezos: TezosToolkit, dexAddress: string, config: FullCo
     token_metadata.set(0, { token_id: 0, token_info });
 
     let tokens: MichelsonMap<string, string> = new MichelsonMap();
-    tokens.set(config.manager, lqtTotal);
+    tokens.set(config.manager, lqtAllocation.provider);
+    tokens.set(dexAddress, lqtAllocation.locked);
 
     const storageSchema = new Schema(lqtStorageType);
     const lqtStorage: LqtStorage = {
@@ -169,6 +172,7 @@ function saveDeploymentInfo(
         config.seedAmount.xtz,
         config.seedAmount.token
     );
+    const lqtAllocation = allocateInitialLqt(lqtTotal);
     const deploymentInfo = {
         network: network,
         timestamp: new Date().toISOString(),
@@ -186,6 +190,8 @@ function saveDeploymentInfo(
             poolType: config.poolType,
             seedAmount: config.seedAmount,
             lqtTotal,
+            minimumLqt: lqtAllocation.locked,
+            initialProviderLqt: lqtAllocation.provider,
             lpFeeBp: config.poolType === "mod" ? 25 : undefined,
             protocolFeeBp: config.poolType === "mod" ? 5 : undefined,
             totalFeeBp: config.poolType === "mod" ? 30 : undefined,
@@ -324,6 +330,7 @@ async function verifyDeployment(
         config.seedAmount.xtz,
         config.seedAmount.token
     );
+    const expectedLqtAllocation = allocateInitialLqt(expectedLqtTotal);
 
     verifyEqual(toNatString(dexStorage.xtzPool, "DEX xtzPool"), config.seedAmount.xtz, "DEX xtzPool");
     const dexTokenPool = toNatString(dexStorage.tokenPool, "DEX tokenPool");
@@ -337,6 +344,16 @@ async function verifyDeployment(
         toNatString(lqtStorage.total_supply, "LQT total_supply"),
         expectedLqtTotal,
         "LQT total_supply"
+    );
+    verifyEqual(
+        toNatString(await lqtStorage.tokens.get(dexAddress), "locked LQT balance"),
+        expectedLqtAllocation.locked,
+        "locked LQT balance"
+    );
+    verifyEqual(
+        toNatString(await lqtStorage.tokens.get(config.manager), "provider LQT balance"),
+        expectedLqtAllocation.provider,
+        "provider LQT balance"
     );
 
     if (dexStorage.manager !== config.manager) {
@@ -390,6 +407,12 @@ async function main(): Promise<void> {
     console.log(`Network: ${networkName}`);
 
     const config = getConfig(networkName);
+
+    // Fail before any origination if the seeds cannot fund both an ordinary
+    // provider position and the permanent liquidity floor.
+    allocateInitialLqt(
+        calculateInitialLqt(config.seedAmount.xtz, config.seedAmount.token)
+    );
 
     const tezos = new TezosToolkit(config.rpc);
     tezos.setProvider({

--- a/dex/scripts/src/schema.test.ts
+++ b/dex/scripts/src/schema.test.ts
@@ -4,6 +4,8 @@ import test from "node:test";
 import { Parser } from "@taquito/michel-codec";
 import { MichelsonMap, Schema } from "@taquito/michelson-encoder";
 import {
+    dexStorageType,
+    dexStorageTypeFA2,
     dexStorageTypeFA2Mod,
     dexStorageTypeMod,
     lqtStorageType,
@@ -27,7 +29,9 @@ function compiledStorageType(filename: string): object {
     return JSON.parse(JSON.stringify(storage.args[0])) as object;
 }
 
-test("deployment schemas match the compiled modified contracts", () => {
+test("deployment schemas match every compiled pool contract", () => {
+    assert.deepEqual(compiledStorageType("pool.tz"), dexStorageType);
+    assert.deepEqual(compiledStorageType("pool_fa2.tz"), dexStorageTypeFA2);
     assert.deepEqual(compiledStorageType("pool_mod.tz"), dexStorageTypeMod);
     assert.deepEqual(compiledStorageType("pool_fa2_mod.tz"), dexStorageTypeFA2Mod);
 });

--- a/dex/scripts/src/schema.test.ts
+++ b/dex/scripts/src/schema.test.ts
@@ -8,6 +8,7 @@ import {
     dexStorageTypeMod,
     lqtStorageType,
 } from "./types.js";
+import { allocateInitialLqt } from "./amounts.js";
 
 const parser = new Parser();
 
@@ -54,8 +55,10 @@ test("deployment schemas preserve arbitrary-precision storage integers", () => {
         accumulated_protocol_fee_token: "0",
     });
 
+    const allocation = allocateInitialLqt(exactLqtTotal);
     const tokens = new MichelsonMap<string, string>();
-    tokens.set(manager, exactLqtTotal);
+    tokens.set(manager, allocation.provider);
+    tokens.set(token, allocation.locked);
     const lqtStorage = new Schema(lqtStorageType).Encode({
         tokens,
         allowances: new MichelsonMap(),
@@ -68,4 +71,5 @@ test("deployment schemas preserve arbitrary-precision storage integers", () => {
     const encoded = JSON.stringify([dexStorage, lqtStorage]);
     assert.match(encoded, new RegExp(exactLqtTotal));
     assert.match(encoded, new RegExp(exactTokenId));
+    assert.match(encoded, new RegExp(allocation.provider));
 });

--- a/dex/tests/dexter_mod.test.mligo
+++ b/dex/tests/dexter_mod.test.mligo
@@ -1069,3 +1069,52 @@ let test_view_quote_token_to_tez_zero =
   match view_result with
     None -> failwith "quote_token_to_tez view failed"
   | Some xtz_out -> Assert.assert (xtz_out = 0n)
+
+let test_view_get_minimum_lqt =
+  let (dex_orig, _, _) = Util.setup_full_dex () in
+  let dex_address = Test.Typed_address.to_address dex_orig.taddr in
+  let view_result : nat option =
+    Tezos.View.call "get_minimum_lqt" () dex_address in
+  match view_result with
+  | Some minimum -> Assert.assert (minimum = 1000n)
+  | None -> failwith "get_minimum_lqt view failed"
+
+let test_final_ordinary_lp_cannot_cross_minimum_lqt =
+  let test_name = "test_final_ordinary_lp_cannot_cross_minimum_lqt" in
+  let (dex_orig, lqt_orig, tok_orig) = Util.setup_full_dex () in
+  let withdraw_to_floor : DexterMod.Dexter.remove_liquidity =
+    {
+      to_ = Util.src ();
+      lqtBurned = 999000n;
+      minXtzWithdrawn = 999000mutez;
+      minTokensWithdrawn = 999000n;
+      deadline = Util.future
+    } in
+  let _ : nat =
+    Test.Typed_address.transfer_exn
+      dex_orig.taddr
+      (RemoveLiquidity withdraw_to_floor)
+      0tez in
+  let () =
+    Util.assert_dex_state dex_orig.taddr test_name 1000mutez 1000n 1000n in
+  let () =
+    Util.assert_token_balance lqt_orig.taddr test_name (Util.src ()) 1000n in
+  let () =
+    Util.assert_token_balance tok_orig.taddr test_name (Util.src ()) 1000999000n in
+  let cross_floor : DexterMod.Dexter.remove_liquidity =
+    {
+      to_ = Util.src ();
+      lqtBurned = 1n;
+      minXtzWithdrawn = 0mutez;
+      minTokensWithdrawn = 0n;
+      deadline = Util.future
+    } in
+  let result =
+    Test.Typed_address.transfer
+      dex_orig.taddr
+      (RemoveLiquidity cross_floor)
+      0tez in
+  Util.assert_error
+    test_name
+    DexterMod.Dexter.error_MINIMUM_LQT_MUST_REMAIN_LOCKED
+    result

--- a/dex/tests/dexter_mod_fa2.test.mligo
+++ b/dex/tests/dexter_mod_fa2.test.mligo
@@ -446,8 +446,8 @@ let test_modified_fa2_cannot_activate_twice =
     Test.Contract.transfer activate_entrypoint activate_param 0tez in
   assert_error test_name Dexter.error_POOL_ALREADY_ACTIVE result
 
-let test_modified_fa2_empty_pool_stays_fail_closed =
-  let test_name = "test_modified_fa2_empty_pool_stays_fail_closed" in
+let test_modified_fa2_complete_withdrawal_is_rejected =
+  let test_name = "test_modified_fa2_complete_withdrawal_is_rejected" in
   let (dex_orig, _, _) = setup_full_dex () in
   let remove_param : Dexter.remove_liquidity =
     {
@@ -457,32 +457,25 @@ let test_modified_fa2_empty_pool_stays_fail_closed =
      minTokensWithdrawn = 1000000n;
      deadline = future;
     } in
-  let _ : nat =
-    Test.Typed_address.transfer_exn
-      dex_orig.taddr
-      (RemoveLiquidity remove_param)
-      0tez in
-  let storage : Dexter.storage =
-    Test.Typed_address.get_storage dex_orig.taddr in
-  let () =
-    if
-      storage.xtzPool <> 0tez
-      or storage.tokenPool <> 0n
-      or storage.lqtTotal <> 0n
-    then failwith (test_name ^ ": pool was not emptied")
-    else () in
-  let swap_param : Dexter.xtz_to_token =
-    {
-     to_ = src ();
-     minTokensBought = 0n;
-     deadline = future;
-    } in
   let result =
     Test.Typed_address.transfer
       dex_orig.taddr
-      (XtzToToken swap_param)
-      1tez in
-  assert_error test_name Dexter.error_POOL_NOT_ACTIVE result
+      (RemoveLiquidity remove_param)
+      0tez in
+  let () =
+    assert_error
+      test_name
+      Dexter.error_MINIMUM_LQT_MUST_REMAIN_LOCKED
+      result in
+  let storage : Dexter.storage =
+    Test.Typed_address.get_storage dex_orig.taddr in
+  if
+    storage.xtzPool <> 1tez
+    or storage.tokenPool <> 1000000n
+    or storage.lqtTotal <> 1000000n
+    or not storage.active
+  then failwith (test_name ^ ": rejected withdrawal changed pool state")
+  else ()
 
 let test_modified_fa2_one_sided_active_states_fail_closed =
   let test_name = "test_modified_fa2_one_sided_active_states_fail_closed" in
@@ -687,3 +680,54 @@ let test_modified_fa2_liquidity_lifecycle_after_activation =
     or lqt_storage.total_supply <> 1500000n
   then failwith (test_name ^ ": remove-liquidity state mismatch")
   else ()
+
+let test_modified_fa2_final_lp_cannot_cross_minimum_lqt =
+  let test_name = "test_modified_fa2_final_lp_cannot_cross_minimum_lqt" in
+  let (dex_orig, lqt_orig, _) = setup_full_dex () in
+  let withdraw_to_floor : Dexter.remove_liquidity =
+    {
+      to_ = src ();
+      lqtBurned = 999000n;
+      minXtzWithdrawn = 999000mutez;
+      minTokensWithdrawn = 999000n;
+      deadline = future;
+    } in
+  let _ : nat =
+    Test.Typed_address.transfer_exn
+      dex_orig.taddr
+      (RemoveLiquidity withdraw_to_floor)
+      0tez in
+  let pool_storage : Dexter.storage =
+    Test.Typed_address.get_storage dex_orig.taddr in
+  let lqt_storage : LQT.LQT.storage =
+    Test.Typed_address.get_storage lqt_orig.taddr in
+  let owner_lqt =
+    match Big_map.find_opt (src ()) lqt_storage.tokens with
+    | Some balance -> balance
+    | None -> 0n in
+  let () =
+    if
+      pool_storage.xtzPool <> 1000mutez
+      or pool_storage.tokenPool <> 1000n
+      or pool_storage.lqtTotal <> Dexter.minimum_lqt
+      or lqt_storage.total_supply <> Dexter.minimum_lqt
+      or owner_lqt <> Dexter.minimum_lqt
+    then failwith (test_name ^ ": minimum state mismatch")
+    else () in
+  let cross_floor : Dexter.remove_liquidity =
+    {
+      to_ = src ();
+      lqtBurned = 1n;
+      minXtzWithdrawn = 0mutez;
+      minTokensWithdrawn = 0n;
+      deadline = future;
+    } in
+  let result =
+    Test.Typed_address.transfer
+      dex_orig.taddr
+      (RemoveLiquidity cross_floor)
+      0tez in
+  assert_error
+    test_name
+    Dexter.error_MINIMUM_LQT_MUST_REMAIN_LOCKED
+    result

--- a/dex/tests/lqt_fa12.test.mligo
+++ b/dex/tests/lqt_fa12.test.mligo
@@ -1,0 +1,138 @@
+#import "../contracts/lqt_fa12.mligo" "LQT"
+
+module Test = Test.Next
+module Tezos = Tezos.Next
+
+type lqt_parameter = LQT.LQT parameter_of
+type lqt_typed_address = (lqt_parameter, LQT.LQT.storage) typed_address
+
+let admin () = Test.Account.address 0n
+let owner () = Test.Account.address 1n
+let recipient () = Test.Account.address 2n
+
+let clean () : unit =
+  Test.State.reset 3n [1000000tez; 1000000tez; 1000000tez]
+
+let deploy_lqt (owner_balance : nat) (total_supply : nat) =
+  let storage : LQT.LQT.storage =
+    {
+      tokens = Big_map.literal [(owner (), owner_balance)];
+      allowances = (Big_map.empty : LQT.LQT.allowances);
+      admin = admin ();
+      total_supply = total_supply;
+      metadata = (Big_map.empty : (string, bytes) big_map);
+      token_metadata =
+        (Big_map.empty : (nat, LQT.LQT.token_metadata_value) big_map)
+    } in
+  Test.Originate.contract (contract_of LQT.LQT) storage 0tez
+
+let balance (lqt : lqt_typed_address) (account : address) : nat =
+  let storage : LQT.LQT.storage = Test.Typed_address.get_storage lqt in
+  match Big_map.find_opt account storage.tokens with
+  | Some value -> value
+  | None -> 0n
+
+let assert_string_failure
+  (test_name : string)
+  (expected : string)
+  (result : test_exec_result)
+: unit =
+  match result with
+  | Success _ -> failwith (test_name ^ ": expected failure")
+  | Fail failure ->
+      (match failure with
+       | Rejected (actual, _) ->
+           let expected = Test.Michelson.eval (expected : string) in
+           if Test.Compare.eq actual expected
+           then ()
+           else failwith (test_name ^ ": wrong failure")
+       | _ -> failwith (test_name ^ ": unexpected failure type"))
+
+let test_mint_and_burn_update_supply_exactly =
+  let () = clean () in
+  let lqt = deploy_lqt 1000n 1000n in
+  let () = Test.State.set_source (admin ()) in
+  let mint : LQT.LQT.mintOrBurn = {quantity = 200; target = recipient ()} in
+  let _ : nat =
+    Test.Contract.transfer_exn
+      (Test.Typed_address.get_entrypoint "mintOrBurn" lqt.taddr)
+      mint
+      0tez in
+  let burn : LQT.LQT.mintOrBurn = {quantity = -50; target = recipient ()} in
+  let _ : nat =
+    Test.Contract.transfer_exn
+      (Test.Typed_address.get_entrypoint "mintOrBurn" lqt.taddr)
+      burn
+      0tez in
+  let storage : LQT.LQT.storage = Test.Typed_address.get_storage lqt.taddr in
+  Assert.Error.assert
+    (storage.total_supply = 1150n && balance lqt.taddr (recipient ()) = 150n)
+    "unexpected mint/burn accounting"
+
+let test_total_supply_underflow_fails_closed =
+  let () = clean () in
+  (* Deliberately inconsistent storage proves supply is checked independently
+     from the target balance. *)
+  let lqt = deploy_lqt 200n 100n in
+  let () = Test.State.set_source (admin ()) in
+  let burn : LQT.LQT.mintOrBurn = {quantity = -150; target = owner ()} in
+  let result =
+    Test.Contract.transfer
+      (Test.Typed_address.get_entrypoint "mintOrBurn" lqt.taddr)
+      burn
+      0tez in
+  assert_string_failure
+    "supply underflow"
+    LQT.LQT.err_supply_underflow
+    result
+
+let test_mutating_entrypoints_reject_attached_xtz =
+  let () = clean () in
+  let lqt = deploy_lqt 1000n 1000n in
+  let () = Test.State.set_source (owner ()) in
+  let transfer : LQT.LQT.transfer =
+    {address_from = owner (); address_to = recipient (); value = 1n} in
+  let transfer_result =
+    Test.Contract.transfer
+      (Test.Typed_address.get_entrypoint "transfer" lqt.taddr)
+      transfer
+      1mutez in
+  let () =
+    assert_string_failure
+      "payable transfer"
+      LQT.LQT.err_non_payable
+      transfer_result in
+  let approve : LQT.LQT.approve = {spender = recipient (); value = 1n} in
+  let approve_result =
+    Test.Contract.transfer
+      (Test.Typed_address.get_entrypoint "approve" lqt.taddr)
+      approve
+      1mutez in
+  let () =
+    assert_string_failure
+      "payable approve"
+      LQT.LQT.err_non_payable
+      approve_result in
+  let () = Test.State.set_source (admin ()) in
+  let mint : LQT.LQT.mintOrBurn = {quantity = 1; target = owner ()} in
+  let mint_result =
+    Test.Contract.transfer
+      (Test.Typed_address.get_entrypoint "mintOrBurn" lqt.taddr)
+      mint
+      1mutez in
+  assert_string_failure
+    "payable mint"
+    LQT.LQT.err_non_payable
+    mint_result
+
+let test_only_admin_can_mint_or_burn =
+  let () = clean () in
+  let lqt = deploy_lqt 1000n 1000n in
+  let () = Test.State.set_source (owner ()) in
+  let mint : LQT.LQT.mintOrBurn = {quantity = 1; target = owner ()} in
+  let result =
+    Test.Contract.transfer
+      (Test.Typed_address.get_entrypoint "mintOrBurn" lqt.taddr)
+      mint
+      0tez in
+  assert_string_failure "unauthorized mint" "OnlyAdmin" result


### PR DESCRIPTION
## Summary

- enforce an immutable 1,000-unit LQT floor in the modified FA1.2 and FA2 pools
- harden LQT supply accounting against underflow and reject attached XTZ
- allocate the permanent floor to the DEX at origination and verify both locked and provider balances after deployment
- add focused LQT, pool-lifecycle, deployment, and reproducible-artifact tests
- add a pinned LIGO 1.11.5 contract release gate

## Why

The remaining liquidity-token lifecycle gap allowed the last provider to burn the complete LQT supply and leave an unrecoverable zero-reserve pool. The LQT implementation also reflected a negative total supply through `abs` if storage became inconsistent. This change makes both conditions fail closed.

## Deployment impact

Initial LQT must exceed 1,000 units. The DEX receives the permanent 1,000-unit position, while the configured final provider receives the remainder. Deployment-specific addresses and assets remain configuration values and are not compiled into these contracts.

## Validation

- LQT security suite passed
- full modified FA1.2 pool suite passed
- full modified FA2 pool suite passed
- deployment scripts type-check and all 13 unit/schema tests pass
- production Michelson rebuilt twice with LIGO 1.11.5 and matched byte-for-byte

## Integration

This PR now targets `trunk` after the contract remediation in #254 was merged and addresses the remaining work tracked in #245.