### PR TITLE
Harden Sirius adapter transaction boundaries

### DIFF
--- a/V2/tezex/README.md
+++ b/V2/tezex/README.md
@@ -1,5 +1,9 @@
 # Github pages deploy instructions
 
+## Security reviews
+
+- [Sirius adapter security review](./SIRIUS_ADAPTER_SECURITY_REVIEW.md)
+
 ## `npm run deploy`
 
 Deploys the app through gh-pages branch

--- a/V2/tezex/SIRIUS_ADAPTER_SECURITY_REVIEW.md
+++ b/V2/tezex/SIRIUS_ADAPTER_SECURITY_REVIEW.md
@@ -64,19 +64,23 @@ The focused test suite covers:
 - slippage-adjusted swap, withdrawal, and SIRS minima;
 - approval reset and cleanup ordering in a single wallet request;
 - propagation of a rejected atomic batch without a second cleanup request;
-- cached storage reads and explicit refresh behavior; and
-- canonical mainnet pool, token, SIRS, and decimal configuration.
+- cached storage reads and explicit refresh behavior;
+- canonical mainnet pool, token, SIRS, and decimal configuration;
+- fail-closed runtime checks for the token and SIRS addresses decoded from pool storage; and
+- wrong-chain, raw-storage-address, and wallet-operation-destination rejection.
 
 ## Final no-broadcast release rehearsal
 
-On 2026-08-05, after rebasing onto `400eec2`, the opt-in rehearsal read the configured contracts through the mainnet RPC at block `BLDZn6FGqpZJP6NoLxJjKSJusTrvn9akg776vikUHsLnxkcVS6a`, level `14,370,655`, under the Ushuaia protocol.
+On 2026-08-06, after rebasing onto `400eec2`, the opt-in rehearsal read the configured contracts through the mainnet RPC at block `BKrd5HFbQMu8xa3qkjEQQEMo6wMzF5vp3y87xyiCZTawjW96k4u`, level `14,387,043`, under the Ushuaia protocol.
 
-The live pool still exposed `xtzToToken`, `tokenToXtz`, `addLiquidity`, and `removeLiquidity`, and its storage still pointed to the configured underlying-token and SIRS contracts. A capture-only Beacon client then constructed, but could not sign or broadcast:
+The rehearsal first requires the RPC chain ID to match the configured mainnet chain ID. It reads the pool's raw Micheline storage and requires its underlying-token and SIRS addresses to match the configured canonical contracts. The live pool still exposed `xtzToToken`, `tokenToXtz`, `addLiquidity`, and `removeLiquidity`. A capture-only Beacon client then constructed, but could not sign or broadcast:
 
 - the direct XTZ-to-token operation;
 - the approval-reset, approval, token-to-XTZ, and cleanup batch;
 - the approval-reset, approval, add-liquidity, and cleanup batch; and
 - the remove-liquidity operation.
+
+Every captured operation is also required to target the canonical token or pool address in the expected batch position; checking entrypoint names alone is not sufficient.
 
 The rejection path produced one wallet request and no follow-up cleanup request. Reproduce this release gate with:
 

--- a/V2/tezex/SIRIUS_ADAPTER_SECURITY_REVIEW.md
+++ b/V2/tezex/SIRIUS_ADAPTER_SECURITY_REVIEW.md
@@ -1,0 +1,93 @@
+# Sirius adapter security review
+
+Date: 2026-07-30
+
+Scope: `src/adapters/sirius.ts`, direct-route registration and selection, mainnet configuration, transaction construction, dedicated tests, and the opt-in live no-broadcast rehearsal
+
+Repository baseline: `400eec2`
+
+## Disposition
+
+The remediation makes the TEZEX integration match the immutable Sirius contract's integer arithmetic and fail closed for unsupported or unprotected operations. It is suitable for code review and a no-broadcast mainnet simulation plus test-wallet rehearsal. It is not an authorization to use Sirius as an oracle or to treat the external token as immutable.
+
+Sirius remains an external protocol-designated pool. TEZEX does not deploy, administer, upgrade, or pause that contract. This change hardens the adapter and route boundary; it does not fork or replace the pool.
+
+## Verified contract boundary
+
+The configured mainnet pool was checked through Tezos RPC at block `BM166sLK8j7VDSpoaacSjMfzUz9RwMSs2A1pQ68Mwc1bSDgWbcQ`, level `14,290,950`, under the Ushuaia protocol. Its exposed entrypoints were:
+
+```text
+addLiquidity
+default
+removeLiquidity
+tokenToToken
+tokenToXtz
+xtzToToken
+```
+
+The storage shape remained the expected five-field liquidity-baking tuple: token reserve, XTZ reserve, LQT supply, underlying-token address, and LQT address. The production configuration test pins the expected pool, underlying-token, and SIRS addresses and decimals.
+
+The arithmetic order was compared with the published Dexter liquidity-baking Michelson at upstream revision `d98643881fe14996803997f1283e84ebd2067e35`.
+
+## Remediated findings
+
+| ID    | Risk                                                                                                                           | Resolution                                                                                                                 |
+| ----- | ------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| SA-01 | The adapter delayed two floors until the final result and could overquote by one atomic unit.                                  | XTZ burn and gross XTZ output are floored at the same intermediate steps as Michelson.                                     |
+| SA-02 | No test imported or directly exercised `SiriusAdapter`.                                                                        | A dedicated suite covers quotes, boundary rounding, liquidity math, storage caching, operation construction, and failures. |
+| SA-03 | Add-liquidity protected maximum token input but submitted the strict quoted SIRS minimum.                                      | The selected slippage tolerance is now applied to `minLqtMinted`, with one final floor.                                    |
+| SA-04 | Tiny swaps or deposits could construct operations with zero output or zero minimum SIRS.                                       | Quotes and execution reject non-positive, fractional, or non-finite contract amounts and reject minima that floor to zero. |
+| SA-05 | Any non-XTZ input was treated as the configured token, and a malformed Sirius configuration could expose an unsupported route. | The adapter accepts only the configured XTZ/tzBTC pair; registry and UI routing share the same direct-route predicate.     |
+| SA-06 | Token-to-XTZ swaps relied only on exact allowance consumption.                                                                 | Approval reset, exact approval, swap, and final cleanup are submitted in one atomic wallet batch.                          |
+| SA-07 | `BigNumber.toNumber()` could silently lose integer precision for an unexpectedly large parameter.                              | Every converted contract parameter is checked as a positive integer within JavaScript's exact safe range.                  |
+
+## Enforced invariants
+
+```text
+Sirius route = XTZ -> tzBTC or tzBTC -> XTZ
+quoted and submitted raw amounts are positive integers
+submitted minimum output > 0
+submitted minimum SIRS > 0
+pool reserves and LQT supply > 0 before division
+token approval reset + approval + action + cleanup = one operation group
+```
+
+The immutable `tokenToToken` entrypoint is intentionally absent from the adapter. TEZEX does not synthesize a multi-pool route through Sirius. Any future multi-hop feature must construct separately protected direct swaps with an independent minimum output and deadline for every hop.
+
+## Test evidence
+
+The focused test suite covers:
+
+- both swap directions at representative and first-difference rounding boundaries;
+- exact add-liquidity, required-deposit, and remove-liquidity floors;
+- zero-output, zero-SIRS, invalid-token, and malformed-configuration rejection;
+- slippage-adjusted swap, withdrawal, and SIRS minima;
+- approval reset and cleanup ordering in a single wallet request;
+- propagation of a rejected atomic batch without a second cleanup request;
+- cached storage reads and explicit refresh behavior; and
+- canonical mainnet pool, token, SIRS, and decimal configuration.
+
+## Final no-broadcast release rehearsal
+
+On 2026-08-05, after rebasing onto `400eec2`, the opt-in rehearsal read the configured contracts through the mainnet RPC at block `BLDZn6FGqpZJP6NoLxJjKSJusTrvn9akg776vikUHsLnxkcVS6a`, level `14,370,655`, under the Ushuaia protocol.
+
+The live pool still exposed `xtzToToken`, `tokenToXtz`, `addLiquidity`, and `removeLiquidity`, and its storage still pointed to the configured underlying-token and SIRS contracts. A capture-only Beacon client then constructed, but could not sign or broadcast:
+
+- the direct XTZ-to-token operation;
+- the approval-reset, approval, token-to-XTZ, and cleanup batch;
+- the approval-reset, approval, add-liquidity, and cleanup batch; and
+- the remove-liquidity operation.
+
+The rejection path produced one wallet request and no follow-up cleanup request. Reproduce this release gate with:
+
+```sh
+RUN_SIRIUS_MAINNET_REHEARSAL=1 npm test -- --watchAll=false --runInBand src/adapters/sirius.rehearsal.test.ts
+```
+
+## Residual requirements
+
+- The underlying token remains externally controlled and upgradeable; pause, upgrade, ownership, issuance, and bridge events require monitoring and an operational response.
+- The reserve ratio is a manipulable AMM spot price and must not be used for lending, collateral, minting, or liquidation decisions.
+- The immutable `tokenToToken` entrypoint remains unsupported because its legacy mutez arithmetic can overflow at realistic reserves.
+- Subsidy state and yield claims must be sourced from current protocol state rather than assumed from historical Liquidity Baking behavior.
+- Before release, exercise both direct swaps, add/remove liquidity, wallet rejection, and allowance cleanup with no-broadcast simulation or a controlled test wallet, then independently review the final diff.

--- a/V2/tezex/src/adapters/poolRegistry.ts
+++ b/V2/tezex/src/adapters/poolRegistry.ts
@@ -3,6 +3,8 @@ import {
   PoolConfig,
   PoolType,
   StablePoolConfig,
+  isSupportedPoolConfiguration,
+  supportsDirectSwap,
 } from "../types/pools";
 import { Asset, Token } from "../types/general";
 import { SiriusAdapter } from "./sirius";
@@ -14,6 +16,9 @@ export class PoolRegistry {
   private static assets: Asset[] = [];
 
   static registerPool(config: PoolConfig): void {
+    if (!isSupportedPoolConfiguration(config)) {
+      throw new Error(`Unsupported pool configuration: ${config.id}`);
+    }
     const adapter = this.createAdapter(config);
     this.adapters.set(config.id, adapter);
   }
@@ -53,10 +58,8 @@ export class PoolRegistry {
   }
 
   static getPoolsByTokenPair(tokenA: Token, tokenB: Token): PoolConfig[] {
-    return this.getAllPools().filter(
-      (pool) =>
-        (pool.tokenA === tokenA && pool.tokenB === tokenB) ||
-        (pool.tokenA === tokenB && pool.tokenB === tokenA)
+    return this.getAllPools().filter((pool) =>
+      supportsDirectSwap(pool, tokenA, tokenB)
     );
   }
 

--- a/V2/tezex/src/adapters/sirius.rehearsal.test.ts
+++ b/V2/tezex/src/adapters/sirius.rehearsal.test.ts
@@ -1,0 +1,184 @@
+import { DAppClient } from "@airgap/beacon-dapp";
+import { TezosToolkit } from "@taquito/taquito";
+import BigNumber from "bignumber.js";
+
+import mainnet from "../config/network/mainnet.json";
+import { Asset, ExecutionKit, Token } from "../types/general";
+import { PoolConfig } from "../types/pools";
+import { PoolDataCache } from "../utils/poolDataCache";
+import { PoolRegistry } from "./poolRegistry";
+import { SiriusAdapter } from "./sirius";
+
+type BeaconOperation = {
+  amount?: string;
+  parameters?: {
+    entrypoint?: string;
+  };
+};
+
+type BeaconRequest = {
+  operationDetails: BeaconOperation[];
+};
+
+const USER_ADDRESS = "tz1burnburnburnburnburnburnburjAYjjX";
+
+const liveConfig = mainnet as unknown as {
+  tezosServer: string;
+  pools: PoolConfig[];
+  assets: Asset[];
+};
+
+const pool = liveConfig.pools.find(
+  (candidate) => candidate.id === "xtz-tzbtc-sirius"
+);
+
+if (!pool) {
+  throw new Error("Canonical Sirius pool is missing from mainnet config");
+}
+
+const entrypoints = (request: BeaconRequest): Array<string | undefined> =>
+  request.operationDetails.map((operation) => operation.parameters?.entrypoint);
+
+const describeLiveRehearsal =
+  process.env.RUN_SIRIUS_MAINNET_REHEARSAL === "1" ? describe : describe.skip;
+
+describeLiveRehearsal("Sirius live no-broadcast release rehearsal", () => {
+  jest.setTimeout(120000);
+
+  beforeAll(() => {
+    PoolDataCache.clear();
+    PoolRegistry.clear();
+    PoolRegistry.initializeFromConfig([], liveConfig.assets);
+  });
+
+  afterAll(() => {
+    PoolDataCache.clear();
+    PoolRegistry.clear();
+  });
+
+  beforeEach(() => {
+    jest.spyOn(console, "error").mockImplementation(() => undefined);
+    jest.spyOn(console, "warn").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("constructs every protected mainnet operation path without broadcasting", async () => {
+    const toolkit = new TezosToolkit(liveConfig.tezosServer);
+    const captured: BeaconRequest[] = [];
+    const requestOperation = jest.fn(async (request: BeaconRequest) => {
+      captured.push(request);
+      return { transactionHash: "no-broadcast-rehearsal" };
+    });
+    const kit = {
+      toolkit,
+      client: { requestOperation } as unknown as DAppClient,
+    } as ExecutionKit;
+    const adapter = new SiriusAdapter(pool);
+
+    const poolData = await adapter.getPoolData(toolkit, true);
+    expect(poolData.tokenAPool.isPositive()).toBe(true);
+    expect(poolData.tokenBPool.isPositive()).toBe(true);
+    expect(poolData.lpTokenSupply.isPositive()).toBe(true);
+
+    const xtzInput = new BigNumber(1000000);
+    const xtzSwap = await adapter.estimateSwap(toolkit, Token.XTZ, xtzInput);
+    await adapter.executeSwap(
+      kit,
+      USER_ADDRESS,
+      Token.XTZ,
+      xtzInput,
+      xtzSwap.outputAmount,
+      0.5
+    );
+    expect(entrypoints(captured[0])).toEqual(["xtzToToken"]);
+
+    const tokenInput = new BigNumber(1000);
+    const tokenSwap = await adapter.estimateSwap(
+      toolkit,
+      Token.TzBTC,
+      tokenInput
+    );
+    await adapter.executeSwap(
+      kit,
+      USER_ADDRESS,
+      Token.TzBTC,
+      tokenInput,
+      tokenSwap.outputAmount,
+      0.5
+    );
+    expect(entrypoints(captured[1])).toEqual([
+      "approve",
+      "approve",
+      "tokenToXtz",
+      "approve",
+    ]);
+
+    const liquidityXtz = new BigNumber(1000000);
+    const liquidityToken = await adapter.calculateRequiredTokenForLiquidity(
+      toolkit,
+      Token.XTZ,
+      liquidityXtz
+    );
+    const addQuote = await adapter.estimateAddLiquidity(
+      toolkit,
+      Token.XTZ,
+      liquidityXtz,
+      liquidityToken
+    );
+    await adapter.executeAddLiquidity(
+      kit,
+      USER_ADDRESS,
+      liquidityXtz,
+      liquidityToken,
+      addQuote.lpTokenAmount,
+      0.5
+    );
+    expect(entrypoints(captured[2])).toEqual([
+      "approve",
+      "approve",
+      "addLiquidity",
+      "approve",
+    ]);
+
+    const liquidityBurn = new BigNumber(1);
+    const removeQuote = await adapter.estimateRemoveLiquidity(
+      toolkit,
+      liquidityBurn
+    );
+    expect(removeQuote.tokenAAmount.isPositive()).toBe(true);
+    expect(removeQuote.tokenBAmount.isPositive()).toBe(true);
+    await adapter.executeRemoveLiquidity(kit, USER_ADDRESS, liquidityBurn, 0.5);
+    expect(entrypoints(captured[3])).toEqual(["removeLiquidity"]);
+
+    expect(requestOperation).toHaveBeenCalledTimes(4);
+  });
+
+  it("propagates wallet rejection without a second cleanup request", async () => {
+    const toolkit = new TezosToolkit(liveConfig.tezosServer);
+    const requestOperation = jest.fn(async () => {
+      throw new Error("wallet rejected");
+    });
+    const kit = {
+      toolkit,
+      client: { requestOperation } as unknown as DAppClient,
+    } as ExecutionKit;
+    const adapter = new SiriusAdapter(pool);
+    const tokenInput = new BigNumber(1000);
+    const quote = await adapter.estimateSwap(toolkit, Token.TzBTC, tokenInput);
+
+    await expect(
+      adapter.executeSwap(
+        kit,
+        USER_ADDRESS,
+        Token.TzBTC,
+        tokenInput,
+        quote.outputAmount,
+        0.5
+      )
+    ).rejects.toThrow("wallet rejected");
+    expect(requestOperation).toHaveBeenCalledTimes(1);
+  });
+});

--- a/V2/tezex/src/adapters/sirius.rehearsal.test.ts
+++ b/V2/tezex/src/adapters/sirius.rehearsal.test.ts
@@ -11,6 +11,7 @@ import { SiriusAdapter } from "./sirius";
 
 type BeaconOperation = {
   amount?: string;
+  destination?: string;
   parameters?: {
     entrypoint?: string;
   };
@@ -24,6 +25,7 @@ const USER_ADDRESS = "tz1burnburnburnburnburnburnburjAYjjX";
 
 const liveConfig = mainnet as unknown as {
   tezosServer: string;
+  chainId: string;
   pools: PoolConfig[];
   assets: Asset[];
 };
@@ -38,6 +40,119 @@ if (!pool) {
 
 const entrypoints = (request: BeaconRequest): Array<string | undefined> =>
   request.operationDetails.map((operation) => operation.parameters?.entrypoint);
+
+const asRecord = (value: unknown): Record<string, unknown> | undefined =>
+  typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : undefined;
+
+const flattenCombPair = (value: unknown): unknown[] => {
+  const node = asRecord(value);
+  if (node?.prim !== "Pair" || !Array.isArray(node.args)) return [value];
+  return node.args.flatMap(flattenCombPair);
+};
+
+const assertConfiguredChainId = (actual: string, expected: string): void => {
+  if (actual !== expected) {
+    throw new Error(
+      `Sirius rehearsal chain mismatch: expected ${expected}, received ${actual}`
+    );
+  }
+};
+
+const assertRawStorageAddresses = (
+  storage: unknown,
+  expectedTokenAddress: string,
+  expectedLqtAddress: string
+): void => {
+  const fields = flattenCombPair(storage);
+  const tokenAddress = asRecord(fields[3])?.string;
+  const lqtAddress = asRecord(fields[4])?.string;
+
+  if (fields.length !== 5 || typeof tokenAddress !== "string") {
+    throw new Error("Sirius raw storage has an unexpected token address shape");
+  }
+  if (typeof lqtAddress !== "string") {
+    throw new Error("Sirius raw storage has an unexpected SIRS address shape");
+  }
+  if (tokenAddress !== expectedTokenAddress) {
+    throw new Error(
+      `Sirius raw storage token mismatch: expected ${expectedTokenAddress}, received ${tokenAddress}`
+    );
+  }
+  if (lqtAddress !== expectedLqtAddress) {
+    throw new Error(
+      `Sirius raw storage SIRS mismatch: expected ${expectedLqtAddress}, received ${lqtAddress}`
+    );
+  }
+};
+
+const assertOperationDestinations = (
+  request: BeaconRequest,
+  expected: string[]
+): void => {
+  const actual = request.operationDetails.map(
+    (operation) => operation.destination
+  );
+  const matches =
+    actual.length === expected.length &&
+    actual.every((destination, index) => destination === expected[index]);
+
+  if (!matches) {
+    throw new Error(
+      `Sirius operation destination mismatch: expected ${expected.join(
+        ","
+      )}, received ${actual.join(",")}`
+    );
+  }
+};
+
+const requireAssetAddress = (token: Token): string => {
+  const address = liveConfig.assets.find(
+    (asset) => asset.name === token
+  )?.address;
+  if (!address) {
+    throw new Error(`Canonical ${token} asset is missing from mainnet config`);
+  }
+  return address;
+};
+
+describe("Sirius rehearsal boundary validation", () => {
+  const rawStorage = {
+    prim: "Pair",
+    args: [
+      { int: "1" },
+      { int: "2" },
+      { int: "3" },
+      { string: "KT1-token" },
+      { string: "KT1-sirs" },
+    ],
+  };
+
+  it("rejects a response from the wrong chain", () => {
+    expect(() =>
+      assertConfiguredChainId("NetXWrongChain", "NetXExpectedChain")
+    ).toThrow(/chain mismatch/i);
+  });
+
+  it("rejects mismatched raw storage addresses", () => {
+    expect(() =>
+      assertRawStorageAddresses(rawStorage, "KT1-other-token", "KT1-sirs")
+    ).toThrow(/token mismatch/i);
+    expect(() =>
+      assertRawStorageAddresses(rawStorage, "KT1-token", "KT1-other-sirs")
+    ).toThrow(/SIRS mismatch/i);
+  });
+
+  it("rejects an operation sent to the wrong destination", () => {
+    expect(() =>
+      assertOperationDestinations(
+        { operationDetails: [{ destination: "KT1-wrong" }] },
+        ["KT1-pool"]
+      )
+    ).toThrow(/destination mismatch/i);
+  });
+});
 
 const describeLiveRehearsal =
   process.env.RUN_SIRIUS_MAINNET_REHEARSAL === "1" ? describe : describe.skip;
@@ -67,6 +182,15 @@ describeLiveRehearsal("Sirius live no-broadcast release rehearsal", () => {
 
   it("constructs every protected mainnet operation path without broadcasting", async () => {
     const toolkit = new TezosToolkit(liveConfig.tezosServer);
+    const tokenAddress = requireAssetAddress(pool.tokenB);
+    const lqtAddress = requireAssetAddress(pool.lpToken);
+    assertConfiguredChainId(await toolkit.rpc.getChainId(), liveConfig.chainId);
+    assertRawStorageAddresses(
+      await toolkit.rpc.getStorage(pool.address),
+      tokenAddress,
+      lqtAddress
+    );
+
     const captured: BeaconRequest[] = [];
     const requestOperation = jest.fn(async (request: BeaconRequest) => {
       captured.push(request);
@@ -94,6 +218,7 @@ describeLiveRehearsal("Sirius live no-broadcast release rehearsal", () => {
       0.5
     );
     expect(entrypoints(captured[0])).toEqual(["xtzToToken"]);
+    assertOperationDestinations(captured[0], [pool.address]);
 
     const tokenInput = new BigNumber(1000);
     const tokenSwap = await adapter.estimateSwap(
@@ -114,6 +239,12 @@ describeLiveRehearsal("Sirius live no-broadcast release rehearsal", () => {
       "approve",
       "tokenToXtz",
       "approve",
+    ]);
+    assertOperationDestinations(captured[1], [
+      tokenAddress,
+      tokenAddress,
+      pool.address,
+      tokenAddress,
     ]);
 
     const liquidityXtz = new BigNumber(1000000);
@@ -142,6 +273,12 @@ describeLiveRehearsal("Sirius live no-broadcast release rehearsal", () => {
       "addLiquidity",
       "approve",
     ]);
+    assertOperationDestinations(captured[2], [
+      tokenAddress,
+      tokenAddress,
+      pool.address,
+      tokenAddress,
+    ]);
 
     const liquidityBurn = new BigNumber(1);
     const removeQuote = await adapter.estimateRemoveLiquidity(
@@ -152,6 +289,7 @@ describeLiveRehearsal("Sirius live no-broadcast release rehearsal", () => {
     expect(removeQuote.tokenBAmount.isPositive()).toBe(true);
     await adapter.executeRemoveLiquidity(kit, USER_ADDRESS, liquidityBurn, 0.5);
     expect(entrypoints(captured[3])).toEqual(["removeLiquidity"]);
+    assertOperationDestinations(captured[3], [pool.address]);
 
     expect(requestOperation).toHaveBeenCalledTimes(4);
   });

--- a/V2/tezex/src/adapters/sirius.test.ts
+++ b/V2/tezex/src/adapters/sirius.test.ts
@@ -11,6 +11,7 @@ import { SiriusAdapter } from "./sirius";
 
 const POOL_ADDRESS = "KT1-sirius-pool";
 const TOKEN_ADDRESS = "KT1-tzbtc-token";
+const LP_TOKEN_ADDRESS = "KT1-sirs-token";
 const USER_ADDRESS = "tz1-user";
 
 const poolConfig: PoolConfig = {
@@ -27,6 +28,8 @@ const auditedSnapshot = {
   xtzPool: "4210300907572",
   tokenPool: "1356293834",
   lqtTotal: "27188438",
+  tokenAddress: TOKEN_ADDRESS,
+  lqtAddress: LP_TOKEN_ADDRESS,
 };
 
 const integerModel = {
@@ -69,7 +72,7 @@ const makeInvocation = (
   })),
 });
 
-const makeHarness = () => {
+const makeHarness = (storageValue = auditedSnapshot) => {
   const poolMethods = {
     xtzToToken: jest.fn((value) =>
       makeInvocation(POOL_ADDRESS, "xtzToToken", value)
@@ -89,7 +92,7 @@ const makeHarness = () => {
       makeInvocation(TOKEN_ADDRESS, "approve", value)
     ),
   };
-  const storage = jest.fn().mockResolvedValue(auditedSnapshot);
+  const storage = jest.fn().mockResolvedValue(storageValue);
   const poolContract = { methodsObject: poolMethods, storage };
   const tokenContract = { methodsObject: tokenMethods };
   const contractAt = jest.fn(async (address: string) =>
@@ -130,6 +133,14 @@ describe("SiriusAdapter", () => {
           logo: "",
           address: TOKEN_ADDRESS,
           decimals: 8,
+          type: TokenType.FA12,
+        },
+        {
+          name: Token.Sirs,
+          label: "Sirs",
+          logo: "",
+          address: LP_TOKEN_ADDRESS,
+          decimals: 0,
           type: TokenType.FA12,
         },
       ]
@@ -270,6 +281,18 @@ describe("SiriusAdapter", () => {
     expect(storage).toHaveBeenCalledTimes(2);
   });
 
+  it.each([
+    ["underlying token", { tokenAddress: "KT1-wrong-token" }],
+    ["SIRS", { lqtAddress: "KT1-wrong-sirs" }],
+  ])("rejects a mismatched %s storage address", async (label, override) => {
+    const { toolkit } = makeHarness({ ...auditedSnapshot, ...override });
+    const adapter = new SiriusAdapter(poolConfig);
+
+    await expect(adapter.getPoolData(toolkit, true)).rejects.toThrow(
+      new RegExp(`${label} storage mismatch`, "i")
+    );
+  });
+
   it("submits a protected direct XTZ-to-token swap", async () => {
     const { kit, requestOperation, poolMethods } = makeHarness();
     const adapter = new SiriusAdapter(poolConfig);
@@ -292,6 +315,7 @@ describe("SiriusAdapter", () => {
       })
     );
     const operation = requestOperation.mock.calls[0][0].operationDetails[0];
+    expect(operation.destination).toBe(POOL_ADDRESS);
     expect(operation.amount).toBe("1000000");
     expect(operation.parameters.entrypoint).toBe("xtzToToken");
   });
@@ -322,6 +346,11 @@ describe("SiriusAdapter", () => {
         (op: { parameters: { entrypoint: string } }) => op.parameters.entrypoint
       )
     ).toEqual(["approve", "approve", "tokenToXtz", "approve"]);
+    expect(
+      operations.map(
+        (operation: { destination: string }) => operation.destination
+      )
+    ).toEqual([TOKEN_ADDRESS, TOKEN_ADDRESS, POOL_ADDRESS, TOKEN_ADDRESS]);
     expect(operations[0].parameters.value.value).toBe(0);
     expect(operations[1].parameters.value.value).toBe(1);
     expect(operations[3].parameters.value.value).toBe(0);
@@ -353,6 +382,11 @@ describe("SiriusAdapter", () => {
         (op: { parameters: { entrypoint: string } }) => op.parameters.entrypoint
       )
     ).toEqual(["approve", "approve", "addLiquidity", "approve"]);
+    expect(
+      operations.map(
+        (operation: { destination: string }) => operation.destination
+      )
+    ).toEqual([TOKEN_ADDRESS, TOKEN_ADDRESS, POOL_ADDRESS, TOKEN_ADDRESS]);
     expect(operations[2].amount).toBe("1000000");
   });
 
@@ -394,6 +428,9 @@ describe("SiriusAdapter", () => {
       })
     );
     expect(requestOperation).toHaveBeenCalledTimes(1);
+    expect(
+      requestOperation.mock.calls[0][0].operationDetails[0].destination
+    ).toBe(POOL_ADDRESS);
   });
 
   it("propagates a rejected atomic batch without attempting cleanup separately", async () => {

--- a/V2/tezex/src/adapters/sirius.test.ts
+++ b/V2/tezex/src/adapters/sirius.test.ts
@@ -1,0 +1,498 @@
+import { DAppClient } from "@airgap/beacon-dapp";
+import { TezosToolkit } from "@taquito/taquito";
+import BigNumber from "bignumber.js";
+
+import mainnet from "../config/network/mainnet.json";
+import { ExecutionKit, Token, TokenType } from "../types/general";
+import { PoolConfig, PoolType } from "../types/pools";
+import { PoolDataCache } from "../utils/poolDataCache";
+import { PoolRegistry } from "./poolRegistry";
+import { SiriusAdapter } from "./sirius";
+
+const POOL_ADDRESS = "KT1-sirius-pool";
+const TOKEN_ADDRESS = "KT1-tzbtc-token";
+const USER_ADDRESS = "tz1-user";
+
+const poolConfig: PoolConfig = {
+  id: "sirius-test",
+  name: "Sirius",
+  type: PoolType.SIRIUS,
+  address: POOL_ADDRESS,
+  tokenA: Token.XTZ,
+  tokenB: Token.TzBTC,
+  lpToken: Token.Sirs,
+};
+
+const auditedSnapshot = {
+  xtzPool: "4210300907572",
+  tokenPool: "1356293834",
+  lqtTotal: "27188438",
+};
+
+const integerModel = {
+  xtzToToken(input: string): string {
+    const xtzIn = BigInt(input);
+    const xtzPool = BigInt(auditedSnapshot.xtzPool);
+    const tokenPool = BigInt(auditedSnapshot.tokenPool);
+    const fee = BigInt(999);
+    const scale = BigInt(1000);
+    const amountNetBurn = (xtzIn * fee) / scale;
+    return (
+      (amountNetBurn * fee * tokenPool) /
+      (xtzPool * scale + amountNetBurn * fee)
+    ).toString();
+  },
+  tokenToXtz(input: string): string {
+    const tokenIn = BigInt(input);
+    const xtzPool = BigInt(auditedSnapshot.xtzPool);
+    const tokenPool = BigInt(auditedSnapshot.tokenPool);
+    const fee = BigInt(999);
+    const scale = BigInt(1000);
+    const grossXtz =
+      (tokenIn * fee * xtzPool) / (tokenPool * scale + tokenIn * fee);
+    return ((grossXtz * fee) / scale).toString();
+  },
+};
+
+type TransferOptions = { amount?: number; mutez?: boolean };
+
+const makeInvocation = (
+  destination: string,
+  entrypoint: string,
+  value: unknown
+) => ({
+  toTransferParams: jest.fn((options: TransferOptions = {}) => ({
+    to: destination,
+    amount: options.amount ?? 0,
+    mutez: options.mutez ?? false,
+    parameter: { entrypoint, value },
+  })),
+});
+
+const makeHarness = () => {
+  const poolMethods = {
+    xtzToToken: jest.fn((value) =>
+      makeInvocation(POOL_ADDRESS, "xtzToToken", value)
+    ),
+    tokenToXtz: jest.fn((value) =>
+      makeInvocation(POOL_ADDRESS, "tokenToXtz", value)
+    ),
+    addLiquidity: jest.fn((value) =>
+      makeInvocation(POOL_ADDRESS, "addLiquidity", value)
+    ),
+    removeLiquidity: jest.fn((value) =>
+      makeInvocation(POOL_ADDRESS, "removeLiquidity", value)
+    ),
+  };
+  const tokenMethods = {
+    approve: jest.fn((value) =>
+      makeInvocation(TOKEN_ADDRESS, "approve", value)
+    ),
+  };
+  const storage = jest.fn().mockResolvedValue(auditedSnapshot);
+  const poolContract = { methodsObject: poolMethods, storage };
+  const tokenContract = { methodsObject: tokenMethods };
+  const contractAt = jest.fn(async (address: string) =>
+    address === POOL_ADDRESS ? poolContract : tokenContract
+  );
+  const walletAt = jest.fn().mockResolvedValue(poolContract);
+  const requestOperation = jest
+    .fn()
+    .mockResolvedValue({ transactionHash: "operation-hash" });
+  const toolkit = {
+    contract: { at: contractAt },
+    wallet: { at: walletAt },
+  } as unknown as TezosToolkit;
+  const client = { requestOperation } as unknown as DAppClient;
+
+  return {
+    toolkit,
+    kit: { toolkit, client } as ExecutionKit,
+    contractAt,
+    walletAt,
+    requestOperation,
+    poolMethods,
+    tokenMethods,
+    storage,
+  };
+};
+
+describe("SiriusAdapter", () => {
+  beforeEach(() => {
+    PoolDataCache.clear();
+    PoolRegistry.clear();
+    PoolRegistry.initializeFromConfig(
+      [],
+      [
+        {
+          name: Token.TzBTC,
+          label: "tzBTC",
+          logo: "",
+          address: TOKEN_ADDRESS,
+          decimals: 8,
+          type: TokenType.FA12,
+        },
+      ]
+    );
+    jest.spyOn(console, "error").mockImplementation(() => undefined);
+    jest.spyOn(console, "warn").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it.each([
+    [Token.XTZ, "3112", "1"],
+    [Token.XTZ, "1000000", "321"],
+    [Token.XTZ, "1000000000", "321416"],
+    [Token.TzBTC, "1", "3097"],
+    [Token.TzBTC, "100", "309805"],
+    [Token.TzBTC, "1000000", "3095783319"],
+  ])(
+    "matches Michelson floor order for %s input %s",
+    async (inputToken, input, expectedOutput) => {
+      const { toolkit } = makeHarness();
+      const adapter = new SiriusAdapter(poolConfig);
+
+      const estimate = await adapter.estimateSwap(
+        toolkit,
+        inputToken,
+        new BigNumber(input)
+      );
+
+      expect(estimate.outputAmount.toFixed()).toBe(expectedOutput);
+    }
+  );
+
+  it("rejects a swap whose exact chain output rounds to zero", async () => {
+    const { toolkit } = makeHarness();
+    const adapter = new SiriusAdapter(poolConfig);
+
+    await expect(
+      adapter.estimateSwap(toolkit, Token.XTZ, new BigNumber(3111))
+    ).rejects.toThrow(/swap output must be a positive integer/i);
+  });
+
+  it("matches a literal integer model across deterministic input sweeps", async () => {
+    const { toolkit } = makeHarness();
+    const adapter = new SiriusAdapter(poolConfig);
+
+    for (let index = 0; index < 128; index += 1) {
+      const xtzInput = (3112 + index * 7919).toString();
+      const tokenInput = (1 + index * 6151).toString();
+      const xtzEstimate = await adapter.estimateSwap(
+        toolkit,
+        Token.XTZ,
+        new BigNumber(xtzInput)
+      );
+      const tokenEstimate = await adapter.estimateSwap(
+        toolkit,
+        Token.TzBTC,
+        new BigNumber(tokenInput)
+      );
+
+      expect(xtzEstimate.outputAmount.toFixed()).toBe(
+        integerModel.xtzToToken(xtzInput)
+      );
+      expect(tokenEstimate.outputAmount.toFixed()).toBe(
+        integerModel.tokenToXtz(tokenInput)
+      );
+    }
+  });
+
+  it("rejects unsupported assets before reading pool state", async () => {
+    const { toolkit, contractAt } = makeHarness();
+    const adapter = new SiriusAdapter(poolConfig);
+
+    await expect(
+      adapter.estimateSwap(toolkit, Token.BTCtz, new BigNumber(1000))
+    ).rejects.toThrow(/unsupported Sirius input token/i);
+    expect(contractAt).not.toHaveBeenCalled();
+  });
+
+  it("matches liquidity mint, requirement, and withdrawal floors", async () => {
+    const { toolkit } = makeHarness();
+    const adapter = new SiriusAdapter(poolConfig);
+
+    const requiredToken = await adapter.calculateRequiredTokenForLiquidity(
+      toolkit,
+      Token.XTZ,
+      new BigNumber(1000000)
+    );
+    const requiredXtz = await adapter.calculateRequiredTokenForLiquidity(
+      toolkit,
+      Token.TzBTC,
+      new BigNumber(323)
+    );
+    expect(requiredToken.toFixed()).toBe("323");
+    expect(requiredXtz.toFixed()).toBe("1002678");
+
+    const add = await adapter.estimateAddLiquidity(
+      toolkit,
+      Token.XTZ,
+      new BigNumber(1000000),
+      new BigNumber(323)
+    );
+    expect(add.lpTokenAmount.toFixed()).toBe("6");
+
+    const remove = await adapter.estimateRemoveLiquidity(
+      toolkit,
+      new BigNumber(1000)
+    );
+    expect(remove.tokenAAmount.toFixed()).toBe("154856299");
+    expect(remove.tokenBAmount.toFixed()).toBe("49884");
+  });
+
+  it("rejects a liquidity deposit that would mint zero SIRS", async () => {
+    const { toolkit } = makeHarness();
+    const adapter = new SiriusAdapter(poolConfig);
+
+    await expect(
+      adapter.estimateAddLiquidity(
+        toolkit,
+        Token.XTZ,
+        new BigNumber(1),
+        new BigNumber(1)
+      )
+    ).rejects.toThrow(/SIRS minted must be a positive integer/i);
+  });
+
+  it("caches storage reads but honors an explicit refresh", async () => {
+    const { toolkit, storage } = makeHarness();
+    const adapter = new SiriusAdapter(poolConfig);
+
+    await adapter.getPoolData(toolkit);
+    await adapter.getPoolData(toolkit);
+    expect(storage).toHaveBeenCalledTimes(1);
+
+    await adapter.getPoolData(toolkit, true);
+    expect(storage).toHaveBeenCalledTimes(2);
+  });
+
+  it("submits a protected direct XTZ-to-token swap", async () => {
+    const { kit, requestOperation, poolMethods } = makeHarness();
+    const adapter = new SiriusAdapter(poolConfig);
+
+    await expect(
+      adapter.executeSwap(
+        kit,
+        USER_ADDRESS,
+        Token.XTZ,
+        new BigNumber(1000000),
+        new BigNumber(321),
+        0.5
+      )
+    ).resolves.toBe("operation-hash");
+
+    expect(poolMethods.xtzToToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: USER_ADDRESS,
+        minTokensBought: 319,
+      })
+    );
+    const operation = requestOperation.mock.calls[0][0].operationDetails[0];
+    expect(operation.amount).toBe("1000000");
+    expect(operation.parameters.entrypoint).toBe("xtzToToken");
+  });
+
+  it("keeps token approval reset, swap, and cleanup in one wallet batch", async () => {
+    const { kit, requestOperation, poolMethods } = makeHarness();
+    const adapter = new SiriusAdapter(poolConfig);
+
+    await adapter.executeSwap(
+      kit,
+      USER_ADDRESS,
+      Token.TzBTC,
+      new BigNumber(1),
+      new BigNumber(3097),
+      0.5
+    );
+
+    expect(poolMethods.tokenToXtz).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: USER_ADDRESS,
+        tokensSold: 1,
+        minXtzBought: 3081,
+      })
+    );
+    const operations = requestOperation.mock.calls[0][0].operationDetails;
+    expect(
+      operations.map(
+        (op: { parameters: { entrypoint: string } }) => op.parameters.entrypoint
+      )
+    ).toEqual(["approve", "approve", "tokenToXtz", "approve"]);
+    expect(operations[0].parameters.value.value).toBe(0);
+    expect(operations[1].parameters.value.value).toBe(1);
+    expect(operations[3].parameters.value.value).toBe(0);
+  });
+
+  it("applies slippage to both maximum tzBTC and minimum SIRS", async () => {
+    const { kit, requestOperation, poolMethods } = makeHarness();
+    const adapter = new SiriusAdapter(poolConfig);
+
+    await adapter.executeAddLiquidity(
+      kit,
+      USER_ADDRESS,
+      new BigNumber(1000000),
+      new BigNumber(500),
+      new BigNumber(1000),
+      0.5
+    );
+
+    expect(poolMethods.addLiquidity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner: USER_ADDRESS,
+        minLqtMinted: 995,
+        maxTokensDeposited: 502,
+      })
+    );
+    const operations = requestOperation.mock.calls[0][0].operationDetails;
+    expect(
+      operations.map(
+        (op: { parameters: { entrypoint: string } }) => op.parameters.entrypoint
+      )
+    ).toEqual(["approve", "approve", "addLiquidity", "approve"]);
+    expect(operations[2].amount).toBe("1000000");
+  });
+
+  it("rejects add-liquidity when slippage would reduce minimum SIRS to zero", async () => {
+    const { kit, requestOperation, contractAt } = makeHarness();
+    const adapter = new SiriusAdapter(poolConfig);
+
+    await expect(
+      adapter.executeAddLiquidity(
+        kit,
+        USER_ADDRESS,
+        new BigNumber(1000000),
+        new BigNumber(500),
+        new BigNumber(1),
+        0.1
+      )
+    ).rejects.toThrow(/minimum SIRS minted must be a positive integer/i);
+    expect(contractAt).not.toHaveBeenCalled();
+    expect(requestOperation).not.toHaveBeenCalled();
+  });
+
+  it("floors both remove-liquidity outputs before applying slippage", async () => {
+    const { kit, requestOperation, poolMethods } = makeHarness();
+    const adapter = new SiriusAdapter(poolConfig);
+
+    await adapter.executeRemoveLiquidity(
+      kit,
+      USER_ADDRESS,
+      new BigNumber(1000),
+      0.5
+    );
+
+    expect(poolMethods.removeLiquidity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: USER_ADDRESS,
+        lqtBurned: 1000,
+        minXtzWithdrawn: 154082017,
+        minTokensWithdrawn: 49634,
+      })
+    );
+    expect(requestOperation).toHaveBeenCalledTimes(1);
+  });
+
+  it("propagates a rejected atomic batch without attempting cleanup separately", async () => {
+    const { kit, requestOperation } = makeHarness();
+    requestOperation.mockRejectedValueOnce(new Error("wallet rejected"));
+    const adapter = new SiriusAdapter(poolConfig);
+
+    await expect(
+      adapter.executeAddLiquidity(
+        kit,
+        USER_ADDRESS,
+        new BigNumber(1000000),
+        new BigNumber(500),
+        new BigNumber(1000),
+        0.5
+      )
+    ).rejects.toThrow("wallet rejected");
+
+    expect(requestOperation).toHaveBeenCalledTimes(1);
+    expect(requestOperation.mock.calls[0][0].operationDetails).toHaveLength(4);
+  });
+
+  it("rejects a zero minimum after slippage before asking the wallet", async () => {
+    const { kit, requestOperation, contractAt } = makeHarness();
+    const adapter = new SiriusAdapter(poolConfig);
+
+    await expect(
+      adapter.executeSwap(
+        kit,
+        USER_ADDRESS,
+        Token.XTZ,
+        new BigNumber(3112),
+        new BigNumber(1),
+        0.1
+      )
+    ).rejects.toThrow(/minimum swap output must be a positive integer/i);
+    expect(contractAt).not.toHaveBeenCalled();
+    expect(requestOperation).not.toHaveBeenCalled();
+  });
+
+  it("rejects unsafe slippage and inexact JavaScript contract parameters", async () => {
+    const { kit, requestOperation } = makeHarness();
+    const adapter = new SiriusAdapter(poolConfig);
+
+    await expect(
+      adapter.executeSwap(
+        kit,
+        USER_ADDRESS,
+        Token.XTZ,
+        new BigNumber(1000000),
+        new BigNumber(321),
+        10
+      )
+    ).rejects.toThrow(/slippage tolerance is outside safe limits/i);
+    await expect(
+      adapter.executeSwap(
+        kit,
+        USER_ADDRESS,
+        Token.XTZ,
+        new BigNumber("9007199254740992"),
+        new BigNumber(321),
+        0.5
+      )
+    ).rejects.toThrow(/exceeds the exact JavaScript integer range/i);
+    expect(requestOperation).not.toHaveBeenCalled();
+  });
+
+  it("pins the canonical mainnet pool and asset configuration", () => {
+    const sirius = mainnet.pools.find((pool) => pool.id === "xtz-tzbtc-sirius");
+    const token = mainnet.assets.find((asset) => asset.name === "TzBTC");
+    const lpToken = mainnet.assets.find((asset) => asset.name === "Sirs");
+
+    expect(sirius).toMatchObject({
+      type: PoolType.SIRIUS,
+      address: "KT1TxqZ8QtKvLu3V3JH7Gx58n7Co8pgtpQU5",
+      tokenA: Token.XTZ,
+      tokenB: Token.TzBTC,
+      lpToken: Token.Sirs,
+    });
+    expect(token).toMatchObject({
+      address: "KT1PWx2mnDueood7fEmfbBDKx1D9BAnnXitn",
+      decimals: 8,
+      type: TokenType.FA12,
+    });
+    expect(lpToken).toMatchObject({
+      address: "KT1AafHA1C1vk959wvHWBispY9Y2f3fxBUUo",
+      decimals: 0,
+      type: TokenType.FA12,
+    });
+  });
+
+  it("rejects a Sirius adapter configured for token-to-token routing", () => {
+    expect(
+      () =>
+        new SiriusAdapter({
+          ...poolConfig,
+          tokenA: Token.BTCtz,
+          tokenB: Token.TzBTC,
+        })
+    ).toThrow(/only the direct XTZ\/tzBTC pool/i);
+  });
+});

--- a/V2/tezex/src/adapters/sirius.ts
+++ b/V2/tezex/src/adapters/sirius.ts
@@ -6,6 +6,7 @@ import {
   PoolData,
   RemoveLiquidityEstimate,
   SwapEstimate,
+  isSupportedPoolConfiguration,
 } from "../types/pools";
 import BigNumber from "bignumber.js";
 import { ExecutionKit, Token } from "../types/general";
@@ -14,19 +15,27 @@ import { PoolDataCache } from "../utils/poolDataCache";
 import { getTxDeadline } from "../functions/util";
 import { DAppClient } from "@airgap/beacon-dapp";
 import { transferParamsToBeaconOp } from "../functions/transactions";
+import { isValidSlippage } from "../functions/transactionSafety";
 
 export class SiriusAdapter implements IPoolAdapter {
   private readonly FEE = 999; // 0.1% fee
   private readonly BURN = 999; // 0.1% burned
 
-  constructor(public poolConfig: PoolConfig) {}
+  constructor(public poolConfig: PoolConfig) {
+    if (!isSupportedPoolConfiguration(poolConfig)) {
+      throw new Error("Sirius supports only the direct XTZ/tzBTC pool");
+    }
+  }
 
   async estimateSwap(
     toolkit: TezosToolkit,
     inputToken: Token,
     inputAmount: BigNumber
   ): Promise<SwapEstimate> {
+    this.assertSupportedInputToken(inputToken);
+    this.assertPositiveInteger("swap input", inputAmount);
     const poolData = await this.getPoolData(toolkit);
+    this.assertActivePool(poolData);
     const { tokenAPool: xtzPool, tokenBPool: tokenPool } = poolData;
 
     const isXtzInput = inputToken === Token.XTZ;
@@ -37,6 +46,7 @@ export class SiriusAdapter implements IPoolAdapter {
     } else {
       outputAmount = this.calcTokenToXtz(inputAmount, xtzPool, tokenPool);
     }
+    this.assertPositiveInteger("swap output", outputAmount);
 
     return {
       inputAmount,
@@ -50,7 +60,11 @@ export class SiriusAdapter implements IPoolAdapter {
     tokenAAmount: BigNumber,
     tokenBAmount: BigNumber
   ): Promise<AddLiquidityEstimate> {
+    this.assertSupportedInputToken(inputToken);
+    this.assertPositiveInteger("first liquidity amount", tokenAAmount);
+    this.assertPositiveInteger("second liquidity amount", tokenBAmount);
     const poolData = await this.getPoolData(toolkit);
+    this.assertActivePool(poolData);
     const { tokenAPool: xtzPool, lpTokenSupply: lqtTotal } = poolData;
 
     const xtzAmount = inputToken === Token.XTZ ? tokenAAmount : tokenBAmount;
@@ -60,6 +74,7 @@ export class SiriusAdapter implements IPoolAdapter {
       .times(lqtTotal)
       .dividedBy(xtzPool)
       .integerValue(BigNumber.ROUND_DOWN);
+    this.assertPositiveInteger("SIRS minted", lpTokenAmount);
 
     return {
       tokenAAmount,
@@ -72,15 +87,25 @@ export class SiriusAdapter implements IPoolAdapter {
     toolkit: TezosToolkit,
     lpTokenAmount: BigNumber
   ): Promise<RemoveLiquidityEstimate> {
+    this.assertPositiveInteger("SIRS burned", lpTokenAmount);
     const poolData = await this.getPoolData(toolkit);
+    this.assertActivePool(poolData);
     const {
       tokenAPool: xtzPool,
       tokenBPool: tokenPool,
       lpTokenSupply: lqtTotal,
     } = poolData;
 
-    const xtzReceived = lpTokenAmount.times(xtzPool).dividedBy(lqtTotal);
-    const tokenReceived = lpTokenAmount.times(tokenPool).dividedBy(lqtTotal);
+    const xtzReceived = lpTokenAmount
+      .times(xtzPool)
+      .dividedBy(lqtTotal)
+      .integerValue(BigNumber.ROUND_DOWN);
+    const tokenReceived = lpTokenAmount
+      .times(tokenPool)
+      .dividedBy(lqtTotal)
+      .integerValue(BigNumber.ROUND_DOWN);
+    this.assertPositiveInteger("XTZ withdrawn", xtzReceived);
+    this.assertPositiveInteger("tzBTC withdrawn", tokenReceived);
 
     return {
       lpTokenAmount,
@@ -95,7 +120,10 @@ export class SiriusAdapter implements IPoolAdapter {
     inputAmount: BigNumber
   ): Promise<BigNumber> {
     try {
+      this.assertSupportedInputToken(inputToken);
+      this.assertPositiveInteger("liquidity input", inputAmount);
       const storage = await this.getPoolData(toolkit);
+      this.assertActivePool(storage);
       const { tokenAPool: xtzPool, tokenBPool: tokenPool } = storage;
 
       const isXtzInput = inputToken === Token.XTZ;
@@ -108,15 +136,17 @@ export class SiriusAdapter implements IPoolAdapter {
           .dividedBy(xtzPool)
           .integerValue(BigNumber.ROUND_CEIL);
 
+        this.assertPositiveInteger("required tzBTC", requiredToken);
         return requiredToken;
       } else {
         // User input token, calculate required XTZ
-        // Formula: ceildiv(tokenAmount * xtzPool, tokenPool)
+        // Formula: floordiv(tokenAmount * xtzPool, tokenPool)
         const numerator = inputAmount.times(xtzPool);
         const requiredXtz = numerator
           .dividedBy(tokenPool)
           .integerValue(BigNumber.ROUND_DOWN);
 
+        this.assertPositiveInteger("required XTZ", requiredXtz);
         return requiredXtz;
       }
     } catch (error) {
@@ -134,9 +164,14 @@ export class SiriusAdapter implements IPoolAdapter {
     slippage: number
   ): Promise<string> {
     const { client, toolkit } = kit;
+    this.assertSupportedInputToken(inputToken);
+    this.assertPositiveInteger("swap input", inputAmount);
+    this.assertPositiveInteger("quoted swap output", minOutputAmount);
+    this.assertValidSlippage(slippage);
     const isXtzInput = inputToken === Token.XTZ;
 
     const minWithSlippage = this.removeSlippage(slippage, minOutputAmount);
+    this.assertPositiveInteger("minimum swap output", minWithSlippage);
 
     let opHash: string;
     if (isXtzInput) {
@@ -172,17 +207,24 @@ export class SiriusAdapter implements IPoolAdapter {
   ): Promise<string> {
     const { client, toolkit } = kit;
     try {
+      this.assertPositiveInteger("XTZ deposit", tokenAAmount);
+      this.assertPositiveInteger("tzBTC deposit", tokenBAmount);
+      this.assertPositiveInteger("quoted SIRS", minLpTokens);
+      this.assertValidSlippage(slippage);
       const deadline = getTxDeadline().toISOString();
       const tokenAddress = PoolRegistry.getAssetAddress(this.poolConfig.tokenB);
-
-      const lbContract = await toolkit.contract.at(this.poolConfig.address);
-      const tokenContract = await toolkit.contract.at(tokenAddress);
 
       // Calculate max tokens with slippage
       const maxTokensSold = this.addSlippage(
         new BigNumber(slippage),
         tokenBAmount
       );
+      const minLqtMinted = this.removeSlippage(slippage, minLpTokens);
+      this.assertPositiveInteger("maximum tzBTC deposit", maxTokensSold);
+      this.assertPositiveInteger("minimum SIRS minted", minLqtMinted);
+
+      const lbContract = await toolkit.contract.at(this.poolConfig.address);
+      const tokenContract = await toolkit.contract.at(tokenAddress);
 
       // Prepare operations
       const approve0 = tokenContract.methodsObject.approve({
@@ -191,12 +233,15 @@ export class SiriusAdapter implements IPoolAdapter {
       });
       const approve1 = tokenContract.methodsObject.approve({
         spender: this.poolConfig.address,
-        value: maxTokensSold.toNumber(),
+        value: this.toSafeNumber("maximum tzBTC deposit", maxTokensSold),
       });
       const addLiq = lbContract.methodsObject.addLiquidity({
         owner: userAddress,
-        minLqtMinted: minLpTokens.integerValue(BigNumber.ROUND_DOWN).toNumber(),
-        maxTokensDeposited: maxTokensSold.toNumber(),
+        minLqtMinted: this.toSafeNumber("minimum SIRS minted", minLqtMinted),
+        maxTokensDeposited: this.toSafeNumber(
+          "maximum tzBTC deposit",
+          maxTokensSold
+        ),
         deadline,
       });
 
@@ -206,7 +251,7 @@ export class SiriusAdapter implements IPoolAdapter {
         transferParamsToBeaconOp(approve1.toTransferParams()),
         transferParamsToBeaconOp(
           addLiq.toTransferParams({
-            amount: tokenAAmount.toNumber(),
+            amount: this.toSafeNumber("XTZ deposit", tokenAAmount),
             mutez: true,
           })
         ),
@@ -234,6 +279,8 @@ export class SiriusAdapter implements IPoolAdapter {
   ): Promise<string> {
     const { client, toolkit } = kit;
     try {
+      this.assertPositiveInteger("SIRS burned", lpTokenAmount);
+      this.assertValidSlippage(slippage);
       // Entrypoint signature:
       // removeLiquidity(address to, nat lqtBurned, mutez minXtzWithdrawn, nat minTokensWithdrawn, timestamp deadline)
       const deadline = getTxDeadline().toISOString();
@@ -246,15 +293,28 @@ export class SiriusAdapter implements IPoolAdapter {
 
       const lbContract = await toolkit.wallet.at(this.poolConfig.address);
 
+      const minXtzWithdrawn = this.removeSlippage(
+        slippage,
+        estimate.tokenAAmount
+      );
+      const minTokensWithdrawn = this.removeSlippage(
+        slippage,
+        estimate.tokenBAmount
+      );
+      this.assertPositiveInteger("minimum XTZ withdrawn", minXtzWithdrawn);
+      this.assertPositiveInteger("minimum tzBTC withdrawn", minTokensWithdrawn);
+
       const operation = lbContract.methodsObject.removeLiquidity({
         to: userAddress,
-        lqtBurned: lpTokenAmount.integerValue(BigNumber.ROUND_DOWN).toNumber(),
-        minXtzWithdrawn: this.removeSlippage(slippage, estimate.tokenAAmount)
-          .integerValue(BigNumber.ROUND_DOWN)
-          .toNumber(),
-        minTokensWithdrawn: this.removeSlippage(slippage, estimate.tokenBAmount)
-          .integerValue(BigNumber.ROUND_DOWN)
-          .toNumber(),
+        lqtBurned: this.toSafeNumber("SIRS burned", lpTokenAmount),
+        minXtzWithdrawn: this.toSafeNumber(
+          "minimum XTZ withdrawn",
+          minXtzWithdrawn
+        ),
+        minTokensWithdrawn: this.toSafeNumber(
+          "minimum tzBTC withdrawn",
+          minTokensWithdrawn
+        ),
         deadline,
       });
       // Execute
@@ -316,7 +376,10 @@ export class SiriusAdapter implements IPoolAdapter {
   ): BigNumber {
     // Step 1: Apply burn to input (0.1%)
     // amount_net_burn = (xtzIn * 999) / 1000
-    const amountNetBurn = xtzIn.times(this.BURN).div(1000);
+    const amountNetBurn = xtzIn
+      .times(this.BURN)
+      .div(1000)
+      .integerValue(BigNumber.ROUND_DOWN);
 
     // Step 2: Calculate tokens bought with fee
     // tokens_bought = (amount_net_burn * 999 * tokenPool) / (xtzPool * 1000 + amount_net_burn * 999)
@@ -335,7 +398,9 @@ export class SiriusAdapter implements IPoolAdapter {
     // xtz_bought = (tokensSold * 999 * xtzPool) / (tokenPool * 1000 + tokensSold * 999)
     const numerator = tokenIn.times(this.FEE).times(xtzPool);
     const denominator = tokenPool.times(1000).plus(tokenIn.times(this.FEE));
-    const xtzBought = numerator.div(denominator);
+    const xtzBought = numerator
+      .div(denominator)
+      .integerValue(BigNumber.ROUND_DOWN);
 
     // Step 2: Apply burn to output (0.1%)
     // xtz_bought_net_burn = (xtz_bought * 999) / 1000
@@ -359,14 +424,17 @@ export class SiriusAdapter implements IPoolAdapter {
 
       const operation = lbContract.methodsObject.xtzToToken({
         to: userAddress,
-        minTokensBought: minTokensBought.toNumber(),
+        minTokensBought: this.toSafeNumber(
+          "minimum tzBTC bought",
+          minTokensBought
+        ),
         deadline,
       });
 
       // Convert to Beacon format
       const operationRequest = transferParamsToBeaconOp(
         operation.toTransferParams({
-          amount: xtzAmount.toNumber(),
+          amount: this.toSafeNumber("XTZ sold", xtzAmount),
           mutez: true,
         })
       );
@@ -404,12 +472,12 @@ export class SiriusAdapter implements IPoolAdapter {
       });
       const approve = tokenContract.methodsObject.approve({
         spender: this.poolConfig.address,
-        value: tokenAmount.integerValue(BigNumber.ROUND_DOWN).toNumber(),
+        value: this.toSafeNumber("tzBTC sold", tokenAmount),
       });
       const transfer = lbContract.methodsObject.tokenToXtz({
         to: userAddress,
-        tokensSold: tokenAmount.integerValue(BigNumber.ROUND_DOWN).toNumber(),
-        minXtzBought: minXtzBought.toNumber(),
+        tokensSold: this.toSafeNumber("tzBTC sold", tokenAmount),
+        minXtzBought: this.toSafeNumber("minimum XTZ bought", minXtzBought),
         deadline,
       });
 
@@ -418,6 +486,7 @@ export class SiriusAdapter implements IPoolAdapter {
         transferParamsToBeaconOp(approve0.toTransferParams()),
         transferParamsToBeaconOp(approve.toTransferParams()),
         transferParamsToBeaconOp(transfer.toTransferParams()),
+        transferParamsToBeaconOp(approve0.toTransferParams()),
       ];
       const response = await client.requestOperation({
         operationDetails: operations,
@@ -439,5 +508,37 @@ export class SiriusAdapter implements IPoolAdapter {
     return amount
       .plus(amount.times(slippage).div(100))
       .integerValue(BigNumber.ROUND_DOWN);
+  }
+
+  private assertSupportedInputToken(inputToken: Token): void {
+    if (inputToken !== Token.XTZ && inputToken !== Token.TzBTC) {
+      throw new Error(`Unsupported Sirius input token: ${inputToken}`);
+    }
+  }
+
+  private assertPositiveInteger(name: string, value: BigNumber): void {
+    if (!value.isFinite() || !value.isInteger() || value.lte(0)) {
+      throw new Error(`${name} must be a positive integer`);
+    }
+  }
+
+  private assertActivePool(poolData: PoolData): void {
+    this.assertPositiveInteger("Sirius XTZ reserve", poolData.tokenAPool);
+    this.assertPositiveInteger("Sirius tzBTC reserve", poolData.tokenBPool);
+    this.assertPositiveInteger("Sirius SIRS supply", poolData.lpTokenSupply);
+  }
+
+  private assertValidSlippage(slippage: number): void {
+    if (!isValidSlippage(slippage)) {
+      throw new Error("Sirius slippage tolerance is outside safe limits");
+    }
+  }
+
+  private toSafeNumber(name: string, value: BigNumber): number {
+    this.assertPositiveInteger(name, value);
+    if (value.gt(Number.MAX_SAFE_INTEGER)) {
+      throw new Error(`${name} exceeds the exact JavaScript integer range`);
+    }
+    return value.toNumber();
   }
 }

--- a/V2/tezex/src/adapters/sirius.ts
+++ b/V2/tezex/src/adapters/sirius.ts
@@ -17,6 +17,14 @@ import { DAppClient } from "@airgap/beacon-dapp";
 import { transferParamsToBeaconOp } from "../functions/transactions";
 import { isValidSlippage } from "../functions/transactionSafety";
 
+interface SiriusStorage {
+  xtzPool: BigNumber.Value;
+  tokenPool: BigNumber.Value;
+  lqtTotal: BigNumber.Value;
+  tokenAddress: string;
+  lqtAddress: string;
+}
+
 export class SiriusAdapter implements IPoolAdapter {
   private readonly FEE = 999; // 0.1% fee
   private readonly BURN = 999; // 0.1% burned
@@ -348,8 +356,20 @@ export class SiriusAdapter implements IPoolAdapter {
     }
 
     const contract = await toolkit.contract.at(this.poolConfig.address);
-    // eslint-disable-next-line
-    const storage = await contract.storage<any>();
+    const storage = await contract.storage<SiriusStorage>();
+
+    if (storage) {
+      this.assertStorageAddress(
+        "underlying token",
+        storage.tokenAddress,
+        PoolRegistry.getAssetAddress(this.poolConfig.tokenB)
+      );
+      this.assertStorageAddress(
+        "SIRS",
+        storage.lqtAddress,
+        PoolRegistry.getAssetAddress(this.poolConfig.lpToken)
+      );
+    }
 
     const poolData: PoolData = storage
       ? {
@@ -531,6 +551,18 @@ export class SiriusAdapter implements IPoolAdapter {
   private assertValidSlippage(slippage: number): void {
     if (!isValidSlippage(slippage)) {
       throw new Error("Sirius slippage tolerance is outside safe limits");
+    }
+  }
+
+  private assertStorageAddress(
+    name: string,
+    actual: string,
+    expected: string
+  ): void {
+    if (actual !== expected) {
+      throw new Error(
+        `Sirius ${name} storage mismatch: expected ${expected}, received ${actual}`
+      );
     }
   }
 

--- a/V2/tezex/src/components/swap/tokenRouting.test.ts
+++ b/V2/tezex/src/components/swap/tokenRouting.test.ts
@@ -1,5 +1,6 @@
 import { Token, TokenType } from "../../types/general";
 import { PoolConfig, PoolType } from "../../types/pools";
+import { PoolRegistry } from "../../adapters/poolRegistry";
 import { findPoolForTokenPair, getCompatibleSwapAssets } from "./tokenRouting";
 
 const pools: PoolConfig[] = [
@@ -54,5 +55,37 @@ describe("swap token routing", () => {
         (asset) => asset.name
       )
     ).toEqual([Token.XTZ]);
+  });
+
+  it("does not synthesize a token-to-token route through Sirius", () => {
+    expect(
+      findPoolForTokenPair(pools, Token.TzBTC, Token.BTCtz)
+    ).toBeUndefined();
+    expect(
+      getCompatibleSwapAssets(pools, Token.TzBTC, getAsset).map(
+        (asset) => asset.name
+      )
+    ).toEqual([Token.XTZ]);
+  });
+
+  it("rejects and hides a Sirius pool configured without a direct XTZ leg", () => {
+    const unsupported: PoolConfig = {
+      ...pools[0],
+      id: "unsupported-sirius-token-route",
+      tokenA: Token.BTCtz,
+      tokenB: Token.TzBTC,
+    };
+
+    expect(
+      findPoolForTokenPair([unsupported], Token.BTCtz, Token.TzBTC)
+    ).toBeUndefined();
+    expect(
+      getCompatibleSwapAssets([unsupported], Token.BTCtz, getAsset)
+    ).toEqual([]);
+
+    PoolRegistry.clear();
+    expect(() => PoolRegistry.registerPool(unsupported)).toThrow(
+      /unsupported pool configuration/i
+    );
   });
 });

--- a/V2/tezex/src/components/swap/tokenRouting.ts
+++ b/V2/tezex/src/components/swap/tokenRouting.ts
@@ -1,16 +1,12 @@
 import { Asset, Token } from "../../types/general";
-import { PoolConfig } from "../../types/pools";
+import { PoolConfig, supportsDirectSwap } from "../../types/pools";
 
 export const findPoolForTokenPair = (
   pools: PoolConfig[],
   tokenA: Token,
   tokenB: Token
 ): PoolConfig | undefined =>
-  pools.find(
-    (pool) =>
-      (pool.tokenA === tokenA && pool.tokenB === tokenB) ||
-      (pool.tokenA === tokenB && pool.tokenB === tokenA)
-  );
+  pools.find((pool) => supportsDirectSwap(pool, tokenA, tokenB));
 
 export const getCompatibleSwapAssets = (
   pools: PoolConfig[],
@@ -27,7 +23,11 @@ export const getCompatibleSwapAssets = (
         ? pool.tokenA
         : undefined;
 
-    if (token && !compatibleTokens.includes(token))
+    if (
+      token &&
+      supportsDirectSwap(pool, counterpart, token) &&
+      !compatibleTokens.includes(token)
+    )
       compatibleTokens.push(token);
   });
 

--- a/V2/tezex/src/types/pools.ts
+++ b/V2/tezex/src/types/pools.ts
@@ -48,6 +48,36 @@ export interface PoolData {
   protocolFeeBp?: number; // 0 for classic pools, >0 for mod pools with protocol fee
 }
 
+export const isSupportedPoolConfiguration = (pool: PoolConfig): boolean =>
+  pool.type !== PoolType.SIRIUS ||
+  (pool.tokenA === Token.XTZ &&
+    pool.tokenB === Token.TzBTC &&
+    pool.lpToken === Token.Sirs);
+
+export const supportsDirectSwap = (
+  pool: PoolConfig,
+  inputToken: Token,
+  outputToken: Token
+): boolean => {
+  if (!isSupportedPoolConfiguration(pool) || inputToken === outputToken) {
+    return false;
+  }
+
+  const matchesConfiguredPair =
+    (pool.tokenA === inputToken && pool.tokenB === outputToken) ||
+    (pool.tokenA === outputToken && pool.tokenB === inputToken);
+
+  if (!matchesConfiguredPair) return false;
+
+  // Sirius' immutable tokenToToken entrypoint is deliberately unsupported.
+  // Every Sirius route exposed by TEZEX must be one direct XTZ leg.
+  return (
+    pool.type !== PoolType.SIRIUS ||
+    inputToken === Token.XTZ ||
+    outputToken === Token.XTZ
+  );
+};
+
 export interface IPoolAdapter {
   poolConfig: PoolConfig;
 


### PR DESCRIPTION
## Summary

- match the immutable Sirius contract's intermediate integer-floor order in both direct swap directions
- reject unsupported assets, malformed pool configurations, zero outputs, zero SIRS results, unsafe slippage, and inexact contract parameters
- bind decoded pool storage to the configured underlying-token and SIRS contracts at runtime
- apply slippage to the minimum SIRS minted and keep allowance reset, approval, action, and cleanup in one atomic wallet batch
- exclude Sirius token-to-token routing from the registry and swap UI
- add direct adapter tests, a focused security review, and an opt-in live no-broadcast rehearsal

## Why

The previous adapter could overquote a swap by one atomic unit, did not protect the minimum liquidity-token output with user-selected slippage, and lacked direct regression coverage for the external contract boundary.

Closes #249.

## Validation

- `npm run verify` passed on commit `bd46147`
- normal test run: 28 suites passed; 124 tests passed, 2 live tests skipped
- focused Sirius suites: 27 tests passed
- TypeScript, ESLint, Prettier, the configured high-severity npm audit threshold, and the optimized production build passed
- live mainnet no-broadcast rehearsal: 5 tests passed at block `BKrd5HFbQMu8xa3qkjEQQEMo6wMzF5vp3y87xyiCZTawjW96k4u`, level `14,387,043`
- rehearsal verified the configured chain ID, raw storage token/SIRS addresses, and every constructed operation destination

## Release rehearsal

The no-broadcast release gate is complete. A capture-only Beacon client verified current mainnet chain and contract state, then constructed both direct swaps, add/remove liquidity, wallet rejection, and allowance cleanup paths. Each operation was checked against its canonical destination. The client had no signer and could not broadcast.

This pull request is ready for a fresh independent review of the updated final diff.