### PR TITLE
Use clean application URLs

### DIFF
--- a/V2/tezex/package.json
+++ b/V2/tezex/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Tezex",
   "version": "0.1.0",
-  "homepage": ".",
+  "homepage": "/",
   "private": true,
   "dependencies": {
     "@airgap/beacon-dapp": "^4.8.1",

--- a/V2/tezex/public/404.html
+++ b/V2/tezex/public/404.html
@@ -12,7 +12,13 @@
         var path = window.location.pathname;
         var isAsset = /\.[a-z0-9]+$/i.test(path);
         if (path !== "/" && !isAsset) {
-          window.location.replace("/#" + path + window.location.search);
+          var route = path + window.location.search + window.location.hash;
+          try {
+            window.sessionStorage.setItem("tezex:spa-route", route);
+            window.location.replace("/");
+          } catch (_) {
+            window.location.replace("/?__route=" + encodeURIComponent(route));
+          }
         }
       })();
     </script>
@@ -95,9 +101,7 @@
       <p class="eyebrow">ERROR 404</p>
       <h1>Page not found.</h1>
       <p>The address may have changed, or the page may no longer exist.</p>
-      <a href="/#/home/swap"
-        >RETURN TO SWAP <span aria-hidden="true">→</span></a
-      >
+      <a href="/">RETURN TO SWAP <span aria-hidden="true">→</span></a>
     </main>
   </body>
 </html>

--- a/V2/tezex/public/index.html
+++ b/V2/tezex/public/index.html
@@ -3,28 +3,65 @@
   <head>
     <title>TEZEX | Tezos Liquidity Exchange</title>
     <meta charset="utf-8" />
-    <meta name="viewport"
-     content="width=device-width, height=device-height, initial-scale=1.0,  maximum-scale=1.0,  viewport-fit=cover">
+    <meta
+      name="viewport"
+      content="width=device-width, height=device-height, initial-scale=1.0,  maximum-scale=1.0,  viewport-fit=cover"
+    />
     <meta name="theme-color" content="#000000" />
-    <meta name="description" content="TEZEX (Tezos Exchange) is liquidity hub for the Tezos blockchain ecosystem — aggregating the largest liquidity sources in Tezos — trade and provide liquidity" />
+    <meta
+      name="description"
+      content="TEZEX (Tezos Exchange) is liquidity hub for the Tezos blockchain ecosystem — aggregating the largest liquidity sources in Tezos — trade and provide liquidity"
+    />
+    <script>
+      (function () {
+        var key = "tezex:spa-route";
+        var route = null;
+
+        try {
+          route = window.sessionStorage.getItem(key);
+          window.sessionStorage.removeItem(key);
+        } catch (_) {}
+
+        if (!route) {
+          var params = new URLSearchParams(window.location.search);
+          route = params.get("__route");
+        }
+
+        if (route && route.charAt(0) === "/" && route.slice(0, 2) !== "//") {
+          window.history.replaceState(window.history.state, "", route);
+        }
+      })();
+    </script>
 
     <!--  Open Graph Tags  -->
     <meta property="og:title" content="TEZEX | Tezos Liquidity Exchange" />
-    <meta property="og:description" content="TEZEX (Tezos Exchange) is liquidity hub for the Tezos blockchain ecosystem — aggregating the largest liquidity sources in Tezos — trade and provide liquidity"/>
+    <meta
+      property="og:description"
+      content="TEZEX (Tezos Exchange) is liquidity hub for the Tezos blockchain ecosystem — aggregating the largest liquidity sources in Tezos — trade and provide liquidity"
+    />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://tezex.io" />
     <meta property="og:image" content="%PUBLIC_URL%/assets/tezex_image.png" />
-    
-    <meta property="og:image:width" content="2615" /> <!-- Adjust the width -->
-    <meta property="og:image:height" content="1468" /> <!-- Adjust the height -->
+
+    <meta property="og:image:width" content="2615" />
+    <!-- Adjust the width -->
+    <meta property="og:image:height" content="1468" />
+    <!-- Adjust the height -->
     <meta property="og:site_name" content="TEZEX" />
     <meta property="og:locale" content="en_US" />
 
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="TEZEX | Tezos Liquidity Exchange" />
-    <meta name="twitter:description" content="TEZEX (Tezos Exchange) is liquidity hub for the Tezos blockchain ecosystem — aggregating the largest liquidity sources in Tezos — trade and provide liquidity" />
+    <meta
+      name="twitter:description"
+      content="TEZEX (Tezos Exchange) is liquidity hub for the Tezos blockchain ecosystem — aggregating the largest liquidity sources in Tezos — trade and provide liquidity"
+    />
     <meta name="twitter:image" content="%PUBLIC_URL%/assets/tezex_image.png" />
-    <link rel="icon" type="image/x-icon" href="%PUBLIC_URL%/assets/favicon.ico" />
+    <link
+      rel="icon"
+      type="image/x-icon"
+      href="%PUBLIC_URL%/assets/favicon.ico"
+    />
     <link
       rel="preload"
       href="%PUBLIC_URL%/fonts/inter-latin.woff2"
@@ -46,9 +83,9 @@
         font-weight: 400 700;
         font-display: block;
         src: url("%PUBLIC_URL%/fonts/inter-latin.woff2") format("woff2");
-        unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC,
-          U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F,
-          U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+        unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6,
+          U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122,
+          U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
       }
 
       @font-face {
@@ -56,19 +93,18 @@
         font-style: normal;
         font-weight: 400 600;
         font-display: block;
-        src: url("%PUBLIC_URL%/fonts/red-hat-mono-latin.woff2")
-          format("woff2");
-        unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC,
-          U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F,
-          U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+        src: url("%PUBLIC_URL%/fonts/red-hat-mono-latin.woff2") format("woff2");
+        unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6,
+          U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122,
+          U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
       }
     </style>
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-  <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-  <!--
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
       Only files inside the `public` folder can be referenced from the HTML.
@@ -77,14 +113,14 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-  <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-  <title>Tezex</title>
-</head>
+    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <title>Tezex</title>
+  </head>
 
-<body>
-  <noscript>You need to enable JavaScript to run this app.</noscript>
-  <div id="root"></div>
-  <!--
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+    <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.
 
@@ -94,6 +130,5 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-</body>
-
+  </body>
 </html>

--- a/V2/tezex/src/components/menu/index.tsx
+++ b/V2/tezex/src/components/menu/index.tsx
@@ -152,8 +152,8 @@ export const Menu: FC = () => {
 
   const liquidityHref: () => string = useCallback(() => {
     if (sessionInfo.activeComponent === TransactingComponent.REMOVE_LIQUIDITY) {
-      return "/home/remove";
-    } else return "/home/add";
+      return "/liquidity/remove";
+    } else return "/liquidity";
   }, [sessionInfo]);
 
   return (
@@ -163,7 +163,7 @@ export const Menu: FC = () => {
       onChange={handleChange}
       aria-label="nav-home-tabs"
     >
-      <MenuItem label="Swap" href="/home/swap" />
+      <MenuItem label="Swap" href="/" />
       <MenuItem label="Liquidity" href={liquidityHref()} />
     </Tabs>
   );

--- a/V2/tezex/src/components/nav/NavApp.tsx
+++ b/V2/tezex/src/components/nav/NavApp.tsx
@@ -8,6 +8,7 @@ import useStyles from "../../hooks/styles";
 
 import { useSession } from "../../hooks/session";
 import Box from "@mui/material/Box";
+import { homePathForHost } from "../../routing";
 
 interface NavTabProps {
   label: string;
@@ -59,6 +60,7 @@ export const NavApp: FC<INavApp> = (props) => {
     : 0;
 
   const aboutRedirectUrl = useSession().appConfig.aboutRedirectUrl;
+  const homePath = homePathForHost(window.location.hostname);
 
   return (
     <Tabs
@@ -69,7 +71,7 @@ export const NavApp: FC<INavApp> = (props) => {
         style: { display: "none" },
       }}
     >
-      <NavTab label="Home" href="/home/swap" />
+      <NavTab label="Home" href={homePath} />
       <NavTab label="Analytics" href="/analytics" />
       <NavTab label="sTEZ" href="/stez" />
       <NavTabExternal label="About" href={aboutRedirectUrl} />

--- a/V2/tezex/src/components/nav/NavHome.tsx
+++ b/V2/tezex/src/components/nav/NavHome.tsx
@@ -62,8 +62,8 @@ export const NavHome: FC<INavHome> = (props) => {
 
   const liquidityHref: () => string = useCallback(() => {
     if (sessionInfo.activeComponent === TransactingComponent.REMOVE_LIQUIDITY) {
-      return "/home/remove";
-    } else return "/home/add";
+      return "/liquidity/remove";
+    } else return "/liquidity";
   }, [sessionInfo]);
 
   return (
@@ -76,7 +76,7 @@ export const NavHome: FC<INavHome> = (props) => {
     >
       <NavTab
         label="Swap"
-        href="/home/swap"
+        href="/"
         scalingKey={props.scalingKey}
         onNavigate={props.onNavigate}
         disabled={props.isTransitioning}

--- a/V2/tezex/src/components/nav/NavLiquidity.tsx
+++ b/V2/tezex/src/components/nav/NavLiquidity.tsx
@@ -80,8 +80,8 @@ export const NavLiquidity: FC<INavLiquidty> = (props) => {
         ),
       }}
     >
-      <NavTab label="Add Liquidity" href="/home/add" />
-      <NavTab label="Remove Liquidity" href="/home/remove" />
+      <NavTab label="Add Liquidity" href="/liquidity" />
+      <NavTab label="Remove Liquidity" href="/liquidity/remove" />
     </Tabs>
   );
 };

--- a/V2/tezex/src/components/ui/views/footer/index.test.tsx
+++ b/V2/tezex/src/components/ui/views/footer/index.test.tsx
@@ -22,15 +22,15 @@ test("renders the site footer with working product and resource links", () => {
   expect(screen.getByRole("contentinfo")).toBeInTheDocument();
   expect(screen.getByRole("link", { name: "TEZEX home" })).toHaveAttribute(
     "href",
-    "/home/swap"
+    "/"
   );
   expect(screen.getByRole("link", { name: "Swap" })).toHaveAttribute(
     "href",
-    "/home/swap"
+    "/"
   );
   expect(screen.getByRole("link", { name: "Liquidity" })).toHaveAttribute(
     "href",
-    "/home/add"
+    "/liquidity"
   );
   expect(screen.getByRole("link", { name: "Analytics" })).toHaveAttribute(
     "href",

--- a/V2/tezex/src/components/ui/views/footer/index.tsx
+++ b/V2/tezex/src/components/ui/views/footer/index.tsx
@@ -6,6 +6,7 @@ import tezosLogoBlack from "../../../../assets/TezosLogo_Horizontal_Black.svg";
 import tezosLogoWhite from "../../../../assets/TezosLogo_Horizontal_White.svg";
 import { useSession } from "../../../../hooks/session";
 import "./style.css";
+import { homePathForHost } from "../../../../routing";
 
 const GITHUB_URL = "https://github.com/StableTechnologies/TEZEX";
 const X_URL = "https://x.com/TezosExchange";
@@ -44,6 +45,7 @@ const ExternalLink = ({
 
 export function Footer() {
   const { appConfig } = useSession();
+  const homePath = homePathForHost(window.location.hostname);
 
   return (
     <footer className="tezex-footer">
@@ -51,7 +53,7 @@ export function Footer() {
         <div className="tezex-footer__top">
           <section className="tezex-footer__brand" aria-label="About TEZEX">
             <Link
-              to="/home/swap"
+              to={homePath}
               className="tezex-footer__home"
               aria-label="TEZEX home"
             >
@@ -93,10 +95,10 @@ export function Footer() {
             <h2>Product</h2>
             <ul>
               <li>
-                <Link to="/home/swap">Swap</Link>
+                <Link to={homePath}>Swap</Link>
               </li>
               <li>
-                <Link to="/home/add">Liquidity</Link>
+                <Link to="/liquidity">Liquidity</Link>
               </li>
               <li>
                 <Link to="/analytics">Analytics</Link>

--- a/V2/tezex/src/components/ui/views/header/index.test.tsx
+++ b/V2/tezex/src/components/ui/views/header/index.test.tsx
@@ -47,7 +47,7 @@ const CurrentLocation = () => {
 test("the TEZEX logo navigates to the swap home route", () => {
   render(
     <MemoryRouter
-      initialEntries={["/home/add"]}
+      initialEntries={["/liquidity"]}
       future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
     >
       <Routes>
@@ -66,5 +66,5 @@ test("the TEZEX logo navigates to the swap home route", () => {
 
   fireEvent.click(screen.getByRole("link", { name: "TEZEX home" }));
 
-  expect(screen.getByTestId("location")).toHaveTextContent("/home/swap");
+  expect(screen.getByTestId("location")).toHaveTextContent("/");
 });

--- a/V2/tezex/src/components/ui/views/header/index.tsx
+++ b/V2/tezex/src/components/ui/views/header/index.tsx
@@ -17,6 +17,7 @@ import style from "./style";
 import useStyles from "../../../../hooks/styles";
 import { NetworkSelector } from "../../elements/selectors/networkSelector/NetworkSelector";
 import { useColorMode } from "../../../../contexts/color-mode";
+import { homePathForHost } from "../../../../routing";
 
 export interface IHeader {
   openMenu: boolean;
@@ -27,6 +28,7 @@ export const Header: FC<IHeader> = (props) => {
   const styles = useStyles(style, scalingKey);
   const { mode, toggleMode } = useColorMode();
   const isLight = mode === "light";
+  const homePath = homePathForHost(window.location.hostname);
 
   return (
     <AppBar
@@ -42,7 +44,7 @@ export const Header: FC<IHeader> = (props) => {
           <Box sx={styles.container}>
             <Box
               component={Link}
-              to="/home/swap"
+              to={homePath}
               aria-label="TEZEX home"
               onMouseDown={(event) => event.preventDefault()}
               sx={styles.logoLink}

--- a/V2/tezex/src/components/ui/views/layout/index.tsx
+++ b/V2/tezex/src/components/ui/views/layout/index.tsx
@@ -28,7 +28,8 @@ export const Layout: FC<ILayout> = (props) => {
   const location = useLocation();
   const isStezRoute = location.pathname.startsWith("/stez");
   const isTzktDataRoute =
-    location.pathname.startsWith("/home") ||
+    location.pathname === "/" ||
+    location.pathname.startsWith("/liquidity") ||
     location.pathname.startsWith("/analytics");
   const [openMenu, setOpenMenu] = useState(false);
   const toggleMenu = useCallback(() => {

--- a/V2/tezex/src/components/ui/views/sidebar/index.tsx
+++ b/V2/tezex/src/components/ui/views/sidebar/index.tsx
@@ -24,6 +24,7 @@ import MenuOutlinedIcon from "@mui/icons-material/MenuOutlined";
 import logo from "../../../../assets/TezexLogo.svg";
 import logoSmall from "../../../../assets/tezexIcon.svg";
 import { Wallet as WalletControl } from "../../../wallet";
+import { homePathForHost } from "../../../../routing";
 
 export interface ISideBarProps {
   openMenu: boolean;
@@ -38,6 +39,7 @@ export const SideBar: FC<ISideBarProps> = (props) => {
   const location = useLocation();
   const styles = useStyles(style);
   const { isLandscape } = useMobileOrientation();
+  const homePath = homePathForHost(window.location.hostname);
 
   useEffect(() => {
     switch (sessionInfo.activeComponent) {
@@ -124,7 +126,7 @@ export const SideBar: FC<ISideBarProps> = (props) => {
                 <ListItem disablePadding sx={styles.listItem}>
                   <ListItemButton
                     component={Link}
-                    to="/home/swap"
+                    to={homePath}
                     onClick={props.toggleMenu}
                     selected={active === 0}
                     sx={styles.swapButton}
@@ -153,7 +155,7 @@ export const SideBar: FC<ISideBarProps> = (props) => {
                     <ListItem disablePadding sx={styles.listItem}>
                       <ListItemButton
                         component={Link}
-                        to="/home/add"
+                        to="/liquidity"
                         onClick={props.toggleMenu}
                         selected={active === 1}
                         sx={styles.nestedButton}
@@ -165,7 +167,7 @@ export const SideBar: FC<ISideBarProps> = (props) => {
                     <ListItem disablePadding sx={styles.listItem}>
                       <ListItemButton
                         component={Link}
-                        to="/home/remove"
+                        to="/liquidity/remove"
                         onClick={props.toggleMenu}
                         selected={active === 2}
                         sx={styles.nestedButton}

--- a/V2/tezex/src/index.tsx
+++ b/V2/tezex/src/index.tsx
@@ -7,7 +7,7 @@ import reportWebVitals from "./reportWebVitals";
 import { SessionProvider } from "./contexts/session";
 import ReactDOM from "react-dom/client";
 import {
-  createHashRouter,
+  createBrowserRouter,
   createMemoryRouter,
   Navigate,
   RouterProvider,
@@ -24,6 +24,7 @@ import { ColorModeProvider } from "./contexts/color-mode";
 import {
   canonicalTezexUrl,
   isStezOnlyHost,
+  routeFromLegacyHash,
   stezRouteFromHash,
 } from "./routing";
 
@@ -42,19 +43,31 @@ const CanonicalTezexRedirect = () => {
 const standardRoutes = [
   {
     index: true,
-    element: <Navigate to="/home/swap" replace />,
-  },
-  {
-    path: "home/swap",
     element: <Home path="swap" />,
   },
   {
-    path: "home/add",
+    path: "liquidity",
     element: <Home path="add" />,
   },
   {
-    path: "home/remove",
+    path: "liquidity/remove",
     element: <Home path="remove" />,
+  },
+  {
+    path: "home/swap",
+    element: <Navigate to="/" replace />,
+  },
+  {
+    path: "home/add",
+    element: <Navigate to="/liquidity" replace />,
+  },
+  {
+    path: "home/remove",
+    element: <Navigate to="/liquidity/remove" replace />,
+  },
+  {
+    path: "swap",
+    element: <Navigate to="/" replace />,
   },
   {
     path: "analytics",
@@ -90,6 +103,14 @@ const stezOnlyRoutes = [
     element: <CanonicalTezexRedirect />,
   },
   {
+    path: "swap",
+    element: <CanonicalTezexRedirect />,
+  },
+  {
+    path: "liquidity/*",
+    element: <CanonicalTezexRedirect />,
+  },
+  {
     path: "analytics",
     element: <CanonicalTezexRedirect />,
   },
@@ -102,6 +123,13 @@ const stezOnlyRoutes = [
 const stezOnlyHost = isStezOnlyHost(window.location.hostname);
 const stezInitialRoute = stezRouteFromHash(window.location.hash);
 
+if (!stezOnlyHost) {
+  const legacyRoute = routeFromLegacyHash(window.location.hash);
+  if (legacyRoute) {
+    window.history.replaceState(window.history.state, "", legacyRoute);
+  }
+}
+
 if (stezOnlyHost && window.location.href !== `${window.location.origin}/`) {
   window.history.replaceState(window.history.state, "", "/");
 }
@@ -110,7 +138,7 @@ const router = stezOnlyHost
   ? createMemoryRouter(stezOnlyRoutes, {
       initialEntries: [stezInitialRoute],
     })
-  : createHashRouter([
+  : createBrowserRouter([
       {
         path: "/",
         element: <App />,

--- a/V2/tezex/src/pages/Home/index.test.tsx
+++ b/V2/tezex/src/pages/Home/index.test.tsx
@@ -6,13 +6,7 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
-import {
-  MemoryRouter,
-  Route,
-  Routes,
-  useLocation,
-  useParams,
-} from "react-router-dom";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import { Home } from ".";
 import { NetworkType } from "@airgap/beacon-sdk";
 
@@ -46,14 +40,14 @@ jest.mock("../../components/nav", () => ({
     <nav>
       <button
         type="button"
-        onClick={() => onNavigate("/home/swap")}
+        onClick={() => onNavigate("/")}
         disabled={isTransitioning}
       >
         Swap
       </button>
       <button
         type="button"
-        onClick={() => onNavigate("/home/add")}
+        onClick={() => onNavigate("/liquidity")}
         disabled={isTransitioning}
       >
         Liquidity
@@ -88,8 +82,13 @@ jest.mock("react-device-detect", () => ({
 }));
 
 const RoutedHome = () => {
-  const { mode = "swap" } = useParams();
-  const path = mode === "remove" ? "remove" : mode === "add" ? "add" : "swap";
+  const location = useLocation();
+  const path =
+    location.pathname === "/liquidity/remove"
+      ? "remove"
+      : location.pathname === "/liquidity"
+      ? "add"
+      : "swap";
   return <Home path={path} />;
 };
 
@@ -101,12 +100,12 @@ const Location = () => {
 const renderHome = () =>
   render(
     <MemoryRouter
-      initialEntries={["/home/swap"]}
+      initialEntries={["/"]}
       future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
     >
       <Routes>
         <Route
-          path="/home/:mode"
+          path="*"
           element={
             <>
               <RoutedHome />
@@ -141,7 +140,7 @@ test("changes modes immediately when browser animation is unavailable", () => {
 
   fireEvent.click(screen.getByRole("button", { name: "Liquidity" }));
 
-  expect(screen.getByTestId("location")).toHaveTextContent("/home/add");
+  expect(screen.getByTestId("location")).toHaveTextContent("/liquidity");
   expect(screen.getByText("Liquidity workspace")).toBeInTheDocument();
 });
 
@@ -234,7 +233,7 @@ test("moves outgoing and incoming workspaces on one continuous track", async () 
   renderHome();
   fireEvent.click(screen.getByRole("button", { name: "Liquidity" }));
 
-  expect(screen.getByTestId("location")).toHaveTextContent("/home/swap");
+  expect(screen.getByTestId("location")).toHaveTextContent("/");
   expect(screen.getByText("Liquidity workspace")).toBeInTheDocument();
   expect(
     document.querySelector('[data-workspace-snapshot="true"]')
@@ -277,7 +276,7 @@ test("moves outgoing and incoming workspaces on one continuous track", async () 
   await waitFor(() =>
     expect(document.documentElement.dataset.modeTransition).toBeUndefined()
   );
-  expect(screen.getByTestId("location")).toHaveTextContent("/home/add");
+  expect(screen.getByTestId("location")).toHaveTextContent("/liquidity");
   expect(
     document.querySelector('[data-workspace-snapshot="true"]')
   ).not.toBeInTheDocument();

--- a/V2/tezex/src/pages/Home/index.tsx
+++ b/V2/tezex/src/pages/Home/index.tsx
@@ -39,6 +39,16 @@ const prefersReducedMotion = () =>
 
 const isLiquidityRoute = (path: HomePaths | string) => path !== "swap";
 
+const homePathFromHref = (href: string): HomePaths => {
+  const pathname = href.split(/[?#]/, 1)[0].replace(/\/$/, "");
+
+  if (pathname === "/liquidity/remove" || pathname === "/home/remove") {
+    return "remove";
+  }
+  if (pathname === "/liquidity" || pathname === "/home/add") return "add";
+  return "swap";
+};
+
 const createWorkspaceSnapshot = (panel: HTMLDivElement) => {
   const snapshot = panel.cloneNode(true) as HTMLDivElement;
 
@@ -82,7 +92,7 @@ export const Home: FC<IHome> = (props) => {
 
   const navigateBetweenModes = useCallback(
     (href: string) => {
-      const targetPath = href.split("/").pop() ?? "swap";
+      const targetPath = homePathFromHref(href);
       const currentIsLiquidity = isLiquidityRoute(displayedPath);
       const targetIsLiquidity = isLiquidityRoute(targetPath);
 

--- a/V2/tezex/src/pages/NotFound/index.test.tsx
+++ b/V2/tezex/src/pages/NotFound/index.test.tsx
@@ -18,7 +18,7 @@ describe("NotFound", () => {
     expect(screen.getByText("/missing-page")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "BACK TO SWAP" })).toHaveAttribute(
       "href",
-      "/home/swap"
+      "/"
     );
     expect(
       screen.getByRole("img", {

--- a/V2/tezex/src/pages/NotFound/index.tsx
+++ b/V2/tezex/src/pages/NotFound/index.tsx
@@ -137,7 +137,7 @@ export const NotFound: FC = () => {
         </div>
 
         <div className="not-found__actions">
-          <Link className="not-found__button is-primary" to="/home/swap">
+          <Link className="not-found__button is-primary" to="/">
             BACK TO SWAP
           </Link>
           <Link className="not-found__button is-secondary" to="/analytics">

--- a/V2/tezex/src/routing.test.ts
+++ b/V2/tezex/src/routing.test.ts
@@ -1,6 +1,9 @@
 import {
   canonicalTezexUrl,
+  canonicalPath,
+  homePathForHost,
   isStezOnlyHost,
+  routeFromLegacyHash,
   STEZ_HOSTNAME,
   stezRouteFromHash,
 } from "./routing";
@@ -13,13 +16,34 @@ describe("hostname-specific routing", () => {
     expect(isStezOnlyHost("stez.tezex.io.example.com")).toBe(false);
   });
 
+  it("uses a redirect route when leaving the dedicated sTEZ hostname", () => {
+    expect(homePathForHost(STEZ_HOSTNAME)).toBe("/swap");
+    expect(homePathForHost("tezex.io")).toBe("/");
+  });
+
   it("moves non-sTEZ routes to the canonical TEZEX origin", () => {
-    expect(canonicalTezexUrl("/home/swap")).toBe(
-      "https://tezex.io/#/home/swap"
-    );
+    expect(canonicalTezexUrl("/home/swap")).toBe("https://tezex.io/");
     expect(canonicalTezexUrl("/analytics", "?range=30d")).toBe(
-      "https://tezex.io/#/analytics?range=30d"
+      "https://tezex.io/analytics?range=30d"
     );
+  });
+
+  it("maps legacy application routes to clean canonical paths", () => {
+    expect(canonicalPath("/home/swap")).toBe("/");
+    expect(canonicalPath("/home/add")).toBe("/liquidity");
+    expect(canonicalPath("/home/remove")).toBe("/liquidity/remove");
+    expect(canonicalPath("/analytics")).toBe("/analytics");
+  });
+
+  it("converts old hash URLs without dropping their query string", () => {
+    expect(routeFromLegacyHash("#/home/swap")).toBe("/");
+    expect(routeFromLegacyHash("#/home/add?pool=sirius")).toBe(
+      "/liquidity?pool=sirius"
+    );
+    expect(routeFromLegacyHash("#/analytics?range=30d")).toBe(
+      "/analytics?range=30d"
+    );
+    expect(routeFromLegacyHash("#section")).toBeNull();
   });
 
   it("maps the clean sTEZ URL to its internal page without exposing a hash", () => {

--- a/V2/tezex/src/routing.ts
+++ b/V2/tezex/src/routing.ts
@@ -4,8 +4,37 @@ export const CANONICAL_TEZEX_ORIGIN = "https://tezex.io";
 export const isStezOnlyHost = (hostname: string) =>
   hostname.trim().toLowerCase() === STEZ_HOSTNAME;
 
+export const homePathForHost = (hostname: string) =>
+  isStezOnlyHost(hostname) ? "/swap" : "/";
+
+export const canonicalPath = (pathname: string) => {
+  switch (pathname) {
+    case "/home/swap":
+    case "/swap":
+      return "/";
+    case "/home/add":
+      return "/liquidity";
+    case "/home/remove":
+      return "/liquidity/remove";
+    default:
+      return pathname || "/";
+  }
+};
+
 export const canonicalTezexUrl = (pathname: string, search = "") =>
-  `${CANONICAL_TEZEX_ORIGIN}/#${pathname}${search}`;
+  `${CANONICAL_TEZEX_ORIGIN}${canonicalPath(pathname)}${search}`;
+
+export const routeFromLegacyHash = (hash: string) => {
+  const route = hash.replace(/^#/, "");
+
+  if (!route || !route.startsWith("/")) return null;
+
+  const queryIndex = route.indexOf("?");
+  const pathname = queryIndex === -1 ? route : route.slice(0, queryIndex);
+  const search = queryIndex === -1 ? "" : route.slice(queryIndex);
+
+  return `${canonicalPath(pathname)}${search}`;
+};
 
 export const stezRouteFromHash = (hash: string) => {
   const route = hash.replace(/^#/, "");

--- a/V2/tezex/src/types/general.ts
+++ b/V2/tezex/src/types/general.ts
@@ -23,10 +23,10 @@ export interface AppConfig {
 }
 
 export enum Pages {
-  HOME = "/home/swap",
-  SWAP = "/home/swap",
-  ADD_LIQUIDITY = "/home/add",
-  REMOVE_LIQUIDITY = "/home/remove",
+  HOME = "/",
+  SWAP = "/",
+  ADD_LIQUIDITY = "/liquidity",
+  REMOVE_LIQUIDITY = "/liquidity/remove",
   ANALYTICS = "/analytics",
   ABOUT = "/about",
 }


### PR DESCRIPTION
## What changed
- replace hash-based routing with clean browser paths
- use `/` for Swap, `/liquidity` and `/liquidity/remove` for liquidity, plus `/analytics` and `/stez`
- migrate existing `/#/...` links automatically without dropping query parameters
- preserve direct-link and refresh support on GitHub Pages
- keep `stez.tezex.io` dedicated to its single clean root URL

## Verification
- production dependency audit at the configured high-severity threshold
- TypeScript typecheck
- 23 test suites / 72 tests
- production build
- browser verification of direct routes, tab navigation, and legacy URL migration
