### PR TITLE
Fix mobile faucet link icons

### DIFF
--- a/V2/tezex/src/pages/Home/index.test.tsx
+++ b/V2/tezex/src/pages/Home/index.test.tsx
@@ -155,12 +155,23 @@ test("shows both Shadownet funding routes on swap and liquidity", () => {
   expect(screen.getByTestId("testnet-funding")).toHaveStyle({
     maxWidth: "470px",
   });
-  expect(
-    screen.getByRole("link", { name: "Get Shadownet test XTZ" })
-  ).toHaveAttribute("href", "https://faucet.shadownet.teztnets.com");
-  expect(
-    screen.getByRole("link", { name: "Get StableTez Shadownet test tokens" })
-  ).toHaveAttribute("href", "https://faucet.stabletez.com");
+  const xtzFaucetLink = screen.getByRole("link", {
+    name: "Get Shadownet test XTZ",
+  });
+  const tokenFaucetLink = screen.getByRole("link", {
+    name: "Get StableTez Shadownet test tokens",
+  });
+  expect(xtzFaucetLink).toHaveAttribute(
+    "href",
+    "https://faucet.shadownet.teztnets.com"
+  );
+  expect(tokenFaucetLink).toHaveAttribute(
+    "href",
+    "https://faucet.stabletez.com"
+  );
+  expect(xtzFaucetLink.querySelector("svg")).toBeInTheDocument();
+  expect(tokenFaucetLink.querySelector("svg")).toBeInTheDocument();
+  expect(screen.getByTestId("testnet-funding")).not.toHaveTextContent("↗");
 
   fireEvent.click(screen.getByRole("button", { name: "Liquidity" }));
   expect(screen.getByTestId("testnet-funding")).toHaveStyle({

--- a/V2/tezex/src/pages/Home/index.tsx
+++ b/V2/tezex/src/pages/Home/index.tsx
@@ -14,6 +14,7 @@ import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
 import Link from "@mui/material/Link";
 import Typography from "@mui/material/Typography";
+import ArrowOutwardRoundedIcon from "@mui/icons-material/ArrowOutwardRounded";
 import { NetworkType } from "@airgap/beacon-sdk";
 import { useNetwork } from "../../hooks/network";
 
@@ -353,7 +354,8 @@ export const Home: FC<IHome> = (props) => {
                   sx={styles.testnetFundingPrimary}
                   aria-label="Get Shadownet test XTZ"
                 >
-                  GET TEST XTZ ↗
+                  GET TEST XTZ
+                  <ArrowOutwardRoundedIcon aria-hidden="true" />
                 </Link>
                 <Link
                   href={STABLETEZ_TOKEN_FAUCET_URL}
@@ -362,7 +364,8 @@ export const Home: FC<IHome> = (props) => {
                   sx={styles.testnetFundingSecondary}
                   aria-label="Get StableTez Shadownet test tokens"
                 >
-                  GET TEST TOKENS ↗
+                  GET TEST TOKENS
+                  <ArrowOutwardRoundedIcon aria-hidden="true" />
                 </Link>
               </Box>
             </Box>

--- a/V2/tezex/src/pages/Home/style.js
+++ b/V2/tezex/src/pages/Home/style.js
@@ -104,6 +104,7 @@ const style = (theme, scale = 1) => {
       display: "inline-flex",
       alignItems: "center",
       justifyContent: "center",
+      gap: "6px",
       color: "var(--tezex-action-text)",
       background: "var(--tezex-action)",
       border: "1px solid var(--tezex-action)",
@@ -115,6 +116,11 @@ const style = (theme, scale = 1) => {
       textAlign: "center",
       textDecoration: "none",
       whiteSpace: "nowrap",
+      "& svg": {
+        width: "13px",
+        height: "13px",
+        flex: "0 0 13px",
+      },
       "&:hover": {
         color: "var(--tezex-action-text)",
         background: "var(--tezex-action-hover)",
@@ -127,6 +133,7 @@ const style = (theme, scale = 1) => {
       display: "inline-flex",
       alignItems: "center",
       justifyContent: "center",
+      gap: "6px",
       color: "var(--tezex-text-secondary)",
       background: "transparent",
       border: "1px solid var(--tezex-line-strong)",
@@ -138,6 +145,11 @@ const style = (theme, scale = 1) => {
       textAlign: "center",
       textDecoration: "none",
       whiteSpace: "nowrap",
+      "& svg": {
+        width: "13px",
+        height: "13px",
+        flex: "0 0 13px",
+      },
       "&:hover": {
         color: "var(--tezex-text)",
         background: "var(--tezex-hover)",

--- a/V2/tezex/src/pages/Stez/index.test.tsx
+++ b/V2/tezex/src/pages/Stez/index.test.tsx
@@ -74,11 +74,15 @@ test("renders the real capability gate and keeps action states interactive", asy
   expect(screen.getByText("Liquid sTEZ")).toBeInTheDocument();
   expect(screen.getByText(/Depositing XTZ mints sTEZ/)).toBeInTheDocument();
   expect(screen.getByText("Total sTEZ supply")).toBeInTheDocument();
-  expect(
-    screen.getByRole("link", {
-      name: "Get Shadownet test XTZ from the official faucet",
-    })
-  ).toHaveAttribute("href", "https://faucet.shadownet.teztnets.com");
+  const faucetLink = screen.getByRole("link", {
+    name: "Get Shadownet test XTZ from the official faucet",
+  });
+  expect(faucetLink).toHaveAttribute(
+    "href",
+    "https://faucet.shadownet.teztnets.com"
+  );
+  expect(faucetLink.querySelector("svg")).toBeInTheDocument();
+  expect(faucetLink).not.toHaveTextContent("↗");
   expect(
     screen.queryByRole("button", { name: /check stez availability again/i })
   ).not.toBeInTheDocument();

--- a/V2/tezex/src/pages/Stez/index.tsx
+++ b/V2/tezex/src/pages/Stez/index.tsx
@@ -5,6 +5,7 @@ import ArrowDownwardRoundedIcon from "@mui/icons-material/ArrowDownwardRounded";
 import CheckCircleOutlineRoundedIcon from "@mui/icons-material/CheckCircleOutlineRounded";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import LockClockOutlinedIcon from "@mui/icons-material/LockClockOutlined";
+import ArrowOutwardRoundedIcon from "@mui/icons-material/ArrowOutwardRounded";
 
 import connectWallet from "../../functions/beacon";
 import { useNetwork } from "../../hooks/network";
@@ -264,7 +265,8 @@ export const Stez: FC = () => {
           rel="noreferrer"
           aria-label="Get Shadownet test XTZ from the official faucet"
         >
-          GET SHADOWNET TEST XTZ <span aria-hidden="true">↗</span>
+          GET SHADOWNET TEST XTZ
+          <ArrowOutwardRoundedIcon aria-hidden="true" />
         </a>
       </section>
 

--- a/V2/tezex/src/pages/Stez/style.css
+++ b/V2/tezex/src/pages/Stez/style.css
@@ -145,6 +145,12 @@
   background: var(--tezex-action-hover);
 }
 
+.stez-availability__faucet-link svg {
+  width: 13px;
+  height: 13px;
+  flex: 0 0 13px;
+}
+
 .stez-availability__faucet-link:focus-visible {
   outline: 2px solid var(--tezex-text-secondary);
   outline-offset: 3px;


### PR DESCRIPTION
## What changed
- replace platform-dependent external-link characters with monochrome Material icons
- apply the same treatment to all sTEZ and testnet faucet links
- add regression coverage for the rendered icons

## Why
iOS Safari can render the Unicode northeast arrow as a colored emoji, making the faucet buttons look inconsistent with the TEZEX interface.

## Impact
External faucet links now use a fixed-size vector icon that inherits the button color consistently across desktop and mobile browsers.

## Validation
- `npm run typecheck`
- Home and sTEZ test suites: 6 tests passed
- `npm run build`
- mobile visual verification at 390 × 844
- no browser console errors