### PR TITLE
Advance analytics charts and pool scope

### DIFF
--- a/V2/tezex/src/pages/Analytics/api.test.ts
+++ b/V2/tezex/src/pages/Analytics/api.test.ts
@@ -1,7 +1,9 @@
 import { Token } from "../../types/general";
 import { PoolConfig, PoolType } from "../../types/pools";
+import { ANALYTICS_HISTORY, ANALYTICS_HISTORY_CUTOFF } from "./history";
 import {
   ANALYTICS_RANGES,
+  buildAllTimeSwapSeries,
   buildSwapSeries,
   calculateRemoveLiquidityValueXtz,
   calculateSwapVolumeXtz,
@@ -34,6 +36,20 @@ const transaction = (overrides: Partial<TzktTransaction>): TzktTransaction => ({
 });
 
 describe("analytics calculations", () => {
+  it("keeps the verified historical archive complete through its cutoff", () => {
+    const sumFor = (poolId: string) =>
+      ANALYTICS_HISTORY.filter((point) => point.poolId === poolId).reduce(
+        (sum, point) => sum + point.volumeXtz,
+        0
+      );
+
+    expect(ANALYTICS_HISTORY_CUTOFF).toBe(
+      new Date("2026-08-01T00:00:00Z").getTime()
+    );
+    expect(sumFor("xtz-tzbtc-sirius")).toBeCloseTo(341167267.387464, 5);
+    expect(sumFor("xtz-usdtz-tezex")).toBeCloseTo(29.156105, 5);
+  });
+
   it("uses the transferred tez amount for XTZ-to-token swaps", () => {
     const volume = calculateSwapVolumeXtz(
       transaction({
@@ -102,6 +118,41 @@ describe("analytics calculations", () => {
       expect(series.Volume).toHaveLength(RANGE_CONFIG[range].bucketCount);
       expect(series.Fees).toHaveLength(RANGE_CONFIG[range].bucketCount);
     });
+  });
+
+  it("merges archived and live swaps into a complete all-time series", () => {
+    const now = new Date("2026-08-15T00:00:00Z").getTime();
+    const series = buildAllTimeSwapSeries(
+      [
+        transaction({
+          amount: 4_000_000,
+          timestamp: "2026-08-02T12:00:00Z",
+          parameter: { entrypoint: "xtzToToken" },
+        }),
+      ],
+      [siriusPool],
+      now,
+      new Map([[siriusPool.id, 0.001]]),
+      new Date("2021-08-06T09:29:54Z").getTime(),
+      [
+        {
+          month: "2021-08-01",
+          poolId: siriusPool.id,
+          volumeXtz: 12,
+        },
+        {
+          month: "2021-08-01",
+          poolId: "another-pool",
+          volumeXtz: 100,
+        },
+      ]
+    );
+
+    expect(series.Volume).toHaveLength(61);
+    expect(series.Volume.reduce((sum, point) => sum + point.value, 0)).toBe(16);
+    expect(series.Fees.reduce((sum, point) => sum + point.value, 0)).toBe(
+      0.016
+    );
   });
 
   it("does not invent a flat balance before a pool's first on-chain sample", () => {

--- a/V2/tezex/src/pages/Analytics/api.test.ts
+++ b/V2/tezex/src/pages/Analytics/api.test.ts
@@ -9,6 +9,7 @@ import {
   formatDenominatedXtz,
   RANGE_CONFIG,
   TzktTransaction,
+  valueAt,
 } from "./api";
 
 const siriusPool: PoolConfig = {
@@ -101,6 +102,26 @@ describe("analytics calculations", () => {
       expect(series.Volume).toHaveLength(RANGE_CONFIG[range].bucketCount);
       expect(series.Fees).toHaveLength(RANGE_CONFIG[range].bucketCount);
     });
+  });
+
+  it("does not invent a flat balance before a pool's first on-chain sample", () => {
+    const history = [
+      {
+        timestamp: "2021-08-06T09:29:54Z",
+        balance: 100,
+      },
+      {
+        timestamp: "2021-08-07T09:29:54Z",
+        balance: 2_500_100,
+      },
+    ];
+
+    expect(valueAt(history, new Date("2020-08-06T09:29:54Z").getTime())).toBe(
+      0
+    );
+    expect(valueAt(history, new Date("2021-08-06T12:00:00Z").getTime())).toBe(
+      100
+    );
   });
 
   it("derives removed liquidity value from the post-operation pool state", () => {

--- a/V2/tezex/src/pages/Analytics/api.ts
+++ b/V2/tezex/src/pages/Analytics/api.ts
@@ -1,6 +1,11 @@
 import { NetworkInfo } from "../../contexts/network";
 import { Asset, Token } from "../../types/general";
 import { PoolConfig, PoolType } from "../../types/pools";
+import {
+  ANALYTICS_HISTORY,
+  ANALYTICS_HISTORY_CUTOFF,
+  AnalyticsHistoryPoint,
+} from "./history";
 
 export type AnalyticsRange = "24H" | "7D" | "30D" | "90D" | "6M" | "1Y" | "MAX";
 export type AnalyticsMetric = "Volume" | "TVL" | "Fees";
@@ -355,6 +360,59 @@ export const buildSwapSeries = (
   return { Volume: volume, Fees: fees };
 };
 
+const utcMonthStart = (timestamp: number) => {
+  const date = new Date(timestamp);
+  return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1);
+};
+
+export const buildAllTimeSwapSeries = (
+  transactions: TzktTransaction[],
+  pools: PoolConfig[],
+  now: number,
+  feeRates: Map<string, number>,
+  requestedStart: number,
+  history: AnalyticsHistoryPoint[] = ANALYTICS_HISTORY
+) => {
+  const firstMonth = utcMonthStart(requestedStart);
+  const lastMonth = utcMonthStart(now);
+  const months: number[] = [];
+  for (let month = firstMonth; month <= lastMonth; ) {
+    months.push(month);
+    const cursor = new Date(month);
+    month = Date.UTC(cursor.getUTCFullYear(), cursor.getUTCMonth() + 1, 1);
+  }
+
+  const poolIds = new Set(pools.map((pool) => pool.id));
+  const poolByAddress = new Map(pools.map((pool) => [pool.address, pool]));
+  const indexByMonth = new Map(
+    months.map((timestamp, index) => [timestamp, index])
+  );
+  const volume = months.map((timestamp) => ({ timestamp, value: 0 }));
+  const fees = months.map((timestamp) => ({ timestamp, value: 0 }));
+
+  history.forEach((point) => {
+    if (!poolIds.has(point.poolId)) return;
+    const index = indexByMonth.get(Date.parse(`${point.month}T00:00:00Z`));
+    if (index === undefined) return;
+    volume[index].value += point.volumeXtz;
+    fees[index].value += point.volumeXtz * (feeRates.get(point.poolId) ?? 0);
+  });
+
+  transactions.forEach((transaction) => {
+    const pool = poolByAddress.get(transaction.target.address);
+    if (!pool) return;
+    const timestamp = new Date(transaction.timestamp).getTime();
+    if (timestamp < ANALYTICS_HISTORY_CUTOFF || timestamp > now) return;
+    const index = indexByMonth.get(utcMonthStart(timestamp));
+    if (index === undefined) return;
+    const transactionVolume = calculateSwapVolumeXtz(transaction, pool);
+    volume[index].value += transactionVolume;
+    fees[index].value += transactionVolume * (feeRates.get(pool.id) ?? 0);
+  });
+
+  return { Volume: volume, Fees: fees };
+};
+
 export const valueAt = (
   history: Pick<TzktBalancePoint, "timestamp" | "balance">[],
   timestamp: number
@@ -575,7 +633,10 @@ export const loadAnalytics = async (
   };
   const preliminaryHead = await headPromise;
   const now = new Date(preliminaryHead.timestamp).getTime();
-  const requestedSince = now - RANGE_CONFIG["1Y"].windowMs;
+  const requestedSince = Math.min(
+    now - RANGE_CONFIG["1Y"].windowMs,
+    ANALYTICS_HISTORY_CUTOFF
+  );
   const swapsPromise = async () => {
     const xtzToToken = await fetchTransactionHistory(
       addresses,
@@ -686,7 +747,13 @@ export const loadAnalytics = async (
         const requestedStart = range === "MAX" ? maximumStart : undefined;
         const series =
           range === "MAX"
-            ? { Volume: [], Fees: [] }
+            ? buildAllTimeSwapSeries(
+                swaps,
+                scopePools,
+                now,
+                feeRates,
+                maximumStart
+              )
             : buildSwapSeries(
                 swaps,
                 scopePools,

--- a/V2/tezex/src/pages/Analytics/api.ts
+++ b/V2/tezex/src/pages/Analytics/api.ts
@@ -2,7 +2,7 @@ import { NetworkInfo } from "../../contexts/network";
 import { Asset, Token } from "../../types/general";
 import { PoolConfig, PoolType } from "../../types/pools";
 
-export type AnalyticsRange = "24H" | "7D" | "30D" | "90D" | "6M" | "1Y";
+export type AnalyticsRange = "24H" | "7D" | "30D" | "90D" | "6M" | "1Y" | "MAX";
 export type AnalyticsMetric = "Volume" | "TVL" | "Fees";
 export type AnalyticsCurrency = "XTZ" | "BTC" | "USD";
 
@@ -13,6 +13,7 @@ export const ANALYTICS_RANGES: AnalyticsRange[] = [
   "90D",
   "6M",
   "1Y",
+  "MAX",
 ];
 
 export interface AnalyticsQuote {
@@ -66,9 +67,15 @@ export interface AnalyticsActivity {
 
 export interface AnalyticsModel {
   summary: AnalyticsSummary;
+  summaryByPool: Record<string, AnalyticsSummary>;
   chart: Record<AnalyticsRange, Record<AnalyticsMetric, AnalyticsPoint[]>>;
+  chartByPool: Record<
+    string,
+    Record<AnalyticsRange, Record<AnalyticsMetric, AnalyticsPoint[]>>
+  >;
   pools: AnalyticsPool[];
   activity: AnalyticsActivity[];
+  activityByPool: Record<string, AnalyticsActivity[]>;
   blockLevel: number;
   blockTimestamp: number;
   quote: AnalyticsQuote;
@@ -121,6 +128,7 @@ interface PoolSnapshot {
   balanceHistory: Record<AnalyticsRange, TzktBalancePoint[]>;
   feeRate: number;
   currentTvlXtz: number;
+  firstBalance: TzktBalancePoint;
 }
 
 interface RangeConfig {
@@ -146,14 +154,14 @@ export const RANGE_CONFIG: Record<AnalyticsRange, RangeConfig> = {
   "90D": { windowMs: 90 * DAY, bucketCount: 30, balanceStep: 43_200 },
   "6M": { windowMs: 180 * DAY, bucketCount: 26, balanceStep: 57_600 },
   "1Y": { windowMs: 365 * DAY, bucketCount: 52, balanceStep: 57_600 },
+  MAX: { windowMs: 0, bucketCount: 60, balanceStep: 14_400 },
 };
 
-const BALANCE_HISTORY_RANGES: AnalyticsRange[] = ["24H", "30D", "1Y"];
+const BALANCE_HISTORY_RANGES: AnalyticsRange[] = ["24H", "MAX"];
 
 const balanceHistoryRangeFor = (range: AnalyticsRange): AnalyticsRange => {
   if (range === "24H") return "24H";
-  if (range === "7D" || range === "30D") return "30D";
-  return "1Y";
+  return "MAX";
 };
 
 const toNumber = (value: unknown): number => {
@@ -293,10 +301,17 @@ const formatAssetAmount = (raw: number, asset: Asset) => {
 const shortAddress = (address: string) =>
   address.length > 12 ? `${address.slice(0, 6)}…${address.slice(-4)}` : address;
 
-const buildBuckets = (range: AnalyticsRange, now: number) => {
+const buildBuckets = (
+  range: AnalyticsRange,
+  now: number,
+  requestedStart?: number
+) => {
   const config = RANGE_CONFIG[range];
-  const start = now - config.windowMs;
-  const width = config.windowMs / config.bucketCount;
+  const start =
+    range === "MAX" && requestedStart !== undefined
+      ? requestedStart
+      : now - (config.windowMs || DAY);
+  const width = Math.max(1, now - start) / config.bucketCount;
   return Array.from({ length: config.bucketCount }, (_, index) => ({
     start: start + index * width,
     end: start + (index + 1) * width,
@@ -309,9 +324,10 @@ export const buildSwapSeries = (
   pools: PoolConfig[],
   range: AnalyticsRange,
   now: number,
-  feeRates: Map<string, number>
+  feeRates: Map<string, number>,
+  requestedStart?: number
 ) => {
-  const buckets = buildBuckets(range, now);
+  const buckets = buildBuckets(range, now, requestedStart);
   const poolByAddress = new Map(pools.map((pool) => [pool.address, pool]));
   const volume = buckets.map((bucket) => ({
     timestamp: bucket.timestamp,
@@ -339,8 +355,13 @@ export const buildSwapSeries = (
   return { Volume: volume, Fees: fees };
 };
 
-const valueAt = (history: TzktBalancePoint[], timestamp: number) => {
-  let selected = history[0]?.balance ?? 0;
+export const valueAt = (
+  history: Pick<TzktBalancePoint, "timestamp" | "balance">[],
+  timestamp: number
+) => {
+  // A pool has no liquidity before its first on-chain balance. Starting from
+  // the first returned sample creates a false plateau before pool inception.
+  let selected = 0;
   for (const point of history) {
     if (new Date(point.timestamp).getTime() > timestamp) break;
     selected = point.balance;
@@ -351,11 +372,11 @@ const valueAt = (history: TzktBalancePoint[], timestamp: number) => {
 const buildTvlSeries = (
   snapshots: PoolSnapshot[],
   range: AnalyticsRange,
-  now: number
-) =>
-  buildBuckets(range, now).map((bucket) => ({
-    timestamp: bucket.timestamp,
-    value: snapshots.reduce((total, pool) => {
+  now: number,
+  requestedStart?: number
+) => {
+  const tvlAt = (timestamp: number) =>
+    snapshots.reduce((total, pool) => {
       if (
         pool.config.tokenA !== Token.XTZ &&
         pool.config.tokenB !== Token.XTZ
@@ -363,11 +384,18 @@ const buildTvlSeries = (
         return total;
       }
       return (
-        total +
-        (valueAt(pool.balanceHistory[range], bucket.end) * 2) / 1_000_000
+        total + (valueAt(pool.balanceHistory[range], timestamp) * 2) / 1_000_000
       );
-    }, 0),
+    }, 0);
+  const points = buildBuckets(range, now, requestedStart).map((bucket) => ({
+    timestamp: bucket.timestamp,
+    value: tvlAt(bucket.end),
   }));
+
+  return range === "MAX" && requestedStart !== undefined
+    ? [{ timestamp: requestedStart, value: tvlAt(requestedStart) }, ...points]
+    : points;
+};
 
 const fetchTransactions = (
   addresses: string[],
@@ -377,6 +405,7 @@ const fetchTransactions = (
     limit: number;
     sort: "asc" | "desc";
     select?: string;
+    offset?: number;
   },
   signal?: AbortSignal
 ) => {
@@ -390,6 +419,7 @@ const fetchTransactions = (
       options.select ??
       "id,timestamp,hash,counter,sender,target,amount,parameter,storage",
   };
+  if (options.offset) params.offset = options.offset;
   if (options.since) params["timestamp.ge"] = dateAt(options.since);
   return fetchJson<TzktTransaction[]>(
     `/operations/transactions?${query(params)}`,
@@ -397,20 +427,69 @@ const fetchTransactions = (
   );
 };
 
+const fetchTransactionHistory = async (
+  addresses: string[],
+  entrypoints: string[],
+  since: number,
+  select: string,
+  signal?: AbortSignal
+) => {
+  const pageSize = 10_000;
+  const transactions: TzktTransaction[] = [];
+
+  for (let offset = 0; ; offset += pageSize) {
+    const page = await fetchTransactions(
+      addresses,
+      entrypoints,
+      {
+        since,
+        limit: pageSize,
+        offset,
+        sort: "desc",
+        select,
+      },
+      signal
+    );
+    transactions.push(...page);
+    if (page.length < pageSize) break;
+  }
+
+  return transactions;
+};
+
 const fetchBalanceHistory = (
   pool: PoolConfig,
   range: AnalyticsRange,
+  headLevel: number,
   signal?: AbortSignal
 ) => {
   const config = RANGE_CONFIG[range];
+  const isMaximumRange = range === "MAX";
+  const limit = isMaximumRange ? 1_000 : config.bucketCount + 3;
+  const step = isMaximumRange
+    ? Math.max(config.balanceStep, Math.ceil(headLevel / (limit - 3)))
+    : config.balanceStep;
   return fetchJson<TzktBalancePoint[]>(
     `/accounts/${pool.address}/balance_history?${query({
-      step: config.balanceStep,
-      limit: config.bucketCount + 3,
+      step,
+      limit,
       "sort.desc": "level",
     })}`,
     signal
   );
+};
+
+const fetchFirstBalance = async (pool: PoolConfig, signal?: AbortSignal) => {
+  const points = await fetchJson<TzktBalancePoint[]>(
+    `/accounts/${pool.address}/balance_history?${query({
+      limit: 1,
+      "sort.asc": "level",
+    })}`,
+    signal
+  );
+  const point = points[0];
+  if (!point) throw new Error(`Missing balance history for ${pool.name}`);
+  return point;
 };
 
 const activityFromTransaction = (
@@ -482,49 +561,77 @@ export const loadAnalytics = async (
   const addresses = pools.map((pool) => pool.address);
   const headPromise = fetchJson<TzktHead>("/head", signal);
   const quotePromise = fetchJson<TzktQuote>("/quotes/last", signal);
-  const storagePromises = pools.map((pool) =>
-    fetchJson<Record<string, unknown>>(
-      `/contracts/${pool.address}/storage`,
-      signal
-    )
-  );
-  const preliminaryHead = await headPromise;
-  const now = new Date(preliminaryHead.timestamp).getTime();
-  const requestedSince = now - RANGE_CONFIG["1Y"].windowMs;
-  const balanceHistoriesPromise = async () => {
-    const histories: TzktBalancePoint[][][] = [];
-    for (const range of BALANCE_HISTORY_RANGES) {
-      histories.push(
-        await Promise.all(
-          pools.map((pool) => fetchBalanceHistory(pool, range, signal))
+  const storageDataPromise = async () => {
+    const storages: Record<string, unknown>[] = [];
+    for (const pool of pools) {
+      storages.push(
+        await fetchJson<Record<string, unknown>>(
+          `/contracts/${pool.address}/storage`,
+          signal
         )
       );
     }
-    return histories;
+    return storages;
+  };
+  const preliminaryHead = await headPromise;
+  const now = new Date(preliminaryHead.timestamp).getTime();
+  const requestedSince = now - RANGE_CONFIG["1Y"].windowMs;
+  const swapsPromise = async () => {
+    const xtzToToken = await fetchTransactionHistory(
+      addresses,
+      ["xtzToToken"],
+      requestedSince,
+      "id,timestamp,target,amount,parameter",
+      signal
+    );
+    const tokenToXtz = await fetchTransactionHistory(
+      addresses,
+      ["tokenToXtz"],
+      requestedSince,
+      "id,timestamp,target,amount,parameter,storage",
+      signal
+    );
+    return [...xtzToToken, ...tokenToXtz];
+  };
+  const balanceDataPromise = async () => {
+    const firstBalances: TzktBalancePoint[] = [];
+    for (const pool of pools) {
+      firstBalances.push(await fetchFirstBalance(pool, signal));
+    }
+    const histories: TzktBalancePoint[][][] = [];
+    for (const range of BALANCE_HISTORY_RANGES) {
+      const rangeHistories: TzktBalancePoint[][] = [];
+      for (const pool of pools) {
+        rangeHistories.push(
+          await fetchBalanceHistory(pool, range, preliminaryHead.level, signal)
+        );
+      }
+      histories.push(rangeHistories);
+    }
+    return { firstBalances, histories };
+  };
+  const recentTransactionsPromise = async () => {
+    const transactions: TzktTransaction[][] = [];
+    for (const pool of pools) {
+      transactions.push(
+        await fetchTransactions(
+          [pool.address],
+          ACTIVITY_ENTRYPOINTS,
+          { limit: 8, sort: "desc" },
+          signal
+        )
+      );
+    }
+    return transactions;
   };
 
-  const [quote, storages, balanceHistories, swaps, recentTransactions] =
+  const [quote, storages, balanceData, swaps, recentTransactionsByPool] =
     await Promise.all([
       quotePromise,
-      Promise.all(storagePromises),
-      balanceHistoriesPromise(),
-      fetchTransactions(
-        addresses,
-        SWAP_ENTRYPOINTS,
-        {
-          since: requestedSince,
-          limit: 10_000,
-          sort: "desc",
-          select: "id,timestamp,target,amount,parameter,storage",
-        },
-        signal
-      ),
-      fetchTransactions(
-        addresses,
-        ACTIVITY_ENTRYPOINTS,
-        { limit: 16, sort: "desc" },
-        signal
-      ),
+      storageDataPromise(),
+      balanceDataPromise(),
+      swapsPromise(),
+      recentTransactionsPromise(),
     ]);
 
   const snapshots: PoolSnapshot[] = pools.map((pool, index) => {
@@ -534,7 +641,8 @@ export const loadAnalytics = async (
       ANALYTICS_RANGES.map((range) => [
         range,
         [
-          ...balanceHistories[
+          balanceData.firstBalances[index],
+          ...balanceData.histories[
             BALANCE_HISTORY_RANGES.indexOf(balanceHistoryRangeFor(range))
           ][index],
         ]
@@ -557,6 +665,7 @@ export const loadAnalytics = async (
       balanceHistory: history,
       feeRate: poolFeeRate(pool, storage),
       currentTvlXtz: currentPoolTvlXtz(pool, storage),
+      firstBalance: balanceData.firstBalances[index],
     };
   });
 
@@ -564,19 +673,44 @@ export const loadAnalytics = async (
   const feeRates = new Map(
     snapshots.map((snapshot) => [snapshot.config.id, snapshot.feeRate])
   );
-  const chart = Object.fromEntries(
-    ANALYTICS_RANGES.map((range) => {
-      const series = buildSwapSeries(swaps, pools, range, now, feeRates);
-      return [
-        range,
-        {
-          Volume: series.Volume,
-          TVL: buildTvlSeries(snapshots, range, now),
-          Fees: series.Fees,
-        },
-      ];
-    })
-  ) as Record<AnalyticsRange, Record<AnalyticsMetric, AnalyticsPoint[]>>;
+  const buildChart = (scopeSnapshots: PoolSnapshot[]) => {
+    const scopePools = scopeSnapshots.map((snapshot) => snapshot.config);
+    const maximumStart = Math.min(
+      ...scopeSnapshots.map((snapshot) =>
+        new Date(snapshot.firstBalance.timestamp).getTime()
+      )
+    );
+
+    return Object.fromEntries(
+      ANALYTICS_RANGES.map((range) => {
+        const requestedStart = range === "MAX" ? maximumStart : undefined;
+        const series =
+          range === "MAX"
+            ? { Volume: [], Fees: [] }
+            : buildSwapSeries(
+                swaps,
+                scopePools,
+                range,
+                now,
+                feeRates,
+                requestedStart
+              );
+        return [
+          range,
+          {
+            Volume: series.Volume,
+            TVL: buildTvlSeries(scopeSnapshots, range, now, requestedStart),
+            Fees: series.Fees,
+          },
+        ];
+      })
+    ) as Record<AnalyticsRange, Record<AnalyticsMetric, AnalyticsPoint[]>>;
+  };
+
+  const chart = buildChart(snapshots);
+  const chartByPool = Object.fromEntries(
+    snapshots.map((snapshot) => [snapshot.config.id, buildChart([snapshot])])
+  );
   const currentStart = now - DAY;
   const previousStart = now - 2 * DAY;
   const currentSwaps = swaps.filter(
@@ -603,19 +737,49 @@ export const loadAnalytics = async (
       );
     }, 0);
 
-  const volume24hXtz = sumVolume(currentSwaps);
-  const previousVolume = sumVolume(previousSwaps);
-  const fees24hXtz = sumFees(currentSwaps);
-  const previousFees = sumFees(previousSwaps);
-  const tvlXtz = snapshots.reduce(
-    (total, snapshot) => total + snapshot.currentTvlXtz,
-    0
-  );
-  const previousTvl = snapshots.reduce(
-    (total, snapshot) =>
-      total +
-      (valueAt(snapshot.balanceHistory["24H"], currentStart) * 2) / 1_000_000,
-    0
+  const buildSummary = (scopeSnapshots: PoolSnapshot[]): AnalyticsSummary => {
+    const scopeAddresses = new Set(
+      scopeSnapshots.map((snapshot) => snapshot.config.address)
+    );
+    const scopeCurrentSwaps = currentSwaps.filter((transaction) =>
+      scopeAddresses.has(transaction.target.address)
+    );
+    const scopePreviousSwaps = previousSwaps.filter((transaction) =>
+      scopeAddresses.has(transaction.target.address)
+    );
+    const volume24hXtz = sumVolume(scopeCurrentSwaps);
+    const previousVolume = sumVolume(scopePreviousSwaps);
+    const fees24hXtz = sumFees(scopeCurrentSwaps);
+    const previousFees = sumFees(scopePreviousSwaps);
+    const tvlXtz = scopeSnapshots.reduce(
+      (total, snapshot) => total + snapshot.currentTvlXtz,
+      0
+    );
+    const previousTvl = scopeSnapshots.reduce(
+      (total, snapshot) =>
+        total +
+        (valueAt(snapshot.balanceHistory["24H"], currentStart) * 2) / 1_000_000,
+      0
+    );
+
+    return {
+      tvlXtz,
+      tvlDelta: percentageDelta(tvlXtz, previousTvl),
+      volume24hXtz,
+      volumeDelta: percentageDelta(volume24hXtz, previousVolume),
+      fees24hXtz,
+      feesDelta: percentageDelta(fees24hXtz, previousFees),
+      swaps24h: scopeCurrentSwaps.length,
+      swapsDelta: percentageDelta(
+        scopeCurrentSwaps.length,
+        scopePreviousSwaps.length
+      ),
+    };
+  };
+
+  const summary = buildSummary(snapshots);
+  const summaryByPool = Object.fromEntries(
+    snapshots.map((snapshot) => [snapshot.config.id, buildSummary([snapshot])])
   );
 
   const poolRows = snapshots.map((snapshot) => {
@@ -640,29 +804,32 @@ export const loadAnalytics = async (
     };
   });
 
-  const activity = recentTransactions
-    .map((transaction) => {
-      const pool = poolByAddress.get(transaction.target.address);
-      return pool ? activityFromTransaction(transaction, pool, assets) : null;
-    })
-    .filter((item): item is AnalyticsActivity => item !== null)
-    .sort((a, b) => b.timestamp - a.timestamp)
-    .slice(0, 8);
+  const buildActivity = (transactions: TzktTransaction[]) =>
+    transactions
+      .map((transaction) => {
+        const pool = poolByAddress.get(transaction.target.address);
+        return pool ? activityFromTransaction(transaction, pool, assets) : null;
+      })
+      .filter((item): item is AnalyticsActivity => item !== null)
+      .sort((a, b) => b.timestamp - a.timestamp)
+      .slice(0, 8);
+
+  const activity = buildActivity(recentTransactionsByPool.flat());
+  const activityByPool = Object.fromEntries(
+    pools.map((pool, index) => [
+      pool.id,
+      buildActivity(recentTransactionsByPool[index]),
+    ])
+  );
 
   return {
-    summary: {
-      tvlXtz,
-      tvlDelta: percentageDelta(tvlXtz, previousTvl),
-      volume24hXtz,
-      volumeDelta: percentageDelta(volume24hXtz, previousVolume),
-      fees24hXtz,
-      feesDelta: percentageDelta(fees24hXtz, previousFees),
-      swaps24h: currentSwaps.length,
-      swapsDelta: percentageDelta(currentSwaps.length, previousSwaps.length),
-    },
+    summary,
+    summaryByPool,
     chart,
+    chartByPool,
     pools: poolRows,
     activity,
+    activityByPool,
     blockLevel: preliminaryHead.level,
     blockTimestamp: now,
     quote: {

--- a/V2/tezex/src/pages/Analytics/history.ts
+++ b/V2/tezex/src/pages/Analytics/history.ts
@@ -1,0 +1,319 @@
+export interface AnalyticsHistoryPoint {
+  month: string;
+  poolId: string;
+  volumeXtz: number;
+}
+
+// 116,122 applied xtzToToken calls and 94,298 applied tokenToXtz calls from
+// TzKT, aggregated by UTC month. The archive is exclusive of the cutoff;
+// api.ts appends live swaps from the cutoff forward so the all-time chart stays
+// current without loading 210,420 historical operations in every browser.
+export const ANALYTICS_HISTORY_CUTOFF = Date.parse("2026-08-01T00:00:00Z");
+export const ANALYTICS_HISTORY_SOURCE =
+  "https://api.tzkt.io/v1/operations/transactions";
+
+export const ANALYTICS_HISTORY: AnalyticsHistoryPoint[] = [
+  {
+    month: "2021-08-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 3525531.763032419,
+  },
+  {
+    month: "2021-09-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 5893461.442612408,
+  },
+  {
+    month: "2021-10-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 3429040.019474523,
+  },
+  {
+    month: "2021-11-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 2680824.350215548,
+  },
+  {
+    month: "2021-12-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 3746128.459180974,
+  },
+  {
+    month: "2022-01-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 5429789.491608185,
+  },
+  {
+    month: "2022-02-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 6451666.088373792,
+  },
+  {
+    month: "2022-03-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 4433391.924154716,
+  },
+  {
+    month: "2022-04-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 3942815.61222696,
+  },
+  {
+    month: "2022-05-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 10844595.33845237,
+  },
+  {
+    month: "2022-06-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 7970077.512216561,
+  },
+  {
+    month: "2022-07-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 5018650.224568701,
+  },
+  {
+    month: "2022-08-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 3952253.235316207,
+  },
+  {
+    month: "2022-09-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 3714568.301696358,
+  },
+  {
+    month: "2022-10-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 2031208.188853798,
+  },
+  {
+    month: "2022-11-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 2908758.821270261,
+  },
+  {
+    month: "2022-12-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 2306172.573268864,
+  },
+  {
+    month: "2023-01-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 5349488.479656861,
+  },
+  {
+    month: "2023-02-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 6721040.225822374,
+  },
+  {
+    month: "2023-03-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 6524996.814499776,
+  },
+  {
+    month: "2023-04-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 3095419.069013951,
+  },
+  {
+    month: "2023-05-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 1742131.616698741,
+  },
+  {
+    month: "2023-06-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 4652670.484690648,
+  },
+  {
+    month: "2023-07-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 3602848.898693647,
+  },
+  {
+    month: "2023-08-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 2675142.11084023,
+  },
+  {
+    month: "2023-09-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 1145873.179870906,
+  },
+  {
+    month: "2023-10-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 3889640.116030978,
+  },
+  {
+    month: "2023-11-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 6978508.900590619,
+  },
+  {
+    month: "2023-12-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 9778538.996537985,
+  },
+  {
+    month: "2024-01-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 9822050.300826263,
+  },
+  {
+    month: "2024-02-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 2532115.740906646,
+  },
+  {
+    month: "2024-03-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 6155417.36603882,
+  },
+  {
+    month: "2024-04-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 2699725.823802232,
+  },
+  {
+    month: "2024-05-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 1800759.053900888,
+  },
+  {
+    month: "2024-06-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 5706793.011186555,
+  },
+  {
+    month: "2024-07-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 5500459.112310678,
+  },
+  {
+    month: "2024-08-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 10393559.674355503,
+  },
+  {
+    month: "2024-09-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 6901946.784122736,
+  },
+  {
+    month: "2024-10-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 6644417.78157048,
+  },
+  {
+    month: "2024-11-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 19451060.312659103,
+  },
+  {
+    month: "2024-12-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 14504168.288412208,
+  },
+  {
+    month: "2025-01-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 5912735.398111312,
+  },
+  {
+    month: "2025-02-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 7369777.112353798,
+  },
+  {
+    month: "2025-03-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 5502269.955461043,
+  },
+  {
+    month: "2025-04-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 8053734.577320112,
+  },
+  {
+    month: "2025-05-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 5943452.390882131,
+  },
+  {
+    month: "2025-06-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 4175964.199758627,
+  },
+  {
+    month: "2025-07-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 15548085.543824919,
+  },
+  {
+    month: "2025-08-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 7041545.0197137,
+  },
+  {
+    month: "2025-09-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 3572315.940336214,
+  },
+  {
+    month: "2025-10-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 7111984.843406217,
+  },
+  {
+    month: "2025-11-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 8961569.43838877,
+  },
+  {
+    month: "2025-12-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 4574025.533273053,
+  },
+  { month: "2025-12-01", poolId: "xtz-usdtz-tezex", volumeXtz: 0.019938643 },
+  {
+    month: "2026-01-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 5337445.155469196,
+  },
+  { month: "2026-01-01", poolId: "xtz-usdtz-tezex", volumeXtz: 29.03616633 },
+  {
+    month: "2026-02-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 2528056.617904224,
+  },
+  { month: "2026-02-01", poolId: "xtz-usdtz-tezex", volumeXtz: 0.1 },
+  {
+    month: "2026-03-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 3393688.251811342,
+  },
+  {
+    month: "2026-04-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 2420378.059213484,
+  },
+  {
+    month: "2026-05-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 7448167.890257602,
+  },
+  {
+    month: "2026-06-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 4336584.028553885,
+  },
+  {
+    month: "2026-07-01",
+    poolId: "xtz-tzbtc-sirius",
+    volumeXtz: 5387781.941863233,
+  },
+];

--- a/V2/tezex/src/pages/Analytics/index.tsx
+++ b/V2/tezex/src/pages/Analytics/index.tsx
@@ -8,7 +8,9 @@ import React, {
   useState,
 } from "react";
 import { NetworkType } from "@airgap/beacon-sdk";
+import BarChartRoundedIcon from "@mui/icons-material/BarChartRounded";
 import RefreshRoundedIcon from "@mui/icons-material/RefreshRounded";
+import ShowChartRoundedIcon from "@mui/icons-material/ShowChartRounded";
 
 import { TokenPair } from "../../components/ui/elements/TokenIcon";
 import { useNetwork } from "../../hooks/network";
@@ -30,6 +32,7 @@ import "./style.css";
 
 const METRICS: AnalyticsMetric[] = ["Volume", "TVL", "Fees"];
 const CURRENCIES: AnalyticsCurrency[] = ["XTZ", "BTC", "USD"];
+type AnalyticsChartType = "area" | "bars";
 const CHART_WIDTH = 900;
 const CHART_HEIGHT = 300;
 const CHART_LEFT = 10;
@@ -43,7 +46,11 @@ const formatNumber = (value: number, maximumFractionDigits = 1) =>
 const chartDate = (timestamp: number, range: AnalyticsRange) =>
   new Intl.DateTimeFormat(
     "en-US",
-    range === "24H" ? { hour: "numeric" } : { month: "short", day: "numeric" }
+    range === "24H"
+      ? { hour: "numeric" }
+      : range === "MAX"
+      ? { month: "short", year: "numeric" }
+      : { month: "short", day: "numeric" }
   ).format(timestamp);
 
 const rangeBoundaryDate = (timestamp: number, range: AnalyticsRange) =>
@@ -51,7 +58,7 @@ const rangeBoundaryDate = (timestamp: number, range: AnalyticsRange) =>
     "en-US",
     range === "24H"
       ? { month: "short", day: "numeric", hour: "numeric" }
-      : range === "1Y"
+      : range === "1Y" || range === "MAX"
       ? { month: "short", day: "numeric", year: "numeric" }
       : { month: "short", day: "numeric" }
   ).format(timestamp);
@@ -78,6 +85,7 @@ const Stat: FC<StatProps> = ({ label, value, delta, deltaLabel = "24h" }) => (
 
 interface ChartProps {
   metric: AnalyticsMetric;
+  chartType: AnalyticsChartType;
   range: AnalyticsRange;
   points: AnalyticsPoint[];
   currency: AnalyticsCurrency;
@@ -195,6 +203,7 @@ const RangeScrubber: FC<RangeScrubberProps> = ({
 
 const AnalyticsChart: FC<ChartProps> = ({
   metric,
+  chartType,
   range,
   points,
   currency,
@@ -203,13 +212,14 @@ const AnalyticsChart: FC<ChartProps> = ({
 }) => {
   const [hoverIndex, setHoverIndex] = useState<number | null>(null);
 
-  useEffect(() => setHoverIndex(null), [metric, points, range]);
+  useEffect(() => setHoverIndex(null), [chartType, metric, points, range]);
 
   const geometry = useMemo(() => {
     const values = points.map((point) => point.value);
     const maximum = Math.max(...values, 1);
-    const minimum = metric === "TVL" ? Math.min(...values, maximum) : 0;
-    const floor = metric === "TVL" ? Math.max(0, minimum * 0.985) : 0;
+    const canUseFocusedScale = metric === "TVL" && chartType === "area";
+    const minimum = canUseFocusedScale ? Math.min(...values, maximum) : 0;
+    const floor = canUseFocusedScale ? Math.max(0, minimum * 0.985) : 0;
     const ceiling = Math.max(maximum * 1.025, floor + 1);
     const chartHeight = CHART_HEIGHT - CHART_TOP - CHART_BOTTOM;
     const width =
@@ -232,7 +242,7 @@ const AnalyticsChart: FC<ChartProps> = ({
         } Z`
       : "";
     return { width, y, line, area };
-  }, [metric, points]);
+  }, [chartType, metric, points]);
 
   const activeIndex = hoverIndex ?? Math.max(0, points.length - 1);
   const activePoint = points[activeIndex];
@@ -274,7 +284,7 @@ const AnalyticsChart: FC<ChartProps> = ({
           width="100%"
           role="img"
           tabIndex={0}
-          aria-label={`${metric} over ${range}`}
+          aria-label={`${metric} over ${range}, ${chartType} chart`}
           onPointerMove={(event) =>
             points.length &&
             setHoverIndex(indexAt(event.clientX, event.currentTarget))
@@ -321,7 +331,7 @@ const AnalyticsChart: FC<ChartProps> = ({
             className="analytics-chart__baseline"
           />
 
-          {metric === "TVL" ? (
+          {chartType === "area" ? (
             <>
               <path d={geometry.area} className="analytics-chart__area" />
               <path d={geometry.line} className="analytics-chart__line" />
@@ -399,6 +409,10 @@ const AnalyticsChart: FC<ChartProps> = ({
 export const Analytics: FC = () => {
   const network = useNetwork();
   const [metric, setMetric] = useState<AnalyticsMetric>("Volume");
+  const [chartType, setChartType] = useState<AnalyticsChartType>(() => {
+    const saved = window.localStorage.getItem("tezex-analytics-chart-type");
+    return saved === "bars" ? "bars" : "area";
+  });
   const [range, setRange] = useState<AnalyticsRange>("7D");
   const [rangeWindow, setRangeWindow] = useState<RangeWindow>({
     start: 0,
@@ -410,6 +424,9 @@ export const Analytics: FC = () => {
       ? (saved as AnalyticsCurrency)
       : "XTZ";
   });
+  const [scope, setScope] = useState(
+    () => window.localStorage.getItem("tezex-analytics-scope") ?? "all"
+  );
   const [model, setModel] = useState<AnalyticsModel>();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string>();
@@ -423,6 +440,14 @@ export const Analytics: FC = () => {
   useEffect(() => {
     window.localStorage.setItem("tezex-analytics-currency", currency);
   }, [currency]);
+
+  useEffect(() => {
+    window.localStorage.setItem("tezex-analytics-chart-type", chartType);
+  }, [chartType]);
+
+  useEffect(() => {
+    window.localStorage.setItem("tezex-analytics-scope", scope);
+  }, [scope]);
 
   useEffect(() => {
     if (!isMainnet) return;
@@ -464,11 +489,18 @@ export const Analytics: FC = () => {
 
   useEffect(() => {
     if (!model) return;
+    const scopedChart =
+      scope === "all" ? model.chart : model.chartByPool[scope] ?? model.chart;
     setRangeWindow({
       start: 0,
-      end: Math.max(0, model.chart[range].Volume.length - 1),
+      end: Math.max(0, scopedChart[range][metric].length - 1),
     });
-  }, [model, range]);
+  }, [metric, model, range, scope]);
+
+  useEffect(() => {
+    if (!model || scope === "all") return;
+    if (!model.summaryByPool[scope]) setScope("all");
+  }, [model, scope]);
 
   const refresh = useCallback(() => {
     cache.current.delete(cacheKey);
@@ -482,10 +514,24 @@ export const Analytics: FC = () => {
       if (!model) return;
       setRangeWindow({
         start: 0,
-        end: Math.max(0, model.chart[nextRange].Volume.length - 1),
+        end: Math.max(
+          0,
+          (scope === "all"
+            ? model.chart
+            : model.chartByPool[scope] ?? model.chart)[nextRange][metric]
+            .length - 1
+        ),
       });
     },
-    [model]
+    [metric, model, scope]
+  );
+
+  const selectMetric = useCallback(
+    (nextMetric: AnalyticsMetric) => {
+      setMetric(nextMetric);
+      if (range === "MAX" && nextMetric !== "TVL") setRange("1Y");
+    },
+    [range]
   );
 
   if (!isMainnet) {
@@ -537,8 +583,24 @@ export const Analytics: FC = () => {
     );
   }
 
-  const { summary } = model;
-  const selectedSeries = model.chart[range][metric];
+  const selectedPool =
+    scope === "all" ? undefined : model.pools.find((pool) => pool.id === scope);
+  const summary =
+    scope === "all"
+      ? model.summary
+      : model.summaryByPool[scope] ?? model.summary;
+  const scopedChart =
+    scope === "all" ? model.chart : model.chartByPool[scope] ?? model.chart;
+  const selectedSeries = scopedChart[range][metric];
+  const scopedPools = selectedPool ? [selectedPool] : model.pools;
+  const scopedActivity =
+    scope === "all"
+      ? model.activity
+      : model.activityByPool[scope] ?? model.activity;
+  const availableRanges =
+    metric === "TVL"
+      ? ANALYTICS_RANGES
+      : ANALYTICS_RANGES.filter((item) => item !== "MAX");
   const visiblePoints = selectedSeries.slice(
     Math.min(rangeWindow.start, Math.max(0, selectedSeries.length - 1)),
     Math.min(rangeWindow.end + 1, selectedSeries.length)
@@ -555,9 +617,28 @@ export const Analytics: FC = () => {
         <div>
           <span className="analytics-eyebrow">ANALYTICS</span>
           <h1>On-chain activity</h1>
-          <p>Verified activity and liquidity across TEZEX Mainnet pools.</p>
+          <p>
+            {selectedPool
+              ? `Verified activity and liquidity for ${selectedPool.name}.`
+              : "Verified activity and liquidity across TEZEX Mainnet pools."}
+          </p>
         </div>
         <div className="analytics-intro__tools">
+          <label className="analytics-scope-picker">
+            <span>SCOPE</span>
+            <select
+              value={scope}
+              onChange={(event) => setScope(event.target.value)}
+              aria-label="Analytics pool scope"
+            >
+              <option value="all">All pools</option>
+              {model.pools.map((pool) => (
+                <option key={pool.id} value={pool.id}>
+                  {pool.name} · {pool.tokenA.label}/{pool.tokenB.label}
+                </option>
+              ))}
+            </select>
+          </label>
           <div
             className={`analytics-segments analytics-denomination__segments is-${currency.toLowerCase()}`}
             role="group"
@@ -600,7 +681,7 @@ export const Analytics: FC = () => {
 
       <section className="analytics-stats" aria-label="Market summary">
         <Stat
-          label="Total liquidity"
+          label={selectedPool ? "Pool liquidity" : "Total liquidity"}
           value={formatDenominatedXtz(summary.tvlXtz, currency, model.quote)}
           delta={summary.tvlDelta}
         />
@@ -647,18 +728,42 @@ export const Analytics: FC = () => {
                   type="button"
                   className={metric === item ? "is-active" : ""}
                   aria-pressed={metric === item}
-                  onClick={() => setMetric(item)}
+                  onClick={() => selectMetric(item)}
                 >
                   {item}
                 </button>
               ))}
             </div>
             <div
+              className="analytics-segments analytics-chart-types"
+              role="group"
+              aria-label="Chart type"
+            >
+              <button
+                type="button"
+                className={chartType === "area" ? "is-active" : ""}
+                aria-pressed={chartType === "area"}
+                onClick={() => setChartType("area")}
+              >
+                <ShowChartRoundedIcon />
+                Area
+              </button>
+              <button
+                type="button"
+                className={chartType === "bars" ? "is-active" : ""}
+                aria-pressed={chartType === "bars"}
+                onClick={() => setChartType("bars")}
+              >
+                <BarChartRoundedIcon />
+                Bars
+              </button>
+            </div>
+            <div
               className="analytics-segments"
               role="group"
               aria-label="Chart range"
             >
-              {ANALYTICS_RANGES.map((item) => (
+              {availableRanges.map((item) => (
                 <button
                   key={item}
                   type="button"
@@ -674,6 +779,7 @@ export const Analytics: FC = () => {
         </div>
         <AnalyticsChart
           metric={metric}
+          chartType={chartType}
           range={range}
           points={visiblePoints}
           currency={currency}
@@ -692,7 +798,9 @@ export const Analytics: FC = () => {
         <div className="analytics-panel__head">
           <h2 id="pools-title">POOLS</h2>
           <span className="analytics-panel__meta">
-            Current reserves · 24h activity
+            {selectedPool
+              ? `${selectedPool.name} · Current reserves · 24h activity`
+              : "Current reserves · 24h activity"}
           </span>
         </div>
         <div className="analytics-table-wrap">
@@ -707,7 +815,7 @@ export const Analytics: FC = () => {
               </tr>
             </thead>
             <tbody>
-              {model.pools.map((pool) => (
+              {scopedPools.map((pool) => (
                 <tr key={pool.id}>
                   <td>
                     <a
@@ -758,7 +866,11 @@ export const Analytics: FC = () => {
       <section className="analytics-panel" aria-labelledby="activity-title">
         <div className="analytics-panel__head">
           <h2 id="activity-title">RECENT ACTIVITY</h2>
-          <span className="analytics-panel__meta">Confirmed on Tezos</span>
+          <span className="analytics-panel__meta">
+            {selectedPool
+              ? `${selectedPool.name} · Confirmed on Tezos`
+              : "Confirmed on Tezos"}
+          </span>
         </div>
         <div className="analytics-table-wrap">
           <table className="analytics-table analytics-activity-table">
@@ -772,8 +884,8 @@ export const Analytics: FC = () => {
               </tr>
             </thead>
             <tbody>
-              {model.activity.length ? (
-                model.activity.map((activity) => {
+              {scopedActivity.length ? (
+                scopedActivity.map((activity) => {
                   const displayValue = formatDenominatedXtz(
                     activity.valueXtz,
                     currency,

--- a/V2/tezex/src/pages/Analytics/index.tsx
+++ b/V2/tezex/src/pages/Analytics/index.tsx
@@ -39,6 +39,7 @@ const CHART_LEFT = 10;
 const CHART_RIGHT = 10;
 const CHART_TOP = 18;
 const CHART_BOTTOM = 34;
+const rangeLabel = (range: AnalyticsRange) => (range === "MAX" ? "ALL" : range);
 
 const formatNumber = (value: number, maximumFractionDigits = 1) =>
   new Intl.NumberFormat("en-US", { maximumFractionDigits }).format(value);
@@ -49,7 +50,7 @@ const chartDate = (timestamp: number, range: AnalyticsRange) =>
     range === "24H"
       ? { hour: "numeric" }
       : range === "MAX"
-      ? { month: "short", year: "numeric" }
+      ? { month: "short", year: "numeric", timeZone: "UTC" }
       : { month: "short", day: "numeric" }
   ).format(timestamp);
 
@@ -58,7 +59,9 @@ const rangeBoundaryDate = (timestamp: number, range: AnalyticsRange) =>
     "en-US",
     range === "24H"
       ? { month: "short", day: "numeric", hour: "numeric" }
-      : range === "1Y" || range === "MAX"
+      : range === "MAX"
+      ? { month: "short", day: "numeric", year: "numeric", timeZone: "UTC" }
+      : range === "1Y"
       ? { month: "short", day: "numeric", year: "numeric" }
       : { month: "short", day: "numeric" }
   ).format(timestamp);
@@ -284,7 +287,7 @@ const AnalyticsChart: FC<ChartProps> = ({
           width="100%"
           role="img"
           tabIndex={0}
-          aria-label={`${metric} over ${range}, ${chartType} chart`}
+          aria-label={`${metric} over ${rangeLabel(range)}, ${chartType} chart`}
           onPointerMove={(event) =>
             points.length &&
             setHoverIndex(indexAt(event.clientX, event.currentTarget))
@@ -527,11 +530,8 @@ export const Analytics: FC = () => {
   );
 
   const selectMetric = useCallback(
-    (nextMetric: AnalyticsMetric) => {
-      setMetric(nextMetric);
-      if (range === "MAX" && nextMetric !== "TVL") setRange("1Y");
-    },
-    [range]
+    (nextMetric: AnalyticsMetric) => setMetric(nextMetric),
+    []
   );
 
   if (!isMainnet) {
@@ -597,10 +597,6 @@ export const Analytics: FC = () => {
     scope === "all"
       ? model.activity
       : model.activityByPool[scope] ?? model.activity;
-  const availableRanges =
-    metric === "TVL"
-      ? ANALYTICS_RANGES
-      : ANALYTICS_RANGES.filter((item) => item !== "MAX");
   const visiblePoints = selectedSeries.slice(
     Math.min(rangeWindow.start, Math.max(0, selectedSeries.length - 1)),
     Math.min(rangeWindow.end + 1, selectedSeries.length)
@@ -763,7 +759,7 @@ export const Analytics: FC = () => {
               role="group"
               aria-label="Chart range"
             >
-              {availableRanges.map((item) => (
+              {ANALYTICS_RANGES.map((item) => (
                 <button
                   key={item}
                   type="button"
@@ -771,7 +767,7 @@ export const Analytics: FC = () => {
                   aria-pressed={range === item}
                   onClick={() => selectRange(item)}
                 >
-                  {item}
+                  {rangeLabel(item)}
                 </button>
               ))}
             </div>

--- a/V2/tezex/src/pages/Analytics/style.css
+++ b/V2/tezex/src/pages/Analytics/style.css
@@ -34,6 +34,48 @@
   gap: 14px;
 }
 
+.analytics-scope-picker {
+  min-width: 204px;
+  height: 38px;
+  padding: 0 11px;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  position: relative;
+  background: var(--tezex-panel-subtle);
+  border: 1px solid var(--tezex-line);
+  border-radius: 999px;
+  cursor: pointer;
+  transition: border-color 160ms ease, background-color 160ms ease;
+}
+
+.analytics-scope-picker:hover,
+.analytics-scope-picker:focus-within {
+  background: var(--tezex-hover);
+  border-color: var(--tezex-line-strong);
+}
+
+.analytics-scope-picker > span {
+  color: var(--tezex-faint);
+  font-size: 9px;
+  font-weight: 750;
+  letter-spacing: 0.14em;
+}
+
+.analytics-scope-picker select {
+  min-width: 0;
+  height: 100%;
+  flex: 1;
+  color: var(--tezex-text);
+  background: transparent;
+  border: 0;
+  outline: 0;
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 650;
+  text-overflow: ellipsis;
+}
+
 .analytics-eyebrow,
 .analytics-panel__head h2 {
   display: block;
@@ -224,6 +266,8 @@
 .analytics-controls {
   display: flex;
   align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
   gap: 10px;
 }
 
@@ -259,6 +303,17 @@
 .analytics-segments button.is-active {
   color: var(--tezex-action-text);
   background: var(--tezex-action);
+}
+
+.analytics-chart-types button {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.analytics-chart-types svg {
+  width: 15px;
+  height: 15px;
 }
 
 .analytics-denomination__segments {
@@ -341,6 +396,7 @@
 
 .analytics-chart:focus-visible,
 .analytics-segments button:focus-visible,
+.analytics-scope-picker select:focus-visible,
 .analytics-freshness button:focus-visible,
 .analytics-unavailable button:focus-visible,
 .analytics-pair:focus-visible,
@@ -804,7 +860,7 @@
 
   .analytics-controls {
     width: 100%;
-    justify-content: space-between;
+    justify-content: flex-start;
   }
 
   .analytics-table th,
@@ -846,6 +902,10 @@
   }
 
   .analytics-denomination__segments {
+    width: 100%;
+  }
+
+  .analytics-scope-picker {
     width: 100%;
   }
 


### PR DESCRIPTION
## What changed

- adds an explicit Area/Bars chart toggle
- adds a page-level All pools / Sirius / TEZEX scope selector
- applies the selected scope to KPIs, history, pool rows, and recent activity
- adds complete MAX TVL history from each pool’s first on-chain balance
- removes the false pre-inception liquidity plateau
- paginates the full one-year swap window and reduces TzKT request concurrency

## Why

The previous chart presentation varied by metric without an explicit choice, aggregate KPIs could not be narrowed to a pool, and sparse balance-history sampling carried the earliest returned value backward into dates before the pool existed.

## Validation

- `npm run typecheck`
- `npm run test:ci` — 73 tests passed
- `npm run build`
- desktop and 390px mobile browser QA
- verified Sirius MAX range begins August 6, 2021