### PR TITLE
Preserve exact transaction integers

### DIFF
--- a/V2/tezex/src/adapters/tezex.test.ts
+++ b/V2/tezex/src/adapters/tezex.test.ts
@@ -1,0 +1,211 @@
+import { DAppClient } from "@airgap/beacon-sdk";
+import { TezosToolkit } from "@taquito/taquito";
+import BigNumber from "bignumber.js";
+
+import { ExecutionKit, Token, TokenType } from "../types/general";
+import { PoolConfig, PoolType } from "../types/pools";
+import { PoolDataCache } from "../utils/poolDataCache";
+import { PoolRegistry } from "./poolRegistry";
+import { TezexAdapter } from "./tezex";
+
+jest.mock("../functions/util", () => {
+  const actual = jest.requireActual("../functions/util");
+  return {
+    ...actual,
+    makeEstimationToolkit: () => ({
+      estimate: {
+        batch: jest.fn().mockRejectedValue(new Error("estimation unavailable")),
+        transfer: jest
+          .fn()
+          .mockRejectedValue(new Error("estimation unavailable")),
+      },
+    }),
+  };
+});
+
+const POOL_ADDRESS = "KT1-pool";
+const TOKEN_ADDRESS = "KT1-token";
+const USER_ADDRESS = "tz1-user";
+const ETHtz = "ETHtz" as Token;
+
+type TransferOptions = { amount?: number; mutez?: boolean };
+
+const makeInvocation = (
+  destination: string,
+  entrypoint: string,
+  value: unknown
+) => ({
+  toTransferParams: jest.fn((options: TransferOptions = {}) => ({
+    to: destination,
+    amount: options.amount ?? 0,
+    mutez: options.mutez ?? false,
+    parameter: { entrypoint, value },
+  })),
+});
+
+const makeHarness = () => {
+  const poolMethods = {
+    tokenToXtz: jest.fn((value) =>
+      makeInvocation(POOL_ADDRESS, "tokenToXtz", value)
+    ),
+  };
+  const tokenMethods = {
+    approve: jest.fn((value) =>
+      makeInvocation(TOKEN_ADDRESS, "approve", value)
+    ),
+    update_operators: jest.fn((value) =>
+      makeInvocation(TOKEN_ADDRESS, "update_operators", value)
+    ),
+  };
+  const poolContract = {
+    methodsObject: poolMethods,
+    storage: jest.fn().mockResolvedValue({
+      xtzPool: "1000000000",
+      tokenPool: "1000000000",
+      lqtTotal: "1000000",
+    }),
+  };
+  const tokenContract = { methodsObject: tokenMethods };
+  const contractAt = jest.fn(async (address: string) =>
+    address === POOL_ADDRESS ? poolContract : tokenContract
+  );
+  const requestOperation = jest
+    .fn()
+    .mockResolvedValue({ transactionHash: "operation-hash" });
+  const toolkit = {
+    contract: { at: contractAt },
+  } as unknown as TezosToolkit;
+  const client = { requestOperation } as unknown as DAppClient;
+
+  return {
+    kit: { toolkit, client } as ExecutionKit,
+    requestOperation,
+    poolMethods,
+    tokenMethods,
+  };
+};
+
+const makePool = (tokenB: Token): PoolConfig => ({
+  id: `xtz-${tokenB}`,
+  name: "TEZEX",
+  type: PoolType.TEZEX,
+  address: POOL_ADDRESS,
+  tokenA: Token.XTZ,
+  tokenB,
+  lpToken: Token.LP_XTZUSDt,
+});
+
+describe("TezexAdapter exact transaction construction", () => {
+  beforeEach(() => {
+    PoolDataCache.clear();
+    PoolRegistry.clear();
+    jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    jest.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("removes an FA2 operator after an exact token-to-XTZ swap", async () => {
+    PoolRegistry.initializeFromConfig(
+      [],
+      [
+        {
+          name: Token.USDt,
+          label: "USDt",
+          logo: "",
+          address: TOKEN_ADDRESS,
+          decimals: 6,
+          type: TokenType.FA2,
+          tokenId: 7,
+        },
+      ]
+    );
+    const { kit, requestOperation, poolMethods } = makeHarness();
+    const adapter = new TezexAdapter(makePool(Token.USDt));
+
+    await adapter.executeSwap(
+      kit,
+      USER_ADDRESS,
+      Token.USDt,
+      new BigNumber("9007199254740993"),
+      new BigNumber("1000000"),
+      0.5
+    );
+
+    expect(poolMethods.tokenToXtz).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tokensSold: "9007199254740993",
+        minXtzBought: "995000",
+      })
+    );
+    const operations = requestOperation.mock.calls[0][0].operationDetails;
+    expect(
+      operations.map(
+        (operation: { parameters: { entrypoint: string } }) =>
+          operation.parameters.entrypoint
+      )
+    ).toEqual(["update_operators", "tokenToXtz", "update_operators"]);
+    expect(operations[0].parameters.value).toEqual([
+      {
+        add_operator: {
+          owner: USER_ADDRESS,
+          operator: POOL_ADDRESS,
+          token_id: 7,
+        },
+      },
+    ]);
+    expect(operations[2].parameters.value).toEqual([
+      {
+        remove_operator: {
+          owner: USER_ADDRESS,
+          operator: POOL_ADDRESS,
+          token_id: 7,
+        },
+      },
+    ]);
+    expect(requestOperation).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves a configured 18-decimal FA1.2 amount", async () => {
+    PoolRegistry.initializeFromConfig(
+      [],
+      [
+        {
+          name: ETHtz,
+          label: "ETHtz",
+          logo: "",
+          address: TOKEN_ADDRESS,
+          decimals: 18,
+          type: TokenType.FA12,
+        },
+      ]
+    );
+    const { kit, requestOperation, poolMethods } = makeHarness();
+    const adapter = new TezexAdapter(makePool(ETHtz));
+
+    await adapter.executeSwap(
+      kit,
+      USER_ADDRESS,
+      ETHtz,
+      new BigNumber("1000000000000000001"),
+      new BigNumber("1000000"),
+      0.5
+    );
+
+    expect(poolMethods.tokenToXtz).toHaveBeenCalledWith(
+      expect.objectContaining({ tokensSold: "1000000000000000001" })
+    );
+    const operations = requestOperation.mock.calls[0][0].operationDetails;
+    expect(
+      operations.map(
+        (operation: { parameters: { entrypoint: string } }) =>
+          operation.parameters.entrypoint
+      )
+    ).toEqual(["approve", "approve", "tokenToXtz", "approve"]);
+    expect(operations[0].parameters.value.value).toBe("0");
+    expect(operations[1].parameters.value.value).toBe("1000000000000000001");
+    expect(operations[3].parameters.value.value).toBe("0");
+  });
+});

--- a/V2/tezex/src/adapters/tezex.ts
+++ b/V2/tezex/src/adapters/tezex.ts
@@ -18,7 +18,9 @@ import {
 } from "@airgap/beacon-sdk";
 import {
   buildApproveOp,
+  toExactNat,
   transferParamsToBeaconOp,
+  withExactMutezAmount,
 } from "../functions/transactions";
 import { TransferParams } from "@taquito/taquito";
 
@@ -231,11 +233,11 @@ export class TezexAdapter implements IPoolAdapter {
 
       // Calculate max tokens with slippage
       const maxTokensDeposited = tokenBAmount
-        .times(1 + slippage / 100)
+        .plus(tokenBAmount.times(slippage).div(100))
         .integerValue(BigNumber.ROUND_DOWN);
       // Apply slippage to minLqtMinted so small pool changes between estimate and submit don't fail
       const minLqtWithSlippage = minLpTokens
-        .times(1 - slippage / 100)
+        .minus(minLpTokens.times(slippage).div(100))
         .integerValue(BigNumber.ROUND_DOWN);
 
       // addLiquidity(address owner, nat minLqtMinted, nat maxTokensDeposited, timestamp deadline)
@@ -259,21 +261,21 @@ export class TezexAdapter implements IPoolAdapter {
         token: asset,
         ownerAddress: userAddress,
         spenderAddress: this.poolConfig.address,
-        amount: maxTokensDeposited.toNumber(),
+        amount: maxTokensDeposited,
       });
       allTransferParams.push(approve);
 
       const addLiq = contract.methodsObject.addLiquidity({
         owner: userAddress,
-        minLqtMinted: minLqtWithSlippage.toNumber(),
-        maxTokensDeposited: maxTokensDeposited.toNumber(),
+        minLqtMinted: toExactNat(minLqtWithSlippage, "minimum LQT minted"),
+        maxTokensDeposited: toExactNat(
+          maxTokensDeposited,
+          "maximum tokens deposited"
+        ),
         deadline,
       });
       allTransferParams.push(
-        addLiq.toTransferParams({
-          amount: tokenAAmount.toNumber(),
-          mutez: true,
-        })
+        withExactMutezAmount(addLiq.toTransferParams(), tokenAAmount)
       );
       allTransferParams.push(approve0);
 
@@ -332,20 +334,21 @@ export class TezexAdapter implements IPoolAdapter {
       );
 
       const minTokenA = estimate.tokenAAmount
-        .times(1 - slippage / 100)
+        .minus(estimate.tokenAAmount.times(slippage).div(100))
         .integerValue(BigNumber.ROUND_DOWN);
       const minTokenB = estimate.tokenBAmount
-        .times(1 - slippage / 100)
+        .minus(estimate.tokenBAmount.times(slippage).div(100))
         .integerValue(BigNumber.ROUND_DOWN);
 
       const removeLiqParams = contract.methodsObject
         .removeLiquidity({
           to: userAddress,
-          lqtBurned: lpTokenAmount
-            .integerValue(BigNumber.ROUND_DOWN)
-            .toNumber(),
-          minXtzWithdrawn: minTokenA.toNumber(),
-          minTokensWithdrawn: minTokenB.toNumber(),
+          lqtBurned: toExactNat(
+            lpTokenAmount.integerValue(BigNumber.ROUND_DOWN),
+            "LQT burned"
+          ),
+          minXtzWithdrawn: toExactNat(minTokenA, "minimum XTZ withdrawn"),
+          minTokensWithdrawn: toExactNat(minTokenB, "minimum tokens withdrawn"),
           deadline,
         })
         .toTransferParams();
@@ -436,23 +439,27 @@ export class TezexAdapter implements IPoolAdapter {
 
     const operation = contract.methodsObject.xtzToToken({
       to: userAddress,
-      minTokensBought: minTokensBought.toNumber(),
+      minTokensBought: toExactNat(minTokensBought, "minimum tokens bought"),
       deadline,
     });
 
-    let transferParams: TransferParams = operation.toTransferParams({
-      amount: xtzAmount.toNumber(),
-      mutez: true,
-    });
+    let transferParams: TransferParams = withExactMutezAmount(
+      operation.toTransferParams(),
+      xtzAmount
+    );
 
     try {
       const estToolkit = makeEstimationToolkit(toolkit, userAddress);
-      const estimate = await estToolkit.estimate.transfer({
-        to: this.poolConfig.address,
-        amount: xtzAmount.toNumber(),
-        mutez: true,
-        parameter: transferParams.parameter,
-      });
+      const estimate = await estToolkit.estimate.transfer(
+        withExactMutezAmount(
+          {
+            to: this.poolConfig.address,
+            amount: 0,
+            parameter: transferParams.parameter,
+          },
+          xtzAmount
+        )
+      );
       transferParams = {
         ...transferParams,
         fee: estimate.suggestedFeeMutez,
@@ -490,23 +497,23 @@ export class TezexAdapter implements IPoolAdapter {
       const contract = await toolkit.contract.at(this.poolConfig.address);
       const tokenContract = await toolkit.contract.at(tokenAddress);
 
-      const tokenAmountInt = tokenAmount
-        .integerValue(BigNumber.ROUND_DOWN)
-        .toNumber();
+      const tokenAmountInt = toExactNat(
+        tokenAmount.integerValue(BigNumber.ROUND_DOWN),
+        "tokens sold"
+      );
       const asset = PoolRegistry.getAsset(this.poolConfig.tokenB);
 
       const allTransferParams: TransferParams[] = [];
+      const resetApproval = buildApproveOp({
+        tokenContract,
+        token: asset,
+        ownerAddress: userAddress,
+        spenderAddress: this.poolConfig.address,
+        amount: 0,
+      });
 
       if (asset.type === TokenType.FA12) {
-        allTransferParams.push(
-          buildApproveOp({
-            tokenContract,
-            token: asset,
-            ownerAddress: userAddress,
-            spenderAddress: this.poolConfig.address,
-            amount: 0,
-          })
-        );
+        allTransferParams.push(resetApproval);
       }
 
       allTransferParams.push(
@@ -524,11 +531,13 @@ export class TezexAdapter implements IPoolAdapter {
           .tokenToXtz({
             to: userAddress,
             tokensSold: tokenAmountInt,
-            minXtzBought: minXtzBought.toNumber(),
+            minXtzBought: toExactNat(minXtzBought, "minimum XTZ bought"),
             deadline,
           })
           .toTransferParams()
       );
+
+      allTransferParams.push(resetApproval);
 
       let estimatedParams = allTransferParams;
       try {

--- a/V2/tezex/src/adapters/tezexStable.test.ts
+++ b/V2/tezex/src/adapters/tezexStable.test.ts
@@ -1,0 +1,155 @@
+import { DAppClient } from "@airgap/beacon-sdk";
+import { TezosToolkit } from "@taquito/taquito";
+import BigNumber from "bignumber.js";
+
+import { ExecutionKit, Token, TokenType } from "../types/general";
+import { PoolType, StablePoolConfig } from "../types/pools";
+import { PoolDataCache } from "../utils/poolDataCache";
+import { PoolRegistry } from "./poolRegistry";
+import { StableSwapAdapter } from "./tezexStable";
+
+jest.mock("../functions/util", () => {
+  const actual = jest.requireActual("../functions/util");
+  return {
+    ...actual,
+    makeEstimationToolkit: () => ({
+      estimate: {
+        batch: jest.fn().mockRejectedValue(new Error("estimation unavailable")),
+        transfer: jest
+          .fn()
+          .mockRejectedValue(new Error("estimation unavailable")),
+      },
+    }),
+  };
+});
+
+const POOL_ADDRESS = "KT1-stable-pool";
+const TOKEN_A_ADDRESS = "KT1-token-a";
+const TOKEN_B_ADDRESS = "KT1-token-b";
+const USER_ADDRESS = "tz1-user";
+
+const poolConfig: StablePoolConfig = {
+  id: "stable-test",
+  name: "TEZEX",
+  type: PoolType.STABLE,
+  address: POOL_ADDRESS,
+  tokenA: Token.USDtz,
+  tokenB: Token.USDt,
+  lpToken: Token.LP_USDtzUSDt,
+  poolId: 3,
+  tokenAIdx: 0,
+  tokenBIdx: 1,
+};
+
+const makeInvocation = (
+  destination: string,
+  entrypoint: string,
+  value: unknown
+) => ({
+  toTransferParams: () => ({
+    to: destination,
+    amount: 0,
+    parameter: { entrypoint, value },
+  }),
+});
+
+const makeHarness = () => {
+  const poolMethods = {
+    swap: jest.fn((value) => makeInvocation(POOL_ADDRESS, "swap", value)),
+  };
+  const tokenMethods = {
+    approve: jest.fn((value) =>
+      makeInvocation(TOKEN_A_ADDRESS, "approve", value)
+    ),
+    update_operators: jest.fn((value) =>
+      makeInvocation(TOKEN_B_ADDRESS, "update_operators", value)
+    ),
+  };
+  const poolContract = {
+    methodsObject: poolMethods,
+    storage: jest.fn().mockRejectedValue(new Error("refresh unavailable")),
+  };
+  const tokenContract = { methodsObject: tokenMethods };
+  const contractAt = jest.fn(async (address: string) =>
+    address === POOL_ADDRESS ? poolContract : tokenContract
+  );
+  const requestOperation = jest
+    .fn()
+    .mockResolvedValue({ transactionHash: "operation-hash" });
+  const toolkit = {
+    contract: { at: contractAt },
+  } as unknown as TezosToolkit;
+  const client = { requestOperation } as unknown as DAppClient;
+
+  return {
+    kit: { toolkit, client } as ExecutionKit,
+    poolMethods,
+    requestOperation,
+  };
+};
+
+describe("StableSwapAdapter exact transaction construction", () => {
+  beforeEach(() => {
+    PoolDataCache.clear();
+    PoolRegistry.clear();
+    PoolRegistry.initializeFromConfig(
+      [],
+      [
+        {
+          name: Token.USDtz,
+          label: "USDtz",
+          logo: "",
+          address: TOKEN_A_ADDRESS,
+          decimals: 6,
+          type: TokenType.FA12,
+        },
+        {
+          name: Token.USDt,
+          label: "USDt",
+          logo: "",
+          address: TOKEN_B_ADDRESS,
+          decimals: 6,
+          type: TokenType.FA2,
+          tokenId: 9,
+        },
+      ]
+    );
+    jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    jest.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("preserves a large FA2 amount and removes the operator atomically", async () => {
+    const { kit, poolMethods, requestOperation } = makeHarness();
+    const adapter = new StableSwapAdapter(poolConfig);
+
+    await adapter.executeSwap(
+      kit,
+      USER_ADDRESS,
+      Token.USDt,
+      new BigNumber("9007199254740993"),
+      new BigNumber("1000000"),
+      0.5
+    );
+
+    expect(poolMethods.swap).toHaveBeenCalledWith(
+      expect.objectContaining({
+        amount: "9007199254740993",
+        min_amount_out: "995000",
+      })
+    );
+    const operations = requestOperation.mock.calls[0][0].operationDetails;
+    expect(
+      operations.map(
+        (operation: { parameters: { entrypoint: string } }) =>
+          operation.parameters.entrypoint
+      )
+    ).toEqual(["update_operators", "swap", "update_operators"]);
+    expect(operations[0].parameters.value[0]).toHaveProperty("add_operator");
+    expect(operations[2].parameters.value[0]).toHaveProperty("remove_operator");
+    expect(requestOperation).toHaveBeenCalledTimes(1);
+  });
+});

--- a/V2/tezex/src/adapters/tezexStable.ts
+++ b/V2/tezex/src/adapters/tezexStable.ts
@@ -19,6 +19,7 @@ import { PoolDataCache } from "../utils/poolDataCache";
 import { getTxDeadline, makeEstimationToolkit } from "../functions/util";
 import {
   buildApproveOp,
+  toExactNat,
   transferParamsToBeaconOp,
 } from "../functions/transactions";
 
@@ -409,7 +410,7 @@ export class StableSwapAdapter implements IPoolAdapter {
         : this.poolConfig.tokenB;
 
       const minWithSlippage = minOutputAmount
-        .times(1 - slippage / 100)
+        .minus(minOutputAmount.times(slippage).div(100))
         .integerValue(BigNumber.ROUND_DOWN);
 
       const fromAsset = PoolRegistry.getAsset(fromToken);
@@ -433,7 +434,7 @@ export class StableSwapAdapter implements IPoolAdapter {
           token: fromAsset,
           ownerAddress: userAddress,
           spenderAddress: this.poolConfig.address,
-          amount: inputAmount.toNumber(),
+          amount: inputAmount,
         })
       );
 
@@ -443,8 +444,11 @@ export class StableSwapAdapter implements IPoolAdapter {
             pool_id: this.poolConfig.poolId,
             idx_from: i,
             idx_to: j,
-            amount: inputAmount,
-            min_amount_out: minWithSlippage,
+            amount: toExactNat(inputAmount, "stable swap input"),
+            min_amount_out: toExactNat(
+              minWithSlippage,
+              "stable minimum output"
+            ),
             receiver: userAddress,
             referral: null,
             deadline,
@@ -507,7 +511,7 @@ export class StableSwapAdapter implements IPoolAdapter {
       const deadline = getTxDeadline().toISOString();
 
       const minLpWithSlippage = minLpTokens
-        .times(1 - slippage / 100)
+        .minus(minLpTokens.times(slippage).div(100))
         .integerValue(BigNumber.ROUND_DOWN);
 
       const allTransferParams: TransferParams[] = [];
@@ -545,7 +549,7 @@ export class StableSwapAdapter implements IPoolAdapter {
           token: assetA,
           ownerAddress: userAddress,
           spenderAddress: this.poolConfig.address,
-          amount: tokenAAmount.toNumber(),
+          amount: tokenAAmount,
         })
       );
       allTransferParams.push(
@@ -554,7 +558,7 @@ export class StableSwapAdapter implements IPoolAdapter {
           token: assetB,
           ownerAddress: userAddress,
           spenderAddress: this.poolConfig.address,
-          amount: tokenBAmount.toNumber(),
+          amount: tokenBAmount,
         })
       );
 
@@ -562,14 +566,20 @@ export class StableSwapAdapter implements IPoolAdapter {
         prim: "map",
         args: [{ prim: "nat" }, { prim: "nat" }],
       });
-      inAmounts.set(this.poolConfig.tokenAIdx, tokenAAmount);
-      inAmounts.set(this.poolConfig.tokenBIdx, tokenBAmount);
+      inAmounts.set(
+        this.poolConfig.tokenAIdx,
+        toExactNat(tokenAAmount, "stable token A deposit")
+      );
+      inAmounts.set(
+        this.poolConfig.tokenBIdx,
+        toExactNat(tokenBAmount, "stable token B deposit")
+      );
 
       allTransferParams.push(
         contract.methodsObject
           .invest({
             pool_id: this.poolConfig.poolId,
-            shares: minLpWithSlippage,
+            shares: toExactNat(minLpWithSlippage, "stable minimum LP shares"),
             in_amounts: inAmounts,
             deadline,
           })
@@ -634,25 +644,31 @@ export class StableSwapAdapter implements IPoolAdapter {
         lpTokenAmount
       );
 
-      const minAmounts = new Map<number, BigNumber>([
+      const minAmounts = new Map<number, string>([
         [
           this.poolConfig.tokenAIdx,
-          estimate.tokenAAmount
-            .times(1 - slippage / 100)
-            .integerValue(BigNumber.ROUND_DOWN),
+          toExactNat(
+            estimate.tokenAAmount
+              .minus(estimate.tokenAAmount.times(slippage).div(100))
+              .integerValue(BigNumber.ROUND_DOWN),
+            "stable minimum token A withdrawal"
+          ),
         ],
         [
           this.poolConfig.tokenBIdx,
-          estimate.tokenBAmount
-            .times(1 - slippage / 100)
-            .integerValue(BigNumber.ROUND_DOWN),
+          toExactNat(
+            estimate.tokenBAmount
+              .minus(estimate.tokenBAmount.times(slippage).div(100))
+              .integerValue(BigNumber.ROUND_DOWN),
+            "stable minimum token B withdrawal"
+          ),
         ],
       ]);
 
       const removeLiqParams = contract.methodsObject
         .divest({
           pool_id: this.poolConfig.poolId,
-          shares: lpTokenAmount,
+          shares: toExactNat(lpTokenAmount, "stable LP shares burned"),
           min_amounts: minAmounts,
           deadline,
         })

--- a/V2/tezex/src/functions/transactionEncoding.test.ts
+++ b/V2/tezex/src/functions/transactionEncoding.test.ts
@@ -69,6 +69,25 @@ describe("exact transaction encoding", () => {
     expect(transferParamsToBeaconOp(params).amount).toBe("9007199254740993");
   });
 
+  it("rejects unsafe JavaScript numbers before precision is lost", () => {
+    expect(() => toExactNat(Number.MAX_SAFE_INTEGER + 1)).toThrow(
+      /safe integer/i
+    );
+
+    expect(() =>
+      transferParamsToBeaconOp({
+        to: "KT1-pool",
+        amount: Number.MAX_SAFE_INTEGER + 1,
+        mutez: true,
+      })
+    ).toThrow(/safe integer/i);
+  });
+
+  it("accepts the safe-number boundary and exact strings beyond it", () => {
+    expect(toExactNat(Number.MAX_SAFE_INTEGER)).toBe("9007199254740991");
+    expect(toExactNat("9007199254740993")).toBe("9007199254740993");
+  });
+
   it("converts tez to mutez without JavaScript number arithmetic", () => {
     const params = {
       to: "KT1-pool",

--- a/V2/tezex/src/functions/transactionEncoding.test.ts
+++ b/V2/tezex/src/functions/transactionEncoding.test.ts
@@ -1,0 +1,175 @@
+import {
+  ContractAbstraction,
+  ContractProvider,
+  TransferParams,
+} from "@taquito/taquito";
+
+import { Asset, Token, TokenType } from "../types/general";
+import {
+  buildApproveOp,
+  toExactNat,
+  transferParamsToBeaconOp,
+  withExactMutezAmount,
+} from "./transactions";
+
+const makeTokenContract = () => {
+  const approve = jest.fn((value) => ({
+    toTransferParams: () => ({
+      to: "KT1-token",
+      amount: 0,
+      parameter: { entrypoint: "approve", value },
+    }),
+  }));
+  const updateOperators = jest.fn((value) => ({
+    toTransferParams: () => ({
+      to: "KT1-token",
+      amount: 0,
+      parameter: { entrypoint: "update_operators", value },
+    }),
+  }));
+
+  return {
+    contract: {
+      methodsObject: {
+        approve,
+        update_operators: updateOperators,
+      },
+    } as unknown as ContractAbstraction<ContractProvider>,
+    approve,
+    updateOperators,
+  };
+};
+
+const fa12Asset: Asset = {
+  name: Token.USDtz,
+  label: "USDtz",
+  logo: "",
+  address: "KT1-token",
+  decimals: 18,
+  type: TokenType.FA12,
+};
+
+const fa2Asset: Asset = {
+  name: Token.USDt,
+  label: "USDt",
+  logo: "",
+  address: "KT1-token",
+  decimals: 6,
+  type: TokenType.FA2,
+  tokenId: 7,
+};
+
+describe("exact transaction encoding", () => {
+  it("preserves mutez values above Number.MAX_SAFE_INTEGER", () => {
+    const params = withExactMutezAmount(
+      { to: "KT1-pool", amount: 0 },
+      "9007199254740993"
+    );
+
+    expect(transferParamsToBeaconOp(params).amount).toBe("9007199254740993");
+  });
+
+  it("converts tez to mutez without JavaScript number arithmetic", () => {
+    const params = {
+      to: "KT1-pool",
+      amount: "9007199254.740993" as unknown as number,
+    } satisfies TransferParams;
+
+    expect(transferParamsToBeaconOp(params).amount).toBe("9007199254740993");
+  });
+
+  it.each(["-1", "1.5", "NaN", "Infinity"])(
+    "rejects an invalid contract integer: %s",
+    (value) => {
+      expect(() => toExactNat(value)).toThrow(/non-negative integer/i);
+    }
+  );
+
+  it("rejects sub-mutez attached amounts instead of rounding", () => {
+    const params = {
+      to: "KT1-pool",
+      amount: "0.0000001" as unknown as number,
+    } satisfies TransferParams;
+
+    expect(() => transferParamsToBeaconOp(params)).toThrow(
+      /transaction amount must be a non-negative integer/i
+    );
+  });
+
+  it("passes an 18-decimal FA1.2 amount as an exact string", () => {
+    const { contract, approve } = makeTokenContract();
+
+    buildApproveOp({
+      tokenContract: contract,
+      token: fa12Asset,
+      ownerAddress: "tz1-user",
+      spenderAddress: "KT1-pool",
+      amount: "1000000000000000001",
+    });
+
+    expect(approve).toHaveBeenCalledWith({
+      spender: "KT1-pool",
+      value: "1000000000000000001",
+    });
+  });
+
+  it("uses exact zero/nonzero semantics for FA2 operator changes", () => {
+    const { contract, updateOperators } = makeTokenContract();
+
+    buildApproveOp({
+      tokenContract: contract,
+      token: fa2Asset,
+      ownerAddress: "tz1-user",
+      spenderAddress: "KT1-pool",
+      amount: "9007199254740993",
+    });
+    buildApproveOp({
+      tokenContract: contract,
+      token: fa2Asset,
+      ownerAddress: "tz1-user",
+      spenderAddress: "KT1-pool",
+      amount: 0,
+    });
+
+    expect(updateOperators).toHaveBeenNthCalledWith(1, [
+      {
+        add_operator: {
+          owner: "tz1-user",
+          operator: "KT1-pool",
+          token_id: 7,
+        },
+      },
+    ]);
+    expect(updateOperators).toHaveBeenNthCalledWith(2, [
+      {
+        remove_operator: {
+          owner: "tz1-user",
+          operator: "KT1-pool",
+          token_id: 7,
+        },
+      },
+    ]);
+  });
+
+  it("uses token ID zero for an FA2 asset without an explicit ID", () => {
+    const { contract, updateOperators } = makeTokenContract();
+
+    buildApproveOp({
+      tokenContract: contract,
+      token: { ...fa2Asset, tokenId: undefined },
+      ownerAddress: "tz1-user",
+      spenderAddress: "KT1-pool",
+      amount: 1,
+    });
+
+    expect(updateOperators).toHaveBeenCalledWith([
+      {
+        add_operator: {
+          owner: "tz1-user",
+          operator: "KT1-pool",
+          token_id: 0,
+        },
+      },
+    ]);
+  });
+});

--- a/V2/tezex/src/functions/transactions.ts
+++ b/V2/tezex/src/functions/transactions.ts
@@ -29,6 +29,12 @@ export const toExactNat = (
   value: BigNumber.Value,
   field = "contract amount"
 ): string => {
+  if (typeof value === "number" && !Number.isSafeInteger(value)) {
+    throw new Error(
+      `${field} must use a safe integer number or an exact decimal string`
+    );
+  }
+
   const amount = new BigNumber(value);
   if (!amount.isFinite() || !amount.isInteger() || amount.isNegative()) {
     throw new Error(`${field} must be a non-negative integer`);
@@ -323,11 +329,9 @@ export function tokenDecimalToMantissa(
 export function transferParamsToBeaconOp(
   transferParams: TransferParams
 ): PartialTezosTransactionOperation {
-  const amount = new BigNumber(
-    transferParams.amount as unknown as BigNumber.Value
-  );
+  const amount = transferParams.amount as unknown as BigNumber.Value;
   const amountInMutez = toExactNat(
-    transferParams.mutez ? amount : amount.times(MUTEZ_IN_TEZ),
+    transferParams.mutez ? amount : new BigNumber(amount).times(MUTEZ_IN_TEZ),
     "transaction amount"
   );
 

--- a/V2/tezex/src/functions/transactions.ts
+++ b/V2/tezex/src/functions/transactions.ts
@@ -23,7 +23,29 @@ import {
 import { SubmittedOperationError } from "./failures";
 import { isValidSlippage } from "./transactionSafety";
 
-const MUTEZ_IN_TEZ = 1_000_000;
+const MUTEZ_IN_TEZ = "1000000";
+
+export const toExactNat = (
+  value: BigNumber.Value,
+  field = "contract amount"
+): string => {
+  const amount = new BigNumber(value);
+  if (!amount.isFinite() || !amount.isInteger() || amount.isNegative()) {
+    throw new Error(`${field} must be a non-negative integer`);
+  }
+  return amount.toFixed(0);
+};
+
+export const withExactMutezAmount = (
+  transferParams: TransferParams,
+  amount: BigNumber.Value
+): TransferParams => ({
+  ...transferParams,
+  // Taquito 24 still declares this field as number, but its runtime and Beacon
+  // serializer use amount.toString(). Preserve the integer through that boundary.
+  amount: toExactNat(amount, "mutez amount") as unknown as number,
+  mutez: true,
+});
 
 export interface TransactionLifecycle {
   onSubmitted?: (opHash: string) => void;
@@ -301,10 +323,13 @@ export function tokenDecimalToMantissa(
 export function transferParamsToBeaconOp(
   transferParams: TransferParams
 ): PartialTezosTransactionOperation {
-  // Convert amount to mutez string
-  const amountInMutez = transferParams.mutez
-    ? transferParams.amount.toString()
-    : (transferParams.amount * MUTEZ_IN_TEZ).toString();
+  const amount = new BigNumber(
+    transferParams.amount as unknown as BigNumber.Value
+  );
+  const amountInMutez = toExactNat(
+    transferParams.mutez ? amount : amount.times(MUTEZ_IN_TEZ),
+    "transaction amount"
+  );
 
   const operation: PartialTezosTransactionOperation = {
     kind: TezosOperationType.TRANSACTION,
@@ -338,23 +363,25 @@ interface BuildApproveOpParams {
   token: Asset;
   ownerAddress: string;
   spenderAddress: string;
-  amount: number; // For FA2 tokens, this will be 0 for revocation and any other number for approval.
+  amount: BigNumber.Value; // For FA2 tokens, zero revokes and a positive value installs the operator.
 }
 
 export function buildApproveOp(params: BuildApproveOpParams): TransferParams {
+  const amount = toExactNat(params.amount, "token approval amount");
+
   if (params.token.type === TokenType.FA12) {
     return params.tokenContract.methodsObject
-      .approve({ spender: params.spenderAddress, value: params.amount })
+      .approve({ spender: params.spenderAddress, value: amount })
       .toTransferParams();
   }
 
   const operatorParam = {
     owner: params.ownerAddress,
     operator: params.spenderAddress,
-    token_id: params.token.tokenId,
+    token_id: params.token.tokenId ?? 0,
   };
 
-  const action = params.amount === 0 ? "remove_operator" : "add_operator";
+  const action = amount === "0" ? "remove_operator" : "add_operator";
 
   return params.tokenContract.methodsObject
     .update_operators([{ [action]: operatorParam }])

--- a/V2/tezex/src/functions/util.test.ts
+++ b/V2/tezex/src/functions/util.test.ts
@@ -1,5 +1,8 @@
 import BigNumber from "bignumber.js";
-import { formatWithSubscript, getTxDeadline } from "./util";
+import { NetworkType } from "@airgap/beacon-sdk";
+
+import { Asset, Token, TokenType } from "../types/general";
+import { formatWithSubscript, getBalanceFromTzKT, getTxDeadline } from "./util";
 import { TRANSACTION_DEADLINE_MS } from "./transactionSafety";
 
 describe("formatWithSubscript", () => {
@@ -45,5 +48,125 @@ describe("getTxDeadline", () => {
     expect(getTxDeadline().getTime()).toBe(now + TRANSACTION_DEADLINE_MS);
 
     jest.restoreAllMocks();
+  });
+});
+
+describe("getBalanceFromTzKT", () => {
+  const account = "tz1-user";
+  const asset: Asset = {
+    name: Token.USDt,
+    label: "USDt",
+    logo: "",
+    address: "KT1-token",
+    decimals: 6,
+    type: TokenType.FA2,
+    tokenId: 7,
+  };
+
+  const tokenBalance = (overrides: Record<string, unknown> = {}) => ({
+    account: { address: account },
+    token: {
+      contract: { address: asset.address },
+      tokenId: asset.tokenId?.toString(),
+    },
+    balance: "9007199254740993",
+    ...overrides,
+  });
+
+  const jsonResponse = (data: unknown, ok = true, status = 200) =>
+    ({
+      ok,
+      status,
+      json: jest.fn().mockResolvedValue(data),
+      text: jest.fn(),
+    } as unknown as Response);
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("queries and verifies the exact account, contract, and token ID", async () => {
+    const fetchMock = jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue(jsonResponse([tokenBalance()]));
+
+    const balance = await getBalanceFromTzKT(
+      NetworkType.MAINNET,
+      account,
+      asset
+    );
+
+    expect(balance.toFixed()).toBe("9007199254740993");
+    const requestUrl = new URL(fetchMock.mock.calls[0][0] as string);
+    expect(requestUrl.searchParams.get("account")).toBe(account);
+    expect(requestUrl.searchParams.get("token.contract")).toBe(asset.address);
+    expect(requestUrl.searchParams.get("token.tokenId")).toBe("7");
+    expect(requestUrl.searchParams.get("limit")).toBe("2");
+  });
+
+  it("returns zero only for an unambiguous empty token result", async () => {
+    jest.spyOn(global, "fetch").mockResolvedValue(jsonResponse([]));
+
+    await expect(
+      getBalanceFromTzKT(NetworkType.MAINNET, account, asset)
+    ).resolves.toEqual(new BigNumber(0));
+  });
+
+  it("fails closed on multiple or mismatched token results", async () => {
+    const fetchMock = jest.spyOn(global, "fetch");
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse([tokenBalance(), tokenBalance()])
+    );
+    await expect(
+      getBalanceFromTzKT(NetworkType.MAINNET, account, asset)
+    ).rejects.toThrow(/ambiguous token balance/i);
+
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse([
+        tokenBalance({
+          token: { contract: { address: asset.address }, tokenId: "8" },
+        }),
+      ])
+    );
+    await expect(
+      getBalanceFromTzKT(NetworkType.MAINNET, account, asset)
+    ).rejects.toThrow(/identity did not match/i);
+  });
+
+  it("fails closed on HTTP and malformed balance responses", async () => {
+    const fetchMock = jest.spyOn(global, "fetch");
+    fetchMock.mockResolvedValueOnce(jsonResponse({}, false, 503));
+    await expect(
+      getBalanceFromTzKT(NetworkType.MAINNET, account, asset)
+    ).rejects.toThrow(/HTTP 503/i);
+
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse([tokenBalance({ balance: 9007199254740992 })])
+    );
+    await expect(
+      getBalanceFromTzKT(NetworkType.MAINNET, account, asset)
+    ).rejects.toThrow(/invalid token balance/i);
+  });
+
+  it("reads an XTZ balance as exact text", async () => {
+    const response = {
+      ok: true,
+      status: 200,
+      text: jest.fn().mockResolvedValue("9007199254740993"),
+      json: jest.fn(),
+    } as unknown as Response;
+    jest.spyOn(global, "fetch").mockResolvedValue(response);
+    const xtzAsset: Asset = {
+      name: Token.XTZ,
+      label: "XTZ",
+      logo: "",
+      address: "",
+      decimals: 6,
+      type: TokenType.XTZ,
+    };
+
+    await expect(
+      getBalanceFromTzKT(NetworkType.MAINNET, account, xtzAsset)
+    ).resolves.toEqual(new BigNumber("9007199254740993"));
   });
 });

--- a/V2/tezex/src/functions/util.ts
+++ b/V2/tezex/src/functions/util.ts
@@ -273,6 +273,24 @@ export const getTzktApiUrl = (networkType: NetworkType): string => {
   }
 };
 
+const assertTzktResponse = (response: Response): void => {
+  if (!response.ok) {
+    throw new Error(`TzKT balance request failed with HTTP ${response.status}`);
+  }
+};
+
+const parseExactBalance = (value: unknown, field: string): BigNumber => {
+  if (typeof value !== "string" || !/^\d+$/.test(value)) {
+    throw new Error(`TzKT returned an invalid ${field}`);
+  }
+  return new BigNumber(value);
+};
+
+const asTzktRecord = (value: unknown): Record<string, unknown> | undefined =>
+  typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : undefined;
+
 export async function getBalanceFromTzKT(
   network: NetworkType,
   address: string,
@@ -281,19 +299,53 @@ export async function getBalanceFromTzKT(
   const api = getTzktApiUrl(network);
   switch (asset.type) {
     case TokenType.XTZ: {
-      const response = await fetch(`${api}/v1/accounts/${address}/balance`);
-      const data = await response.json();
-      return data != null ? new BigNumber(data) : new BigNumber(0);
+      const response = await fetch(
+        `${api}/v1/accounts/${encodeURIComponent(address)}/balance`
+      );
+      assertTzktResponse(response);
+      return parseExactBalance((await response.text()).trim(), "XTZ balance");
     }
     case TokenType.FA12:
     case TokenType.FA2: {
-      const response = await fetch(
-        `${api}/v1/tokens/balances?account=${address}&token.contract=${asset.address}`
-      );
-      const data = await response.json();
-      return data[0]?.balance
-        ? new BigNumber(data[0].balance)
-        : new BigNumber(0);
+      const tokenId = asset.tokenId ?? 0;
+      if (!Number.isSafeInteger(tokenId) || tokenId < 0) {
+        throw new Error("Configured token ID must be a non-negative integer");
+      }
+
+      const query = new URLSearchParams({
+        account: address,
+        "token.contract": asset.address,
+        "token.tokenId": tokenId.toString(),
+        limit: "2",
+      });
+      const response = await fetch(`${api}/v1/tokens/balances?${query}`);
+      assertTzktResponse(response);
+
+      const data: unknown = await response.json();
+      if (!Array.isArray(data)) {
+        throw new Error("TzKT returned a malformed token balance response");
+      }
+      if (data.length === 0) return new BigNumber(0);
+      if (data.length !== 1) {
+        throw new Error("TzKT returned an ambiguous token balance response");
+      }
+
+      const balance = asTzktRecord(data[0]);
+      const account = asTzktRecord(balance?.account);
+      const token = asTzktRecord(balance?.token);
+      const contract = asTzktRecord(token?.contract);
+
+      if (
+        account?.address !== address ||
+        contract?.address !== asset.address ||
+        token?.tokenId !== tokenId.toString()
+      ) {
+        throw new Error(
+          "TzKT token balance identity did not match the request"
+        );
+      }
+
+      return parseExactBalance(balance?.balance, "token balance");
     }
   }
 }


### PR DESCRIPTION
## Summary

- preserve mutez, token, liquidity, and slippage-adjusted contract integers as exact decimal strings through Taquito and Beacon transaction construction
- remove FA2 operators after token-to-XTZ swaps in the same atomic wallet batch, while retaining the FA1.2 reset sequence
- scope TzKT fallback balance requests to the requested token ID and fail closed on HTTP, schema, identity, or ambiguity errors
- add adapter and encoding regressions for values above `Number.MAX_SAFE_INTEGER` and the configured 18-decimal asset path

## Why

Converting arbitrary-precision token values to JavaScript numbers can silently change contract arguments above the safe-integer limit. The previous fallback balance request also omitted the token ID, and token-to-XTZ FA2 swaps could leave the pool installed as an operator.

## Impact

Transaction amounts remain exact at serialization boundaries, successful batched swaps leave no residual FA2 permission, and fallback balances cannot be accepted from a different token ID. Sirius-specific adapter hardening remains isolated in #259 to avoid overlapping that review.

## Validation

- `npm run verify`
  - production audit policy passed (12 low, 2 moderate; no high/critical production advisory)
  - TypeScript passed
  - 82 tests passed
  - optimized production build passed
- ESLint passed for all changed TypeScript files
- `git diff --check`

Closes #248