### PR TITLE
Keep the sTEZ subdomain URL clean

### DIFF
--- a/V2/tezex/src/index.tsx
+++ b/V2/tezex/src/index.tsx
@@ -8,6 +8,7 @@ import { SessionProvider } from "./contexts/session";
 import ReactDOM from "react-dom/client";
 import {
   createHashRouter,
+  createMemoryRouter,
   Navigate,
   RouterProvider,
   useLocation,
@@ -20,7 +21,11 @@ import { Analytics } from "./pages/Analytics";
 import { Stez } from "./pages/Stez";
 import { NotFound } from "./pages/NotFound";
 import { ColorModeProvider } from "./contexts/color-mode";
-import { canonicalTezexUrl, isStezOnlyHost } from "./routing";
+import {
+  canonicalTezexUrl,
+  isStezOnlyHost,
+  stezRouteFromHash,
+} from "./routing";
 
 const CanonicalTezexRedirect = () => {
   const location = useLocation();
@@ -94,17 +99,24 @@ const stezOnlyRoutes = [
   },
 ];
 
-const router = createHashRouter(
-  isStezOnlyHost(window.location.hostname)
-    ? stezOnlyRoutes
-    : [
-        {
-          path: "/",
-          element: <App />,
-          children: standardRoutes,
-        },
-      ]
-);
+const stezOnlyHost = isStezOnlyHost(window.location.hostname);
+const stezInitialRoute = stezRouteFromHash(window.location.hash);
+
+if (stezOnlyHost && window.location.href !== `${window.location.origin}/`) {
+  window.history.replaceState(window.history.state, "", "/");
+}
+
+const router = stezOnlyHost
+  ? createMemoryRouter(stezOnlyRoutes, {
+      initialEntries: [stezInitialRoute],
+    })
+  : createHashRouter([
+      {
+        path: "/",
+        element: <App />,
+        children: standardRoutes,
+      },
+    ]);
 const root = ReactDOM.createRoot(document.getElementById("root") as Element);
 
 root.render(

--- a/V2/tezex/src/routing.test.ts
+++ b/V2/tezex/src/routing.test.ts
@@ -1,4 +1,9 @@
-import { canonicalTezexUrl, isStezOnlyHost, STEZ_HOSTNAME } from "./routing";
+import {
+  canonicalTezexUrl,
+  isStezOnlyHost,
+  STEZ_HOSTNAME,
+  stezRouteFromHash,
+} from "./routing";
 
 describe("hostname-specific routing", () => {
   it("recognizes only the dedicated sTEZ hostname", () => {
@@ -14,6 +19,19 @@ describe("hostname-specific routing", () => {
     );
     expect(canonicalTezexUrl("/analytics", "?range=30d")).toBe(
       "https://tezex.io/#/analytics?range=30d"
+    );
+  });
+
+  it("maps the clean sTEZ URL to its internal page without exposing a hash", () => {
+    expect(stezRouteFromHash("")).toBe("/stez");
+    expect(stezRouteFromHash("#/")).toBe("/stez");
+    expect(stezRouteFromHash("#/stez")).toBe("/stez");
+  });
+
+  it("preserves an incoming non-sTEZ route long enough to redirect it", () => {
+    expect(stezRouteFromHash("#/home/swap")).toBe("/home/swap");
+    expect(stezRouteFromHash("#/analytics?range=30d")).toBe(
+      "/analytics?range=30d"
     );
   });
 });

--- a/V2/tezex/src/routing.ts
+++ b/V2/tezex/src/routing.ts
@@ -6,3 +6,13 @@ export const isStezOnlyHost = (hostname: string) =>
 
 export const canonicalTezexUrl = (pathname: string, search = "") =>
   `${CANONICAL_TEZEX_ORIGIN}/#${pathname}${search}`;
+
+export const stezRouteFromHash = (hash: string) => {
+  const route = hash.replace(/^#/, "");
+
+  if (!route || route === "/" || route === "/stez") {
+    return "/stez";
+  }
+
+  return route.startsWith("/") ? route : `/${route}`;
+};


### PR DESCRIPTION
## What changed
- serves the sTEZ interface at the bare `stez.tezex.io` address without exposing a hash route
- keeps subdomain navigation isolated from the main TEZEX application
- continues redirecting swap, liquidity, and analytics routes to `tezex.io`

## Why
The dedicated sTEZ hostname should behave as a single-purpose entry point and remain visually clean in the address bar.

## Validation
- 23 test suites passed (69 tests)
- TypeScript typecheck passed
- production build passed