### PR TITLE
Reject stale transaction quotes

### DIFF
--- a/V2/tezex/src/components/swap/index.tsx
+++ b/V2/tezex/src/components/swap/index.tsx
@@ -265,6 +265,7 @@ export const Swap: FC<ISwapToken> = () => {
   const hasEnteredAmount = new BigNumber(sendInputValue || 0).isGreaterThan(0);
   const hasQuote = Boolean(
     hasEnteredAmount &&
+      transaction?.quote &&
       sendAmount &&
       receiveAmount &&
       sendAmount.isGreaterThan(0)

--- a/V2/tezex/src/contexts/wallet.tsx
+++ b/V2/tezex/src/contexts/wallet.tsx
@@ -5,7 +5,7 @@ import React, {
   useState,
   useRef,
 } from "react";
-import { current, Draft } from "immer";
+import { current, Draft, produce } from "immer";
 import { useImmer } from "use-immer";
 import { Mutex } from "async-mutex";
 import { BeaconEvent, DAppClient, NetworkType } from "@airgap/beacon-dapp";
@@ -193,9 +193,25 @@ export function WalletProvider(props: IWalletProvider) {
   const latestTransactionInitializations = useRef(
     new Map<TransactingComponent, symbol>()
   ).current;
-  const [transactions, setTransactions] = useImmer<{
+  type TransactionState = {
     [key in TransactingComponent]?: Transaction;
-  }>({});
+  };
+  type TransactionStateUpdate =
+    | TransactionState
+    | ((draft: Draft<TransactionState>) => void);
+  const [transactions, setTransactionState] = useImmer<TransactionState>({});
+  const transactionsRef = useRef<TransactionState>({});
+  const setTransactions = useCallback(
+    (update: TransactionStateUpdate): void => {
+      const nextTransactions =
+        typeof update === "function"
+          ? produce(transactionsRef.current, update)
+          : update;
+      transactionsRef.current = nextTransactions;
+      setTransactionState(nextTransactions);
+    },
+    []
+  );
 
   const [isWalletConnected, setIsWalletConnected] = useState(false);
   const [client, setClient] = useState<DAppClient | null>(null);
@@ -394,9 +410,9 @@ export function WalletProvider(props: IWalletProvider) {
   // callback to return the active transaction of a component
   const getActiveTransaction = useCallback(
     (component: TransactingComponent): Transaction | undefined => {
-      return transactions[component];
+      return transactionsRef.current[component];
     },
-    [transactions]
+    []
   );
 
   const clearTransaction = useCallback(
@@ -435,6 +451,8 @@ export function WalletProvider(props: IWalletProvider) {
             const guardedClient = createQuoteGuardedDAppClient({
               client,
               transaction,
+              getActiveTransaction: () =>
+                transactionsRef.current[transaction.component],
               getRuntime: () => {
                 const activeNetwork = networkRef.current;
                 return {

--- a/V2/tezex/src/contexts/wallet.tsx
+++ b/V2/tezex/src/contexts/wallet.tsx
@@ -36,12 +36,14 @@ import { WritableDraft } from "immer/dist/types/types-external";
 import { estimateWithAdapter } from "../functions/estimates";
 import {
   applyQuoteResult,
+  createQuoteGuardedDAppClient,
   createQuoteRequest,
   createTransactionQuote,
   hasFreshTransactionQuote,
   QuoteContext,
   QuoteRequest,
   quoteRequestMatches,
+  transactionResultMatchesActive,
 } from "../functions/quoteSafety";
 import {
   getStatusAfterBalanceCheck,
@@ -209,6 +211,8 @@ export function WalletProvider(props: IWalletProvider) {
     network: network.network,
     chainId: network.info.chainId,
   };
+  const networkRef = useRef(network);
+  networkRef.current = network;
 
   const [assetBalances, setAssetBalances] = useState<AssetBalance[]>(
     network.info.assets.map((asset) => {
@@ -428,10 +432,22 @@ export function WalletProvider(props: IWalletProvider) {
               );
             }
 
+            const guardedClient = createQuoteGuardedDAppClient({
+              client,
+              transaction,
+              getRuntime: () => {
+                const activeNetwork = networkRef.current;
+                return {
+                  context: { ...quoteContextRef.current },
+                  readChainId: () => activeNetwork.toolkit.rpc.getChainId(),
+                };
+              },
+            });
+
             const success = await processTransaction(
               transaction,
               address,
-              { toolkit: network.toolkit, client },
+              { toolkit: network.toolkit, client: guardedClient },
               {
                 onSubmitted: (opHash) => {
                   submittedHash = opHash;
@@ -540,7 +556,14 @@ export function WalletProvider(props: IWalletProvider) {
             }
           );
           setTransactions((draft) => {
-            draft[component] = updatedTransaction;
+            if (
+              transactionResultMatchesActive(
+                draft[component],
+                updatedTransaction
+              )
+            ) {
+              draft[component] = updatedTransaction;
+            }
           });
         }
       });

--- a/V2/tezex/src/contexts/wallet.tsx
+++ b/V2/tezex/src/contexts/wallet.tsx
@@ -5,7 +5,7 @@ import React, {
   useState,
   useRef,
 } from "react";
-import { Draft } from "immer";
+import { current, Draft } from "immer";
 import { useImmer } from "use-immer";
 import { Mutex } from "async-mutex";
 import { BeaconEvent, DAppClient, NetworkType } from "@airgap/beacon-dapp";
@@ -34,6 +34,15 @@ import {
 } from "../functions/util";
 import { WritableDraft } from "immer/dist/types/types-external";
 import { estimateWithAdapter } from "../functions/estimates";
+import {
+  applyQuoteResult,
+  createQuoteRequest,
+  createTransactionQuote,
+  hasFreshTransactionQuote,
+  QuoteContext,
+  QuoteRequest,
+  quoteRequestMatches,
+} from "../functions/quoteSafety";
 import {
   getStatusAfterBalanceCheck,
   isValidSlippage,
@@ -83,6 +92,18 @@ export interface WalletInfo {
     amountUpdateReceive?: Amount,
     slippageUpdate?: number
   ) => Promise<boolean>;
+  refreshTransactionQuote: (
+    component: TransactingComponent,
+    amountUpdateSend?: Amount,
+    slippageUpdate?: number
+  ) => Promise<boolean>;
+  prepareTransactionForSubmission: (
+    component: TransactingComponent
+  ) => Promise<boolean>;
+  invalidateTransactionQuote: (
+    component: TransactingComponent,
+    transactionStatus: TransactionStatus
+  ) => Promise<void>;
   getActiveTransaction: (
     component: TransactingComponent
   ) => Transaction | undefined;
@@ -115,6 +136,21 @@ const defaultWalletInfo: WalletInfo = {
   },
   updateAmount: async () => {
     throw new Error("updateAmount  called outside of wallet provider");
+  },
+  refreshTransactionQuote: async () => {
+    throw new Error(
+      "refreshTransactionQuote called outside of wallet provider"
+    );
+  },
+  prepareTransactionForSubmission: async () => {
+    throw new Error(
+      "prepareTransactionForSubmission called outside of wallet provider"
+    );
+  },
+  invalidateTransactionQuote: async () => {
+    throw new Error(
+      "invalidateTransactionQuote called outside of wallet provider"
+    );
   },
   getActiveTransaction: () => {
     throw new Error("getActiveTransaction called outside of wallet provider");
@@ -149,6 +185,12 @@ export function WalletProvider(props: IWalletProvider) {
   const transactionMutex = useRef(new Mutex()).current;
   const transactionUpdateMutex = useRef(new Mutex()).current;
   const processingTransactionIds = useRef(new Set<string>()).current;
+  const latestQuoteRequests = useRef(
+    new Map<TransactingComponent, QuoteRequest>()
+  ).current;
+  const latestTransactionInitializations = useRef(
+    new Map<TransactingComponent, symbol>()
+  ).current;
   const [transactions, setTransactions] = useImmer<{
     [key in TransactingComponent]?: Transaction;
   }>({});
@@ -157,6 +199,16 @@ export function WalletProvider(props: IWalletProvider) {
   const [client, setClient] = useState<DAppClient | null>(null);
   const [address, setAddress] = useState<string | null>(null);
   const hasReconnectedRef = useRef(false);
+  const quoteContextRef = useRef<QuoteContext>({
+    account: address,
+    network: network.network,
+    chainId: network.info.chainId,
+  });
+  quoteContextRef.current = {
+    account: address,
+    network: network.network,
+    chainId: network.info.chainId,
+  };
 
   const [assetBalances, setAssetBalances] = useState<AssetBalance[]>(
     network.info.assets.map((asset) => {
@@ -205,8 +257,16 @@ export function WalletProvider(props: IWalletProvider) {
   );
 
   useEffect(() => {
+    latestQuoteRequests.clear();
+    latestTransactionInitializations.clear();
     setTransactions({});
-  }, [network.network, setTransactions]);
+  }, [
+    latestQuoteRequests,
+    latestTransactionInitializations,
+    network.network,
+    network.info.chainId,
+    setTransactions,
+  ]);
 
   // Auto-reconnect on mount (ONCE)
   useEffect(() => {
@@ -337,11 +397,13 @@ export function WalletProvider(props: IWalletProvider) {
 
   const clearTransaction = useCallback(
     (component: TransactingComponent) => {
+      latestQuoteRequests.delete(component);
+      latestTransactionInitializations.delete(component);
       setTransactions((draft) => {
         delete draft[component];
       });
     },
-    [setTransactions]
+    [latestQuoteRequests, latestTransactionInitializations, setTransactions]
   );
 
   // calback to send a transaction for final processing
@@ -354,6 +416,18 @@ export function WalletProvider(props: IWalletProvider) {
           let submittedHash: string | undefined;
 
           try {
+            if (
+              !hasFreshTransactionQuote(
+                transaction,
+                quoteContextRef.current,
+                true
+              )
+            ) {
+              throw new Error(
+                "Transaction quote changed before wallet submission"
+              );
+            }
+
             const success = await processTransaction(
               transaction,
               address,
@@ -521,7 +595,11 @@ export function WalletProvider(props: IWalletProvider) {
       receiveAmount?: Amount,
       slipppage = 0.5
     ): Promise<boolean> => {
+      const initializationToken = Symbol("transaction initialization");
+      latestQuoteRequests.delete(component);
+      latestTransactionInitializations.set(component, initializationToken);
       return await transactionUpdateMutex.runExclusive(async () => {
+        const quoteContext = { ...quoteContextRef.current };
         // initialise zeroBalance
         const initBalance = (asset: AssetOrAssetPair): Amount => {
           switch (asset.length) {
@@ -553,6 +631,7 @@ export function WalletProvider(props: IWalletProvider) {
           slippage: slipppage,
           lastModified: new Date(),
           locked: false,
+          quoteRevision: 0,
         };
 
         let transaction: Transaction = _transaction;
@@ -563,6 +642,28 @@ export function WalletProvider(props: IWalletProvider) {
           network.toolkit,
           adapter
         );
+
+        const currentQuoteContext = quoteContextRef.current;
+        if (
+          latestTransactionInitializations.get(component) !==
+            initializationToken ||
+          quoteContext.account !== currentQuoteContext.account ||
+          quoteContext.network !== currentQuoteContext.network ||
+          quoteContext.chainId !== currentQuoteContext.chainId
+        ) {
+          return false;
+        }
+
+        const quotedTransaction: Transaction = {
+          ...transaction,
+          quoteRevision: 1,
+        };
+        transaction = {
+          ...quotedTransaction,
+          quote: createTransactionQuote(quotedTransaction, quoteContext, 1),
+        };
+
+        latestTransactionInitializations.delete(component);
 
         return setActiveTransaction(component, transaction);
       });
@@ -821,6 +922,224 @@ export function WalletProvider(props: IWalletProvider) {
     return updater(transaction);
   };
 
+  const invalidateTransactionQuote = useCallback(
+    async (
+      component: TransactingComponent,
+      transactionStatus: TransactionStatus
+    ): Promise<void> => {
+      latestQuoteRequests.delete(component);
+      await transactionUpdateMutex.runExclusive(() => {
+        setTransactions((draft) => {
+          updateTransaction(draft[component], (transaction) => {
+            transaction.quoteRevision = (transaction.quoteRevision ?? 0) + 1;
+            latestQuoteRequests.delete(component);
+            delete transaction.quote;
+            transaction.receiveAmount = transaction.receiveAsset.map(
+              () => zeroBalance
+            ) as Amount;
+            transaction.transactionStatus = transactionStatus;
+            transaction.lastModified = new Date();
+            return true;
+          });
+        });
+      });
+    },
+    [latestQuoteRequests, setTransactions, transactionUpdateMutex]
+  );
+
+  const runTransactionQuote = useCallback(
+    async (
+      component: TransactingComponent,
+      amountUpdateSend?: Amount,
+      slippageUpdate?: number,
+      submitAfterRefresh = false
+    ): Promise<boolean> => {
+      latestQuoteRequests.delete(component);
+      let pending:
+        | { request: QuoteRequest; transaction: Transaction }
+        | undefined;
+      let updated = false;
+
+      await transactionUpdateMutex.runExclusive(() => {
+        setTransactions((draft) => {
+          updated = updateTransaction(draft[component], (transaction) => {
+            latestQuoteRequests.delete(component);
+            if (isNumber(slippageUpdate) && !isValidSlippage(slippageUpdate)) {
+              transaction.quoteRevision = (transaction.quoteRevision ?? 0) + 1;
+              delete transaction.quote;
+              transaction.receiveAmount = transaction.receiveAsset.map(
+                () => zeroBalance
+              ) as Amount;
+              transaction.transactionStatus =
+                TransactionStatus.INVALID_SLIPPAGE;
+              transaction.lastModified = new Date();
+              return true;
+            }
+
+            if (amountUpdateSend) {
+              transaction.sendAmount = amountUpdateSend;
+            }
+            if (isNumber(slippageUpdate)) {
+              transaction.slippage = slippageUpdate;
+            }
+
+            const revision = (transaction.quoteRevision ?? 0) + 1;
+            transaction.quoteRevision = revision;
+            delete transaction.quote;
+            transaction.receiveAmount = transaction.receiveAsset.map(
+              () => zeroBalance
+            ) as Amount;
+            transaction.lastModified = new Date();
+
+            if (transaction.sendAmount[0].mantissa.isZero()) {
+              transaction.transactionStatus = TransactionStatus.ZERO_AMOUNT;
+              return true;
+            }
+
+            transaction.transactionStatus = TransactionStatus.MODIFIED;
+            const transactionSnapshot = current(
+              transaction as Draft<Transaction>
+            ) as Transaction;
+            pending = {
+              request: createQuoteRequest(
+                transactionSnapshot,
+                quoteContextRef.current,
+                revision
+              ),
+              transaction: transactionSnapshot,
+            };
+            latestQuoteRequests.set(component, pending.request);
+            return true;
+          });
+        });
+      });
+
+      if (!pending) return updated;
+      const pendingQuote = pending;
+
+      let estimatedTransaction: Transaction;
+      try {
+        const adapter = network.getPoolAdapter(pendingQuote.transaction.poolId);
+        estimatedTransaction = await estimateWithAdapter(
+          pendingQuote.transaction,
+          network.toolkit,
+          adapter
+        );
+      } catch (error) {
+        await transactionUpdateMutex.runExclusive(() => {
+          setTransactions((draft) => {
+            const activeTransaction = draft[component];
+            if (
+              activeTransaction &&
+              latestQuoteRequests.get(component) === pendingQuote.request &&
+              quoteRequestMatches(
+                current(activeTransaction as Draft<Transaction>) as Transaction,
+                quoteContextRef.current,
+                pendingQuote.request
+              )
+            ) {
+              activeTransaction.transactionStatus = TransactionStatus.FAILED;
+              activeTransaction.lastModified = new Date();
+            }
+          });
+        });
+        console.error("Error refreshing transaction quote:", error);
+        return false;
+      }
+
+      const isLatestRequest =
+        latestQuoteRequests.get(component) === pendingQuote.request;
+      await transactionUpdateMutex.runExclusive(() => {
+        setTransactions((draft) => {
+          const activeTransaction = draft[component];
+          if (!activeTransaction) return;
+          if (latestQuoteRequests.get(component) !== pendingQuote.request) {
+            return;
+          }
+
+          const transactionSnapshot = current(
+            activeTransaction as Draft<Transaction>
+          ) as Transaction;
+          const balanceStatus = isWalletConnected
+            ? checkSufficientBalance(
+                transactionSnapshot.sendAssetBalance,
+                estimatedTransaction.sendAmount,
+                transactionSnapshot.sendAsset
+              )
+            : TransactionStatus.INITIALIZED;
+          const nextStatus =
+            submitAfterRefresh &&
+            balanceStatus === TransactionStatus.SUFFICIENT_BALANCE
+              ? TransactionStatus.PENDING
+              : balanceStatus;
+          const quotedTransaction = applyQuoteResult(
+            transactionSnapshot,
+            estimatedTransaction,
+            quoteContextRef.current,
+            pendingQuote.request,
+            nextStatus,
+            nextStatus === TransactionStatus.PENDING
+          );
+
+          if (quotedTransaction) {
+            draft[component] = quotedTransaction as WritableDraft<Transaction>;
+          }
+        });
+      });
+
+      return isLatestRequest;
+    },
+    [
+      checkSufficientBalance,
+      isWalletConnected,
+      latestQuoteRequests,
+      network,
+      setTransactions,
+      transactionUpdateMutex,
+    ]
+  );
+
+  const refreshTransactionQuote = useCallback(
+    async (
+      component: TransactingComponent,
+      amountUpdateSend?: Amount,
+      slippageUpdate?: number
+    ): Promise<boolean> =>
+      runTransactionQuote(component, amountUpdateSend, slippageUpdate),
+    [runTransactionQuote]
+  );
+
+  const prepareTransactionForSubmission = useCallback(
+    async (component: TransactingComponent): Promise<boolean> =>
+      runTransactionQuote(component, undefined, undefined, true),
+    [runTransactionQuote]
+  );
+
+  const previousQuoteAccountRef = useRef<string | null>(address);
+  useEffect(() => {
+    if (previousQuoteAccountRef.current === address) return;
+    previousQuoteAccountRef.current = address;
+
+    Object.values(TransactingComponent).forEach((component) => {
+      const transaction = transactions[component];
+      if (!transaction) return;
+
+      if (address) {
+        void refreshTransactionQuote(component);
+      } else {
+        const status = transaction.sendAmount[0].mantissa.isZero()
+          ? TransactionStatus.ZERO_AMOUNT
+          : TransactionStatus.INITIALIZED;
+        void invalidateTransactionQuote(component, status);
+      }
+    });
+  }, [
+    address,
+    invalidateTransactionQuote,
+    refreshTransactionQuote,
+    transactions,
+  ]);
+
   // exported callback to update amount of a  single component
   const updateAmount = useCallback(
     async (
@@ -880,9 +1199,15 @@ export function WalletProvider(props: IWalletProvider) {
             }
           );
           // if updated, update the last modified date
-          if (wasUpdated && draft[component]) {
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            draft[component]!.lastModified = new Date();
+          const activeTransaction = draft[component];
+          if (wasUpdated && activeTransaction) {
+            activeTransaction.lastModified = new Date();
+            // Any legacy direct amount update invalidates the quote. Quote
+            // results are installed only through the revision-checked path.
+            activeTransaction.quoteRevision =
+              (activeTransaction.quoteRevision ?? 0) + 1;
+            latestQuoteRequests.delete(component);
+            delete activeTransaction.quote;
           } else {
             updated = false;
           }
@@ -922,6 +1247,9 @@ export function WalletProvider(props: IWalletProvider) {
     updateStatus,
     updateTransactionBalance,
     updateAmount,
+    refreshTransactionQuote,
+    prepareTransactionForSubmission,
+    invalidateTransactionQuote,
     getActiveTransaction,
     disconnect,
     clearTransaction,

--- a/V2/tezex/src/contexts/walletQuoteLifecycle.test.tsx
+++ b/V2/tezex/src/contexts/walletQuoteLifecycle.test.tsx
@@ -1,0 +1,209 @@
+import React, { useContext } from "react";
+import { act, render, waitFor } from "@testing-library/react";
+import BigNumber from "bignumber.js";
+
+import {
+  Asset,
+  Balance,
+  Token,
+  TokenType,
+  TransactingComponent,
+} from "../types/general";
+import { IPoolAdapter, PoolType } from "../types/pools";
+import { WalletContext, WalletInfo, WalletProvider } from "./wallet";
+
+const mockGetPoolAdapter = jest.fn();
+
+jest.mock("uuid", () => ({ v4: () => "transaction-id" }));
+
+jest.mock("../hooks/network", () => ({
+  useNetwork: () => ({
+    network: "mainnet",
+    info: {
+      tezosServer: "https://rpc.example",
+      rpcFallbacks: [],
+      chainId: "NetXdQprcVkpaWU",
+      pools: [],
+      assets: [
+        {
+          name: "XTZ",
+          label: "XTZ",
+          logo: "",
+          address: "",
+          decimals: 6,
+          type: "XTZ",
+        },
+        {
+          name: "TzBTC",
+          label: "Token",
+          logo: "",
+          address: "KT1-token",
+          decimals: 6,
+          type: "FA1.2",
+        },
+      ],
+    },
+    toolkit: {},
+    selectedPool: null,
+    setSelectedPool: jest.fn(),
+    getAsset: jest.fn(),
+    getPoolAdapter: mockGetPoolAdapter,
+    getPoolsByTokenPair: jest.fn(),
+    getAllPools: jest.fn().mockReturnValue([]),
+    switchNetwork: jest.fn(),
+  }),
+}));
+
+jest.mock("../hooks/session", () => ({
+  useSession: () => ({ setAlert: jest.fn() }),
+}));
+
+const balance = (value: string): Balance => {
+  const number = new BigNumber(value);
+  return {
+    decimal: number,
+    mantissa: number,
+    string: number.toFixed(),
+    greaterOrEqualTo: (other) => number.gte(other.mantissa),
+  };
+};
+
+const xtz: Asset = {
+  name: Token.XTZ,
+  label: "XTZ",
+  logo: "",
+  address: "",
+  decimals: 6,
+  type: TokenType.XTZ,
+};
+
+const token: Asset = {
+  name: Token.TzBTC,
+  label: "Token",
+  logo: "",
+  address: "KT1-token",
+  decimals: 6,
+  type: TokenType.FA12,
+};
+
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+};
+
+describe("WalletProvider quote lifecycle", () => {
+  let wallet: WalletInfo;
+
+  const Probe = () => {
+    wallet = useContext(WalletContext);
+    return null;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("keeps the newest amount when quote RPC responses resolve out of order", async () => {
+    const slowEstimate = deferred<{
+      inputAmount: BigNumber;
+      outputAmount: BigNumber;
+    }>();
+    const fastEstimate = deferred<{
+      inputAmount: BigNumber;
+      outputAmount: BigNumber;
+    }>();
+    const estimateSwap = jest
+      .fn()
+      .mockResolvedValueOnce({
+        inputAmount: new BigNumber(0),
+        outputAmount: new BigNumber(0),
+      })
+      .mockImplementationOnce(() => slowEstimate.promise)
+      .mockImplementationOnce(() => fastEstimate.promise);
+    const adapter = {
+      poolConfig: {
+        id: "pool-id",
+        name: "Pool",
+        type: PoolType.TEZEX,
+        address: "KT1-pool",
+        tokenA: Token.XTZ,
+        tokenB: Token.TzBTC,
+        lpToken: Token.Sirs,
+      },
+      estimateSwap,
+    } as unknown as IPoolAdapter;
+    mockGetPoolAdapter.mockReturnValue(adapter);
+
+    render(
+      <WalletProvider>
+        <Probe />
+      </WalletProvider>
+    );
+
+    await act(async () => {
+      await wallet.initialiseTransaction(
+        TransactingComponent.SWAP,
+        [xtz],
+        [token],
+        "pool-id",
+        [balance("0")],
+        [balance("0")]
+      );
+    });
+    await waitFor(() =>
+      expect(
+        wallet.getActiveTransaction(TransactingComponent.SWAP)
+      ).toBeDefined()
+    );
+
+    let firstRequest!: Promise<boolean>;
+    await act(async () => {
+      firstRequest = wallet.refreshTransactionQuote(TransactingComponent.SWAP, [
+        balance("1"),
+      ]);
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(estimateSwap).toHaveBeenCalledTimes(2));
+
+    let secondRequest!: Promise<boolean>;
+    await act(async () => {
+      secondRequest = wallet.refreshTransactionQuote(
+        TransactingComponent.SWAP,
+        [balance("2")]
+      );
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(estimateSwap).toHaveBeenCalledTimes(3));
+    await waitFor(() => {
+      const pendingTransaction = wallet.getActiveTransaction(
+        TransactingComponent.SWAP
+      );
+      expect(pendingTransaction?.quoteRevision).toBe(3);
+      expect(pendingTransaction?.sendAmount[0].mantissa.toFixed()).toBe("2");
+    });
+
+    fastEstimate.resolve({
+      inputAmount: new BigNumber("2"),
+      outputAmount: new BigNumber("200"),
+    });
+    await act(async () => {
+      await expect(secondRequest).resolves.toBe(true);
+    });
+
+    slowEstimate.resolve({
+      inputAmount: new BigNumber("1"),
+      outputAmount: new BigNumber("100"),
+    });
+    await act(async () => {
+      await expect(firstRequest).resolves.toBe(false);
+    });
+
+    const transaction = wallet.getActiveTransaction(TransactingComponent.SWAP);
+    expect(transaction?.sendAmount[0].mantissa.toFixed()).toBe("2");
+    expect(transaction?.receiveAmount[0].mantissa.toFixed()).toBe("200");
+    expect(transaction?.quoteRevision).toBe(3);
+  });
+});

--- a/V2/tezex/src/contexts/walletQuoteLifecycle.test.tsx
+++ b/V2/tezex/src/contexts/walletQuoteLifecycle.test.tsx
@@ -206,4 +206,52 @@ describe("WalletProvider quote lifecycle", () => {
     expect(transaction?.receiveAmount[0].mantissa.toFixed()).toBe("200");
     expect(transaction?.quoteRevision).toBe(3);
   });
+
+  it("removes a cleared transaction from the synchronous active-state ref", async () => {
+    const adapter = {
+      poolConfig: {
+        id: "pool-id",
+        name: "Pool",
+        type: PoolType.TEZEX,
+        address: "KT1-pool",
+        tokenA: Token.XTZ,
+        tokenB: Token.TzBTC,
+        lpToken: Token.Sirs,
+      },
+      estimateSwap: jest.fn().mockResolvedValue({
+        inputAmount: new BigNumber(0),
+        outputAmount: new BigNumber(0),
+      }),
+    } as unknown as IPoolAdapter;
+    mockGetPoolAdapter.mockReturnValue(adapter);
+
+    render(
+      <WalletProvider>
+        <Probe />
+      </WalletProvider>
+    );
+
+    await act(async () => {
+      await wallet.initialiseTransaction(
+        TransactingComponent.SWAP,
+        [xtz],
+        [token],
+        "pool-id",
+        [balance("0")],
+        [balance("0")]
+      );
+    });
+    await waitFor(() =>
+      expect(
+        wallet.getActiveTransaction(TransactingComponent.SWAP)
+      ).toBeDefined()
+    );
+
+    act(() => {
+      wallet.clearTransaction(TransactingComponent.SWAP);
+      expect(
+        wallet.getActiveTransaction(TransactingComponent.SWAP)
+      ).toBeUndefined();
+    });
+  });
 });

--- a/V2/tezex/src/functions/quoteSafety.test.ts
+++ b/V2/tezex/src/functions/quoteSafety.test.ts
@@ -16,6 +16,7 @@ import {
   TransactingComponent,
 } from "../types/general";
 import {
+  activeTransactionMatchesPreparedSubmission,
   applyQuoteResult,
   createQuoteGuardedDAppClient,
   createQuoteRequest,
@@ -232,6 +233,7 @@ describe("quote revision safety", () => {
     const guardedClient = createQuoteGuardedDAppClient({
       client,
       transaction: preparedTransaction,
+      getActiveTransaction: () => preparedTransaction,
       getRuntime: () => ({
         context,
         readChainId: async () => context.chainId,
@@ -275,6 +277,7 @@ describe("quote revision safety", () => {
     const guardedClient = createQuoteGuardedDAppClient({
       client,
       transaction: preparedTransaction,
+      getActiveTransaction: () => preparedTransaction,
       getRuntime: () => ({
         context,
         readChainId: async () => context.chainId,
@@ -310,6 +313,7 @@ describe("quote revision safety", () => {
     const guardedClient = createQuoteGuardedDAppClient({
       client,
       transaction: preparedTransaction,
+      getActiveTransaction: () => preparedTransaction,
       getRuntime: () => ({
         context: activeContext,
         readChainId: async () => {
@@ -322,6 +326,201 @@ describe("quote revision safety", () => {
     await expect(
       guardedClient.requestOperation({ operationDetails: [] })
     ).rejects.toBeInstanceOf(QuoteSubmissionContextError);
+    expect(requestOperation).not.toHaveBeenCalled();
+  });
+
+  it("requires the active ID, revision, fingerprints, and pending status", () => {
+    const pendingTransaction = makeTransaction("2", "0", 3);
+    const request = createQuoteRequest(pendingTransaction, context, 3);
+    const preparedTransaction = applyQuoteResult(
+      pendingTransaction,
+      makeTransaction("2", "200", 3),
+      context,
+      request,
+      TransactionStatus.PENDING,
+      true
+    ) as Transaction;
+    const quote = preparedTransaction.quote as NonNullable<
+      Transaction["quote"]
+    >;
+
+    expect(
+      activeTransactionMatchesPreparedSubmission(
+        preparedTransaction,
+        preparedTransaction,
+        context
+      )
+    ).toBe(true);
+
+    const changedTransactions: Array<Transaction | undefined> = [
+      undefined,
+      { ...preparedTransaction, id: "replacement-transaction" },
+      { ...preparedTransaction, quoteRevision: 4 },
+      {
+        ...preparedTransaction,
+        quote: { ...quote, inputFingerprint: "changed-input" },
+      },
+      {
+        ...preparedTransaction,
+        quote: { ...quote, resultFingerprint: "changed-result" },
+      },
+      {
+        ...preparedTransaction,
+        transactionStatus: TransactionStatus.SUFFICIENT_BALANCE,
+      },
+    ];
+
+    changedTransactions.forEach((activeTransaction) => {
+      expect(
+        activeTransactionMatchesPreparedSubmission(
+          activeTransaction,
+          preparedTransaction,
+          context
+        )
+      ).toBe(false);
+    });
+  });
+
+  it("blocks a transaction cleared during asynchronous adapter preparation", async () => {
+    const pendingTransaction = makeTransaction("2", "0", 3);
+    const request = createQuoteRequest(pendingTransaction, context, 3);
+    const preparedTransaction = applyQuoteResult(
+      pendingTransaction,
+      makeTransaction("2", "200", 3),
+      context,
+      request,
+      TransactionStatus.PENDING,
+      true
+    ) as Transaction;
+    const adapterPreparation = deferred<void>();
+    const requestOperation = jest.fn();
+    const client = {
+      getActiveAccount: jest.fn().mockResolvedValue({
+        address: context.account,
+        network: { type: context.network },
+      } as AccountInfo),
+      requestOperation,
+    } as unknown as DAppClient;
+    let activeTransaction: Transaction | undefined = preparedTransaction;
+    const guardedClient = createQuoteGuardedDAppClient({
+      client,
+      transaction: preparedTransaction,
+      getActiveTransaction: () => activeTransaction,
+      getRuntime: () => ({
+        context,
+        readChainId: async () => context.chainId,
+      }),
+    });
+
+    const submission = adapterPreparation.promise.then(() =>
+      guardedClient.requestOperation({ operationDetails: [] })
+    );
+    activeTransaction = undefined;
+    adapterPreparation.resolve();
+
+    await expect(submission).rejects.toBeInstanceOf(
+      QuoteSubmissionContextError
+    );
+    expect(requestOperation).not.toHaveBeenCalled();
+  });
+
+  it("re-reads the active transaction immediately before Beacon receives the operation", async () => {
+    const pendingTransaction = makeTransaction("2", "0", 3);
+    const request = createQuoteRequest(pendingTransaction, context, 3);
+    const preparedTransaction = applyQuoteResult(
+      pendingTransaction,
+      makeTransaction("2", "200", 3),
+      context,
+      request,
+      TransactionStatus.PENDING,
+      true
+    ) as Transaction;
+    const chainIdRead = deferred<string>();
+    const requestOperation = jest.fn();
+    const readChainId = jest.fn(() => chainIdRead.promise);
+    const client = {
+      getActiveAccount: jest.fn().mockResolvedValue({
+        address: context.account,
+        network: { type: context.network },
+      } as AccountInfo),
+      requestOperation,
+    } as unknown as DAppClient;
+    let activeTransaction: Transaction | undefined = preparedTransaction;
+    const guardedClient = createQuoteGuardedDAppClient({
+      client,
+      transaction: preparedTransaction,
+      getActiveTransaction: () => activeTransaction,
+      getRuntime: () => ({ context, readChainId }),
+    });
+
+    const submission = guardedClient.requestOperation({ operationDetails: [] });
+    expect(readChainId).toHaveBeenCalledTimes(1);
+    activeTransaction = undefined;
+    chainIdRead.resolve(context.chainId);
+
+    await expect(submission).rejects.toBeInstanceOf(
+      QuoteSubmissionContextError
+    );
+    expect(requestOperation).not.toHaveBeenCalled();
+  });
+
+  it("blocks a valid replacement created during asynchronous adapter preparation", async () => {
+    const pendingTransaction = makeTransaction("2", "0", 3);
+    const request = createQuoteRequest(pendingTransaction, context, 3);
+    const preparedTransaction = applyQuoteResult(
+      pendingTransaction,
+      makeTransaction("2", "200", 3),
+      context,
+      request,
+      TransactionStatus.PENDING,
+      true
+    ) as Transaction;
+    const replacementPending = {
+      ...makeTransaction("5", "0", 4),
+      id: "replacement-transaction",
+    };
+    const replacementRequest = createQuoteRequest(
+      replacementPending,
+      context,
+      4
+    );
+    const replacementTransaction = applyQuoteResult(
+      replacementPending,
+      makeTransaction("5", "500", 4),
+      context,
+      replacementRequest,
+      TransactionStatus.PENDING,
+      true
+    ) as Transaction;
+    const adapterPreparation = deferred<void>();
+    const requestOperation = jest.fn();
+    const client = {
+      getActiveAccount: jest.fn().mockResolvedValue({
+        address: context.account,
+        network: { type: context.network },
+      } as AccountInfo),
+      requestOperation,
+    } as unknown as DAppClient;
+    let activeTransaction = preparedTransaction;
+    const guardedClient = createQuoteGuardedDAppClient({
+      client,
+      transaction: preparedTransaction,
+      getActiveTransaction: () => activeTransaction,
+      getRuntime: () => ({
+        context,
+        readChainId: async () => context.chainId,
+      }),
+    });
+
+    const submission = adapterPreparation.promise.then(() =>
+      guardedClient.requestOperation({ operationDetails: [] })
+    );
+    activeTransaction = replacementTransaction;
+    adapterPreparation.resolve();
+
+    await expect(submission).rejects.toBeInstanceOf(
+      QuoteSubmissionContextError
+    );
     expect(requestOperation).not.toHaveBeenCalled();
   });
 

--- a/V2/tezex/src/functions/quoteSafety.test.ts
+++ b/V2/tezex/src/functions/quoteSafety.test.ts
@@ -1,4 +1,9 @@
-import { NetworkType } from "@airgap/beacon-sdk";
+import {
+  AccountInfo,
+  DAppClient,
+  NetworkType,
+  TezosOperationType,
+} from "@airgap/beacon-sdk";
 import BigNumber from "bignumber.js";
 
 import {
@@ -12,10 +17,13 @@ import {
 } from "../types/general";
 import {
   applyQuoteResult,
+  createQuoteGuardedDAppClient,
   createQuoteRequest,
   hasFreshTransactionQuote,
   QuoteContext,
   quoteRequestMatches,
+  QuoteSubmissionContextError,
+  transactionResultMatchesActive,
 } from "./quoteSafety";
 
 const balance = (mantissa: string): Balance => {
@@ -197,5 +205,135 @@ describe("quote revision safety", () => {
       receiveAmount: [balance("199")] as Transaction["receiveAmount"],
     };
     expect(hasFreshTransactionQuote(changedMinimum, context, true)).toBe(false);
+  });
+
+  it("re-reads the account and chain immediately before the Beacon request", async () => {
+    const pendingTransaction = makeTransaction("2", "0", 3);
+    const request = createQuoteRequest(pendingTransaction, context, 3);
+    const preparedTransaction = applyQuoteResult(
+      pendingTransaction,
+      makeTransaction("2", "200", 3),
+      context,
+      request,
+      TransactionStatus.PENDING,
+      true
+    ) as Transaction;
+    const requestOperation = jest
+      .fn()
+      .mockResolvedValue({ transactionHash: "operation-hash" });
+    const getActiveAccount = jest.fn().mockResolvedValue({
+      address: context.account,
+      network: { type: context.network },
+    } as AccountInfo);
+    const client = {
+      getActiveAccount,
+      requestOperation,
+    } as unknown as DAppClient;
+    const guardedClient = createQuoteGuardedDAppClient({
+      client,
+      transaction: preparedTransaction,
+      getRuntime: () => ({
+        context,
+        readChainId: async () => context.chainId,
+      }),
+    });
+
+    await expect(
+      guardedClient.requestOperation({
+        operationDetails: [
+          {
+            kind: TezosOperationType.TRANSACTION,
+            destination: "KT1-pool",
+            amount: "1",
+          },
+        ],
+      })
+    ).resolves.toEqual({ transactionHash: "operation-hash" });
+    expect(getActiveAccount).toHaveBeenCalledTimes(1);
+    expect(requestOperation).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks a last-moment account switch before Beacon receives the operation", async () => {
+    const pendingTransaction = makeTransaction("2", "0", 3);
+    const request = createQuoteRequest(pendingTransaction, context, 3);
+    const preparedTransaction = applyQuoteResult(
+      pendingTransaction,
+      makeTransaction("2", "200", 3),
+      context,
+      request,
+      TransactionStatus.PENDING,
+      true
+    ) as Transaction;
+    const requestOperation = jest.fn();
+    const client = {
+      getActiveAccount: jest.fn().mockResolvedValue({
+        address: "tz1-other",
+        network: { type: context.network },
+      } as AccountInfo),
+      requestOperation,
+    } as unknown as DAppClient;
+    const guardedClient = createQuoteGuardedDAppClient({
+      client,
+      transaction: preparedTransaction,
+      getRuntime: () => ({
+        context,
+        readChainId: async () => context.chainId,
+      }),
+    });
+
+    await expect(
+      guardedClient.requestOperation({ operationDetails: [] })
+    ).rejects.toBeInstanceOf(QuoteSubmissionContextError);
+    expect(requestOperation).not.toHaveBeenCalled();
+  });
+
+  it("blocks a network switch during request preparation", async () => {
+    const pendingTransaction = makeTransaction("2", "0", 3);
+    const request = createQuoteRequest(pendingTransaction, context, 3);
+    const preparedTransaction = applyQuoteResult(
+      pendingTransaction,
+      makeTransaction("2", "200", 3),
+      context,
+      request,
+      TransactionStatus.PENDING,
+      true
+    ) as Transaction;
+    const requestOperation = jest.fn();
+    const client = {
+      getActiveAccount: jest.fn().mockResolvedValue({
+        address: context.account,
+        network: { type: context.network },
+      } as AccountInfo),
+      requestOperation,
+    } as unknown as DAppClient;
+    let activeContext = context;
+    const guardedClient = createQuoteGuardedDAppClient({
+      client,
+      transaction: preparedTransaction,
+      getRuntime: () => ({
+        context: activeContext,
+        readChainId: async () => {
+          activeContext = { ...context, chainId: "NetDifferent" };
+          return context.chainId;
+        },
+      }),
+    });
+
+    await expect(
+      guardedClient.requestOperation({ operationDetails: [] })
+    ).rejects.toBeInstanceOf(QuoteSubmissionContextError);
+    expect(requestOperation).not.toHaveBeenCalled();
+  });
+
+  it("does not apply an asynchronous result over a replacement transaction", () => {
+    const completed = makeTransaction("1", "100", 2);
+    const replacement = {
+      ...makeTransaction("2", "200", 3),
+      id: "replacement-transaction",
+    };
+
+    expect(transactionResultMatchesActive(completed, completed)).toBe(true);
+    expect(transactionResultMatchesActive(replacement, completed)).toBe(false);
+    expect(transactionResultMatchesActive(undefined, completed)).toBe(false);
   });
 });

--- a/V2/tezex/src/functions/quoteSafety.test.ts
+++ b/V2/tezex/src/functions/quoteSafety.test.ts
@@ -1,0 +1,201 @@
+import { NetworkType } from "@airgap/beacon-sdk";
+import BigNumber from "bignumber.js";
+
+import {
+  Asset,
+  Balance,
+  Token,
+  TokenType,
+  Transaction,
+  TransactionStatus,
+  TransactingComponent,
+} from "../types/general";
+import {
+  applyQuoteResult,
+  createQuoteRequest,
+  hasFreshTransactionQuote,
+  QuoteContext,
+  quoteRequestMatches,
+} from "./quoteSafety";
+
+const balance = (mantissa: string): Balance => {
+  const value = new BigNumber(mantissa);
+  return {
+    decimal: value,
+    mantissa: value,
+    string: value.toFixed(),
+    greaterOrEqualTo: (other) => value.gte(other.mantissa),
+  };
+};
+
+const xtz: Asset = {
+  name: Token.XTZ,
+  label: "XTZ",
+  logo: "",
+  address: "",
+  decimals: 6,
+  type: TokenType.XTZ,
+};
+
+const token: Asset = {
+  name: Token.TzBTC,
+  label: "Token",
+  logo: "",
+  address: "KT1-token",
+  decimals: 6,
+  type: TokenType.FA12,
+};
+
+const context: QuoteContext = {
+  account: "tz1-user",
+  network: NetworkType.MAINNET,
+  chainId: "NetXdQprcVkpaWU",
+};
+
+const makeTransaction = (
+  sendAmount = "1",
+  receiveAmount = "0",
+  revision = 1
+): Transaction => ({
+  id: "transaction-id",
+  network: NetworkType.MAINNET,
+  component: TransactingComponent.SWAP,
+  poolId: "pool-one",
+  sendAsset: [xtz],
+  sendAmount: [balance(sendAmount)],
+  sendAssetBalance: [balance("1000")],
+  receiveAsset: [token],
+  receiveAmount: [balance(receiveAmount)],
+  receiveAssetBalance: [balance("0")],
+  slippage: 0.5,
+  transactionStatus: TransactionStatus.MODIFIED,
+  quoteRevision: revision,
+  lastModified: new Date("2026-07-30T00:00:00Z"),
+  locked: false,
+});
+
+const deferred = <T>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+};
+
+describe("quote revision safety", () => {
+  it("accepts a response only while every request field still matches", () => {
+    const transaction = makeTransaction();
+    const request = createQuoteRequest(transaction, context, 1);
+
+    expect(quoteRequestMatches(transaction, context, request)).toBe(true);
+
+    const changedTransactions: Transaction[] = [
+      { ...transaction, poolId: "pool-two" },
+      { ...transaction, sendAsset: [token], receiveAsset: [xtz] },
+      { ...transaction, sendAmount: [balance("2")] },
+      { ...transaction, slippage: 1 },
+      { ...transaction, network: NetworkType.SHADOWNET },
+      { ...transaction, quoteRevision: 2 },
+    ];
+
+    changedTransactions.forEach((changed) => {
+      expect(quoteRequestMatches(changed, context, request)).toBe(false);
+    });
+
+    expect(
+      quoteRequestMatches(
+        transaction,
+        { ...context, account: "tz1-other" },
+        request
+      )
+    ).toBe(false);
+    expect(
+      quoteRequestMatches(
+        transaction,
+        { ...context, network: NetworkType.SHADOWNET },
+        request
+      )
+    ).toBe(false);
+    expect(
+      quoteRequestMatches(
+        transaction,
+        { ...context, chainId: "NetDifferent" },
+        request
+      )
+    ).toBe(false);
+  });
+
+  it("discards an older RPC response that resolves after a newer quote", async () => {
+    let activeTransaction = makeTransaction("1", "0", 1);
+    const firstRequest = createQuoteRequest(activeTransaction, context, 1);
+    const slowEstimate = deferred<Transaction>();
+
+    const applySlowEstimate = slowEstimate.promise.then((estimate) => {
+      const result = applyQuoteResult(
+        activeTransaction,
+        estimate,
+        context,
+        firstRequest,
+        TransactionStatus.SUFFICIENT_BALANCE
+      );
+      if (result) activeTransaction = result;
+    });
+
+    activeTransaction = makeTransaction("2", "0", 2);
+    const secondRequest = createQuoteRequest(activeTransaction, context, 2);
+    const fastEstimate = makeTransaction("2", "200", 2);
+    const latestResult = applyQuoteResult(
+      activeTransaction,
+      fastEstimate,
+      context,
+      secondRequest,
+      TransactionStatus.SUFFICIENT_BALANCE
+    );
+    expect(latestResult).toBeDefined();
+    activeTransaction = latestResult as Transaction;
+
+    slowEstimate.resolve(makeTransaction("1", "100", 1));
+    await applySlowEstimate;
+
+    expect(activeTransaction.quoteRevision).toBe(2);
+    expect(activeTransaction.sendAmount[0].mantissa.toFixed()).toBe("2");
+    expect(activeTransaction.receiveAmount[0].mantissa.toFixed()).toBe("200");
+    expect(activeTransaction.poolId).toBe("pool-one");
+    expect(activeTransaction.sendAsset[0].name).toBe(Token.XTZ);
+    expect(activeTransaction.transactionStatus).toBe(
+      TransactionStatus.SUFFICIENT_BALANCE
+    );
+  });
+
+  it("requires a fresh, untampered quote prepared specifically for submission", () => {
+    const pendingTransaction = makeTransaction("2", "0", 3);
+    const request = createQuoteRequest(pendingTransaction, context, 3);
+    const estimate = makeTransaction("2", "200", 3);
+    const displayedQuote = applyQuoteResult(
+      pendingTransaction,
+      estimate,
+      context,
+      request,
+      TransactionStatus.SUFFICIENT_BALANCE
+    ) as Transaction;
+
+    expect(hasFreshTransactionQuote(displayedQuote, context)).toBe(true);
+    expect(hasFreshTransactionQuote(displayedQuote, context, true)).toBe(false);
+
+    const submissionQuote = applyQuoteResult(
+      pendingTransaction,
+      estimate,
+      context,
+      request,
+      TransactionStatus.PENDING,
+      true
+    ) as Transaction;
+    expect(hasFreshTransactionQuote(submissionQuote, context, true)).toBe(true);
+
+    const changedMinimum = {
+      ...submissionQuote,
+      receiveAmount: [balance("199")] as Transaction["receiveAmount"],
+    };
+    expect(hasFreshTransactionQuote(changedMinimum, context, true)).toBe(false);
+  });
+});

--- a/V2/tezex/src/functions/quoteSafety.ts
+++ b/V2/tezex/src/functions/quoteSafety.ts
@@ -1,0 +1,143 @@
+import { NetworkType } from "@airgap/beacon-sdk";
+
+import {
+  Asset,
+  Transaction,
+  TransactionQuote,
+  TransactionStatus,
+} from "../types/general";
+
+export interface QuoteContext {
+  account: string | null;
+  network: NetworkType;
+  chainId: string;
+}
+
+export interface QuoteRequest {
+  transactionId: string;
+  revision: number;
+  inputFingerprint: string;
+}
+
+const assetFingerprint = (asset: Asset) => ({
+  name: asset.name,
+  type: asset.type,
+  address: asset.address,
+  tokenId: asset.tokenId ?? null,
+  decimals: asset.decimals,
+});
+
+const amountFingerprint = (transaction: Transaction) =>
+  transaction.sendAmount.map((amount) => amount.mantissa.toFixed());
+
+const receiveFingerprint = (transaction: Transaction) =>
+  transaction.receiveAmount.map((amount) => amount.mantissa.toFixed());
+
+export const createQuoteInputFingerprint = (
+  transaction: Transaction,
+  context: QuoteContext
+): string =>
+  JSON.stringify({
+    transactionId: transaction.id,
+    component: transaction.component,
+    account: context.account,
+    network: context.network,
+    chainId: context.chainId,
+    transactionNetwork: transaction.network,
+    poolId: transaction.poolId,
+    sendAssets: transaction.sendAsset.map(assetFingerprint),
+    receiveAssets: transaction.receiveAsset.map(assetFingerprint),
+    sendAmounts: amountFingerprint(transaction),
+    slippage: transaction.slippage,
+  });
+
+export const createQuoteResultFingerprint = (
+  transaction: Transaction,
+  context: QuoteContext
+): string =>
+  JSON.stringify({
+    input: createQuoteInputFingerprint(transaction, context),
+    receiveAmounts: receiveFingerprint(transaction),
+  });
+
+export const createQuoteRequest = (
+  transaction: Transaction,
+  context: QuoteContext,
+  revision: number
+): QuoteRequest => ({
+  transactionId: transaction.id,
+  revision,
+  inputFingerprint: createQuoteInputFingerprint(transaction, context),
+});
+
+export const quoteRequestMatches = (
+  transaction: Transaction | undefined,
+  context: QuoteContext,
+  request: QuoteRequest
+): transaction is Transaction =>
+  Boolean(
+    transaction &&
+      transaction.id === request.transactionId &&
+      (transaction.quoteRevision ?? 0) === request.revision &&
+      createQuoteInputFingerprint(transaction, context) ===
+        request.inputFingerprint
+  );
+
+export const createTransactionQuote = (
+  transaction: Transaction,
+  context: QuoteContext,
+  revision: number,
+  preparedForSubmission = false
+): TransactionQuote => ({
+  revision,
+  inputFingerprint: createQuoteInputFingerprint(transaction, context),
+  resultFingerprint: createQuoteResultFingerprint(transaction, context),
+  quotedAt: new Date().toISOString(),
+  preparedForSubmission,
+});
+
+export const hasFreshTransactionQuote = (
+  transaction: Transaction,
+  context: QuoteContext,
+  requireSubmissionReady = false
+): boolean =>
+  Boolean(
+    transaction.quote &&
+      transaction.quote.revision === (transaction.quoteRevision ?? 0) &&
+      transaction.quote.inputFingerprint ===
+        createQuoteInputFingerprint(transaction, context) &&
+      transaction.quote.resultFingerprint ===
+        createQuoteResultFingerprint(transaction, context) &&
+      (!requireSubmissionReady || transaction.quote.preparedForSubmission)
+  );
+
+export const applyQuoteResult = (
+  currentTransaction: Transaction | undefined,
+  estimatedTransaction: Transaction,
+  context: QuoteContext,
+  request: QuoteRequest,
+  transactionStatus: TransactionStatus,
+  preparedForSubmission = false
+): Transaction | undefined => {
+  if (!quoteRequestMatches(currentTransaction, context, request)) {
+    return undefined;
+  }
+
+  const nextTransaction: Transaction = {
+    ...currentTransaction,
+    sendAmount: estimatedTransaction.sendAmount,
+    receiveAmount: estimatedTransaction.receiveAmount,
+    transactionStatus,
+    lastModified: new Date(),
+  };
+
+  return {
+    ...nextTransaction,
+    quote: createTransactionQuote(
+      nextTransaction,
+      context,
+      request.revision,
+      preparedForSubmission
+    ),
+  };
+};

--- a/V2/tezex/src/functions/quoteSafety.ts
+++ b/V2/tezex/src/functions/quoteSafety.ts
@@ -1,4 +1,4 @@
-import { NetworkType } from "@airgap/beacon-sdk";
+import { DAppClient, NetworkType } from "@airgap/beacon-sdk";
 
 import {
   Asset,
@@ -17,6 +17,18 @@ export interface QuoteRequest {
   transactionId: string;
   revision: number;
   inputFingerprint: string;
+}
+
+export class QuoteSubmissionContextError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "QuoteSubmissionContextError";
+  }
+}
+
+export interface QuoteSubmissionRuntime {
+  context: QuoteContext;
+  readChainId: () => Promise<string>;
 }
 
 const assetFingerprint = (asset: Asset) => ({
@@ -110,6 +122,66 @@ export const hasFreshTransactionQuote = (
         createQuoteResultFingerprint(transaction, context) &&
       (!requireSubmissionReady || transaction.quote.preparedForSubmission)
   );
+
+const contextsMatch = (left: QuoteContext, right: QuoteContext): boolean =>
+  left.account === right.account &&
+  left.network === right.network &&
+  left.chainId === right.chainId;
+
+export const createQuoteGuardedDAppClient = (input: {
+  client: DAppClient;
+  transaction: Transaction;
+  getRuntime: () => QuoteSubmissionRuntime;
+}): DAppClient => {
+  const guardedClient = Object.create(input.client) as DAppClient;
+
+  guardedClient.requestOperation = async (request) => {
+    const runtimeBefore = input.getRuntime();
+    if (
+      !runtimeBefore.context.account ||
+      !hasFreshTransactionQuote(input.transaction, runtimeBefore.context, true)
+    ) {
+      throw new QuoteSubmissionContextError(
+        "The transaction quote no longer matches the active wallet context."
+      );
+    }
+
+    const chainId = await runtimeBefore.readChainId();
+    const activeAccount = await input.client.getActiveAccount();
+    const runtimeImmediatelyBeforeRequest = input.getRuntime();
+
+    if (
+      !contextsMatch(
+        runtimeBefore.context,
+        runtimeImmediatelyBeforeRequest.context
+      ) ||
+      chainId !== runtimeImmediatelyBeforeRequest.context.chainId ||
+      !activeAccount ||
+      activeAccount.address !==
+        runtimeImmediatelyBeforeRequest.context.account ||
+      activeAccount.network.type !==
+        runtimeImmediatelyBeforeRequest.context.network ||
+      !hasFreshTransactionQuote(
+        input.transaction,
+        runtimeImmediatelyBeforeRequest.context,
+        true
+      )
+    ) {
+      throw new QuoteSubmissionContextError(
+        "The wallet account or network changed during transaction preparation."
+      );
+    }
+
+    return input.client.requestOperation(request);
+  };
+
+  return guardedClient;
+};
+
+export const transactionResultMatchesActive = (
+  activeTransaction: { id: string } | undefined,
+  completedTransaction: { id: string }
+): boolean => activeTransaction?.id === completedTransaction.id;
 
 export const applyQuoteResult = (
   currentTransaction: Transaction | undefined,

--- a/V2/tezex/src/functions/quoteSafety.ts
+++ b/V2/tezex/src/functions/quoteSafety.ts
@@ -123,6 +123,29 @@ export const hasFreshTransactionQuote = (
       (!requireSubmissionReady || transaction.quote.preparedForSubmission)
   );
 
+export const activeTransactionMatchesPreparedSubmission = (
+  activeTransaction: Transaction | undefined,
+  preparedTransaction: Transaction,
+  context: QuoteContext
+): activeTransaction is Transaction =>
+  Boolean(
+    activeTransaction &&
+      activeTransaction.id === preparedTransaction.id &&
+      activeTransaction.transactionStatus === TransactionStatus.PENDING &&
+      preparedTransaction.transactionStatus === TransactionStatus.PENDING &&
+      activeTransaction.quoteRevision === preparedTransaction.quoteRevision &&
+      activeTransaction.quote?.revision ===
+        preparedTransaction.quote?.revision &&
+      activeTransaction.quote?.inputFingerprint ===
+        preparedTransaction.quote?.inputFingerprint &&
+      activeTransaction.quote?.resultFingerprint ===
+        preparedTransaction.quote?.resultFingerprint &&
+      activeTransaction.quote?.preparedForSubmission === true &&
+      preparedTransaction.quote?.preparedForSubmission === true &&
+      hasFreshTransactionQuote(activeTransaction, context, true) &&
+      hasFreshTransactionQuote(preparedTransaction, context, true)
+  );
+
 const contextsMatch = (left: QuoteContext, right: QuoteContext): boolean =>
   left.account === right.account &&
   left.network === right.network &&
@@ -131,6 +154,7 @@ const contextsMatch = (left: QuoteContext, right: QuoteContext): boolean =>
 export const createQuoteGuardedDAppClient = (input: {
   client: DAppClient;
   transaction: Transaction;
+  getActiveTransaction: () => Transaction | undefined;
   getRuntime: () => QuoteSubmissionRuntime;
 }): DAppClient => {
   const guardedClient = Object.create(input.client) as DAppClient;
@@ -139,16 +163,22 @@ export const createQuoteGuardedDAppClient = (input: {
     const runtimeBefore = input.getRuntime();
     if (
       !runtimeBefore.context.account ||
-      !hasFreshTransactionQuote(input.transaction, runtimeBefore.context, true)
+      !activeTransactionMatchesPreparedSubmission(
+        input.getActiveTransaction(),
+        input.transaction,
+        runtimeBefore.context
+      )
     ) {
       throw new QuoteSubmissionContextError(
-        "The transaction quote no longer matches the active wallet context."
+        "The active transaction no longer matches the prepared submission."
       );
     }
 
     const chainId = await runtimeBefore.readChainId();
     const activeAccount = await input.client.getActiveAccount();
     const runtimeImmediatelyBeforeRequest = input.getRuntime();
+    const activeTransactionImmediatelyBeforeRequest =
+      input.getActiveTransaction();
 
     if (
       !contextsMatch(
@@ -161,14 +191,14 @@ export const createQuoteGuardedDAppClient = (input: {
         runtimeImmediatelyBeforeRequest.context.account ||
       activeAccount.network.type !==
         runtimeImmediatelyBeforeRequest.context.network ||
-      !hasFreshTransactionQuote(
+      !activeTransactionMatchesPreparedSubmission(
+        activeTransactionImmediatelyBeforeRequest,
         input.transaction,
-        runtimeImmediatelyBeforeRequest.context,
-        true
+        runtimeImmediatelyBeforeRequest.context
       )
     ) {
       throw new QuoteSubmissionContextError(
-        "The wallet account or network changed during transaction preparation."
+        "The wallet context or active transaction changed during transaction preparation."
       );
     }
 

--- a/V2/tezex/src/hooks/transaction.ts
+++ b/V2/tezex/src/hooks/transaction.ts
@@ -6,7 +6,6 @@ import {
   getAssetStateByTransactionTypeAndAsset,
   transactionToAssetStates,
 } from "../functions/util";
-import { estimateWithAdapter } from "../functions/estimates";
 import {
   Transaction,
   TransactionStatus,
@@ -21,8 +20,6 @@ import {
 
 import { debounce, eq } from "lodash";
 import { useDebounce } from "usehooks-ts";
-import { PoolRegistry } from "../adapters/poolRegistry";
-import { useNetwork } from "./network";
 import {
   getSlippageValidationMessage,
   getSpendableXtz,
@@ -64,7 +61,6 @@ export function useTransaction(
   }
 ): TransactionOps {
   const wallet = useContext(WalletContext);
-  const network = useNetwork();
   const [counter, setCounter] = useState<number>(0);
   const [loading, setLoading] = useState<boolean>(true);
   const [assetStates, setAssetStates] = useState<AssetState[]>([]);
@@ -257,58 +253,47 @@ export function useTransaction(
   // calback to handle send amount or slippage updates to transaction in context
   const _updateAmount = useCallback(
     async (sendAmount?: string, slippage?: string): Promise<boolean> => {
-      // variable to track if transaction was updated
-      let updated = false;
       const transaction = getActiveTransaction();
-      // if transaction exists and is not locked
-      if (transaction && !transaction.locked) {
-        // handle slippage update
-        if (slippage !== undefined) {
-          const validationMessage = getSlippageValidationMessage(slippage);
-          if (validationMessage) {
-            await wallet.updateStatus(
-              component,
-              TransactionStatus.INVALID_SLIPPAGE
-            );
-            updated = true;
-          } else {
-            const _slippage = new BigNumber(slippage).toNumber();
-            updated =
-              updated ||
-              (await wallet.updateAmount(
-                component,
-                undefined,
-                undefined,
-                _slippage
-              ));
-          }
-        }
-        // handle send amount update
-        if (sendAmount) {
-          const adapter = PoolRegistry.getAdapter(transaction.poolId);
+      if (!transaction || transaction.locked) return false;
 
-          const updatedTransaction: Transaction = {
-            ...transaction,
-            sendAmount: !transaction.sendAmount[1]
-              ? [balanceBuilder(sendAmount, transaction.sendAsset[0], false)]
-              : [
-                  balanceBuilder(sendAmount, transaction.sendAsset[0], false),
-                  transaction.sendAmount[1],
-                ],
-          };
-          const _transaction: Transaction = await estimateWithAdapter(
-            updatedTransaction,
-            network.toolkit,
-            adapter
+      let slippageUpdate: number | undefined;
+      if (slippage !== undefined) {
+        const validationMessage = getSlippageValidationMessage(slippage);
+        if (validationMessage) {
+          await wallet.invalidateTransactionQuote(
+            component,
+            TransactionStatus.INVALID_SLIPPAGE
           );
-          updated = await wallet.updateAmount(
-            _transaction.component,
-            _transaction.sendAmount,
-            _transaction.receiveAmount
-          );
+          return true;
         }
+        slippageUpdate = new BigNumber(slippage).toNumber();
       }
-      return updated;
+
+      const sendAmountUpdate =
+        sendAmount !== undefined
+          ? ((!transaction.sendAmount[1]
+              ? [
+                  balanceBuilder(
+                    sendAmount || "0",
+                    transaction.sendAsset[0],
+                    false
+                  ),
+                ]
+              : [
+                  balanceBuilder(
+                    sendAmount || "0",
+                    transaction.sendAsset[0],
+                    false
+                  ),
+                  transaction.sendAmount[1],
+                ]) as Amount)
+          : undefined;
+
+      return wallet.refreshTransactionQuote(
+        component,
+        sendAmountUpdate,
+        slippageUpdate
+      );
     },
     [getActiveTransaction, wallet, component]
   );

--- a/V2/tezex/src/hooks/wallet.ts
+++ b/V2/tezex/src/hooks/wallet.ts
@@ -57,7 +57,7 @@ export function useWalletOps(
   const sendTransaction = useCallback(async () => {
     const _transaction = wallet.getActiveTransaction(component);
     if (wallet && _transaction && !_transaction.locked) {
-      await wallet.updateStatus(component, TransactionStatus.PENDING);
+      await wallet.prepareTransactionForSubmission(component);
     }
   }, [wallet, component, transaction]);
 

--- a/V2/tezex/src/types/general.ts
+++ b/V2/tezex/src/types/general.ts
@@ -107,6 +107,14 @@ export enum TransactingComponent {
 
 export type Id = string;
 
+export interface TransactionQuote {
+  revision: number;
+  inputFingerprint: string;
+  resultFingerprint: string;
+  quotedAt: string;
+  preparedForSubmission: boolean;
+}
+
 export type SendOrRecieve = "Send" | "Receive";
 export type Amount = [Balance] | [Balance, Balance];
 export type AssetOrAssetPair = [Asset] | [Asset, Asset];
@@ -170,6 +178,8 @@ export interface Transaction {
   receiveAssetBalance: Amount;
   transactionStatus: TransactionStatus;
   operationHash?: string;
+  quoteRevision?: number;
+  quote?: TransactionQuote;
   lastModified: Date;
   locked: boolean;
 }


### PR DESCRIPTION
## Summary

- bind quote responses to a monotonic revision and an exact transaction/context fingerprint
- reject delayed responses when the account, network/chain, pool, direction, assets, amount, or slippage has changed
- centralize quote application so stale responses cannot mutate the active amount, minimum output, direction, pool, or status
- require a fresh adapter quote immediately before wallet submission and reject tampered or non-prepared quotes
- re-check the active wallet account, network, RPC chain ID, and quote context immediately at the wallet request boundary
- re-read synchronous WalletProvider state and require the same active transaction ID, revision, fingerprints, submission-ready flag, and `PENDING` status before every wallet request
- prevent a completed async transaction from replacing a newer or cleared transaction
- add deliberately out-of-order lifecycle and quote-safety regression tests

## Why

Quote requests and wallet preparation can complete out of order. Without binding each result to the exact inputs, active transaction, and wallet context that produced it, an older response could overwrite a newer transaction or reach the wallet after the account, network, amount, pool, or direction changed.

## Review feedback addressed

- the guarded Beacon client calls `getActiveAccount()`, verifies the RPC chain ID, re-reads the current context, and revalidates the prepared quote immediately before forwarding each `requestOperation`
- WalletProvider maintains a synchronous active-transaction ref so clear/replace mutations are visible before React's next render
- the request boundary rejects cleared, replaced, revised, re-fingerprinted, non-prepared, and non-pending transactions
- the final transaction-state write succeeds only when the active component still contains the same transaction ID

## Impact

This changes quote state management and submission validation only. It does not include deployment addresses or token-specific configuration. A mismatch fails closed before the wallet receives the operation.

## Validation

- rebased onto current `trunk` at `400eec2`
- `npm run verify` passed on commit `4a5c926`
  - production audit threshold passed (12 low, 2 moderate; no high or critical)
  - TypeScript passed
  - 28 test suites and 108 tests passed
  - optimized production build passed
- 2 focused suites and 13 quote/lifecycle tests passed
- changed-file ESLint passed with zero warnings
- Prettier and `git diff --check` passed

Closes #246