### PR TITLE
Restrict sTEZ subdomain to the sTEZ interface

### DIFF
--- a/V2/tezex/src/index.tsx
+++ b/V2/tezex/src/index.tsx
@@ -6,7 +6,12 @@ import App from "./App";
 import reportWebVitals from "./reportWebVitals";
 import { SessionProvider } from "./contexts/session";
 import ReactDOM from "react-dom/client";
-import { createHashRouter, Navigate, RouterProvider } from "react-router-dom";
+import {
+  createHashRouter,
+  Navigate,
+  RouterProvider,
+  useLocation,
+} from "react-router-dom";
 
 import { AppConfig } from "./types/general";
 import appConfig from "./config/app.json";
@@ -15,43 +20,91 @@ import { Analytics } from "./pages/Analytics";
 import { Stez } from "./pages/Stez";
 import { NotFound } from "./pages/NotFound";
 import { ColorModeProvider } from "./contexts/color-mode";
+import { canonicalTezexUrl, isStezOnlyHost } from "./routing";
 
-const router = createHashRouter([
+const CanonicalTezexRedirect = () => {
+  const location = useLocation();
+
+  React.useEffect(() => {
+    window.location.replace(
+      canonicalTezexUrl(location.pathname, location.search)
+    );
+  }, [location.pathname, location.search]);
+
+  return null;
+};
+
+const standardRoutes = [
+  {
+    index: true,
+    element: <Navigate to="/home/swap" replace />,
+  },
+  {
+    path: "home/swap",
+    element: <Home path="swap" />,
+  },
+  {
+    path: "home/add",
+    element: <Home path="add" />,
+  },
+  {
+    path: "home/remove",
+    element: <Home path="remove" />,
+  },
+  {
+    path: "analytics",
+    element: <Analytics />,
+  },
+  {
+    path: "stez",
+    element: <Stez />,
+  },
+  {
+    path: "*",
+    element: <NotFound />,
+  },
+];
+
+const stezOnlyRoutes = [
   {
     path: "/",
     element: <App />,
     children: [
       {
         index: true,
-        element: <Navigate to="/home/swap" replace />,
-      },
-      {
-        path: "home/swap",
-        element: <Home path="swap" />,
-      },
-      {
-        path: "home/add",
-        element: <Home path="add" />,
-      },
-      {
-        path: "home/remove",
-        element: <Home path="remove" />,
-      },
-      {
-        path: "analytics",
-        element: <Analytics />,
+        element: <Navigate to="/stez" replace />,
       },
       {
         path: "stez",
         element: <Stez />,
       },
-      {
-        path: "*",
-        element: <NotFound />,
-      },
     ],
   },
-]);
+  {
+    path: "home/*",
+    element: <CanonicalTezexRedirect />,
+  },
+  {
+    path: "analytics",
+    element: <CanonicalTezexRedirect />,
+  },
+  {
+    path: "*",
+    element: <Navigate to="/stez" replace />,
+  },
+];
+
+const router = createHashRouter(
+  isStezOnlyHost(window.location.hostname)
+    ? stezOnlyRoutes
+    : [
+        {
+          path: "/",
+          element: <App />,
+          children: standardRoutes,
+        },
+      ]
+);
 const root = ReactDOM.createRoot(document.getElementById("root") as Element);
 
 root.render(

--- a/V2/tezex/src/routing.test.ts
+++ b/V2/tezex/src/routing.test.ts
@@ -1,0 +1,19 @@
+import { canonicalTezexUrl, isStezOnlyHost, STEZ_HOSTNAME } from "./routing";
+
+describe("hostname-specific routing", () => {
+  it("recognizes only the dedicated sTEZ hostname", () => {
+    expect(isStezOnlyHost(STEZ_HOSTNAME)).toBe(true);
+    expect(isStezOnlyHost("STEZ.TEZEX.IO")).toBe(true);
+    expect(isStezOnlyHost("tezex.io")).toBe(false);
+    expect(isStezOnlyHost("stez.tezex.io.example.com")).toBe(false);
+  });
+
+  it("moves non-sTEZ routes to the canonical TEZEX origin", () => {
+    expect(canonicalTezexUrl("/home/swap")).toBe(
+      "https://tezex.io/#/home/swap"
+    );
+    expect(canonicalTezexUrl("/analytics", "?range=30d")).toBe(
+      "https://tezex.io/#/analytics?range=30d"
+    );
+  });
+});

--- a/V2/tezex/src/routing.ts
+++ b/V2/tezex/src/routing.ts
@@ -1,0 +1,8 @@
+export const STEZ_HOSTNAME = "stez.tezex.io";
+export const CANONICAL_TEZEX_ORIGIN = "https://tezex.io";
+
+export const isStezOnlyHost = (hostname: string) =>
+  hostname.trim().toLowerCase() === STEZ_HOSTNAME;
+
+export const canonicalTezexUrl = (pathname: string, search = "") =>
+  `${CANONICAL_TEZEX_ORIGIN}/#${pathname}${search}`;


### PR DESCRIPTION
## What changed

- makes `stez.tezex.io` open the sTEZ interface by default
- prevents swap, liquidity, analytics, and unknown routes from being served on the sTEZ subdomain
- sends intentional navigation to the rest of TEZEX back to the canonical `tezex.io` domain
- leaves all routing on `tezex.io` unchanged

## Why

The sTEZ hostname is a dedicated product entry point, not a second hostname for the complete TEZEX application.

## Validation

- 67 tests passed
- TypeScript check passed
- production build passed