### PR TITLE
Refine header logo focus state

### DIFF
--- a/V2/tezex/src/components/ui/views/header/index.tsx
+++ b/V2/tezex/src/components/ui/views/header/index.tsx
@@ -44,6 +44,7 @@ export const Header: FC<IHeader> = (props) => {
               component={Link}
               to="/home/swap"
               aria-label="TEZEX home"
+              onMouseDown={(event) => event.preventDefault()}
               sx={styles.logoLink}
             >
               <Box component="img" sx={styles.logoLarge} src={logo} alt="" />

--- a/V2/tezex/src/components/ui/views/header/style.js
+++ b/V2/tezex/src/components/ui/views/header/style.js
@@ -49,11 +49,11 @@ const style = (theme, scale = 1) => {
     logoLink: {
       display: "flex",
       flexShrink: 0,
-      borderRadius: "4px",
       textDecoration: "none",
+      outline: "none",
       "&:focus-visible": {
-        outline: "2px solid var(--tezex-text-secondary)",
-        outlineOffset: "4px",
+        outline: "none",
+        boxShadow: "inset 0 -2px 0 var(--tezex-text-secondary)",
       },
     },
     container: {


### PR DESCRIPTION
## What changed

- removes the large rounded focus outline from the clickable TEZEX header logo
- prevents pointer clicks from leaving the logo focused
- preserves a restrained keyboard-only underline focus indicator

## Why

The previous focus style enclosed the logo in a prominent rounded rectangle after clicking it, which did not match the header design.

## Validation

- header interaction test passes
- TypeScript type-check passes
- browser verification confirms a pointer click navigates home without retaining focus on the logo