### PR TITLE
Enable sTEZ testing on Weeklynet

### DIFF
--- a/V2/tezex/src/components/ui/elements/selectors/networkSelector/NetworkSelector.test.tsx
+++ b/V2/tezex/src/components/ui/elements/selectors/networkSelector/NetworkSelector.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { render, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import { NetworkSelector } from "./NetworkSelector";
 
 jest.mock("../../../../../hooks/network", () => ({
@@ -36,7 +37,11 @@ test("accepts Previewnet's empty cycle response without logging an error", async
     }) as unknown as typeof fetch;
   const consoleError = jest.spyOn(console, "error").mockImplementation();
 
-  render(<NetworkSelector />);
+  render(
+    <MemoryRouter>
+      <NetworkSelector />
+    </MemoryRouter>
+  );
 
   await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(2));
   expect(cycleJson).not.toHaveBeenCalled();

--- a/V2/tezex/src/components/ui/elements/selectors/networkSelector/NetworkSelector.tsx
+++ b/V2/tezex/src/components/ui/elements/selectors/networkSelector/NetworkSelector.tsx
@@ -11,6 +11,7 @@ import { NetworkType } from "@airgap/beacon-sdk";
 import { getNetworkSelectorStyles } from "./style";
 import { useNetwork } from "../../../../../hooks/network";
 import { getExplorer, getTzktApiUrl } from "../../../../../functions/util";
+import { useLocation } from "react-router-dom";
 
 interface NetworkOption {
   type: NetworkType;
@@ -53,6 +54,8 @@ export const NetworkSelector: FC = () => {
   const theme = useTheme();
   const network = useNetwork();
   const styles = getNetworkSelectorStyles(theme);
+  const location = useLocation();
+  const isStezRoute = location.pathname.startsWith("/stez");
 
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [stats, setStats] = useState<BlockchainStats | null>(null);
@@ -103,10 +106,11 @@ export const NetworkSelector: FC = () => {
   };
 
   useEffect(() => {
+    if (isStezRoute) return;
     fetchStats();
     const interval = setInterval(fetchStats, 30_000);
     return () => clearInterval(interval);
-  }, [network.network]);
+  }, [isStezRoute, network.network]);
 
   useEffect(() => {
     if (!cycleInfo) return;
@@ -144,6 +148,21 @@ export const NetworkSelector: FC = () => {
 
   const open = Boolean(anchorEl);
   const currentNetwork = networks.find((n) => n.type === network.network);
+
+  if (isStezRoute) {
+    return (
+      <Box
+        component="div"
+        aria-label="Network: Weeklynet, live"
+        sx={{ ...styles.button, cursor: "default" }}
+      >
+        <Box aria-hidden="true" sx={styles.liveSignal} />
+        <Box data-network-label sx={styles.networkIdentity}>
+          <Typography sx={styles.networkLabel}>Weeklynet</Typography>
+        </Box>
+      </Box>
+    );
+  }
 
   return (
     <>

--- a/V2/tezex/src/components/ui/views/header/index.test.tsx
+++ b/V2/tezex/src/components/ui/views/header/index.test.tsx
@@ -7,6 +7,18 @@ jest.mock("../../../wallet/Wallet", () => ({
   Wallet: () => <div>Wallet</div>,
 }));
 
+jest.mock("../../../../hooks/wallet", () => ({
+  useWallet: () => ({ client: null, address: "" }),
+}));
+
+jest.mock("../../../../functions/beacon", () => ({
+  connectWalletToCustomNetwork: jest.fn(),
+}));
+
+jest.mock("../../../../pages/Stez/network", () => ({
+  resolveCurrentWeeklynet: jest.fn(),
+}));
+
 jest.mock("../../../nav", () => ({
   NavApp: () => <nav>Navigation</nav>,
 }));

--- a/V2/tezex/src/components/ui/views/header/index.tsx
+++ b/V2/tezex/src/components/ui/views/header/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import React, { FC, useCallback } from "react";
 import { Wallet } from "../../../wallet/Wallet";
 import { NavApp } from "../../../nav";
 
@@ -12,12 +12,15 @@ import MenuIcon from "@mui/icons-material/Menu";
 import LightModeOutlinedIcon from "@mui/icons-material/LightModeOutlined";
 import DarkModeOutlinedIcon from "@mui/icons-material/DarkModeOutlined";
 import Container from "@mui/material/Container";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import style from "./style";
 import useStyles from "../../../../hooks/styles";
 import { NetworkSelector } from "../../elements/selectors/networkSelector/NetworkSelector";
 import { useColorMode } from "../../../../contexts/color-mode";
 import { homePathForHost } from "../../../../routing";
+import { useWallet } from "../../../../hooks/wallet";
+import { connectWalletToCustomNetwork } from "../../../../functions/beacon";
+import { resolveCurrentWeeklynet } from "../../../../pages/Stez/network";
 
 export interface IHeader {
   openMenu: boolean;
@@ -29,6 +32,16 @@ export const Header: FC<IHeader> = (props) => {
   const { mode, toggleMode } = useColorMode();
   const isLight = mode === "light";
   const homePath = homePathForHost(window.location.hostname);
+  const location = useLocation();
+  const wallet = useWallet();
+  const isStezRoute = location.pathname.startsWith("/stez");
+  const connectToWeeklynet = useCallback(async () => {
+    const weeklynet = await resolveCurrentWeeklynet();
+    await connectWalletToCustomNetwork(wallet, {
+      name: weeklynet.name,
+      rpcUrl: weeklynet.rpcUrl,
+    });
+  }, [wallet]);
 
   return (
     <AppBar
@@ -85,6 +98,7 @@ export const Header: FC<IHeader> = (props) => {
                   variant={"header"}
                   scalingKey={scalingKey}
                   visualVariant="dark"
+                  connectOverride={isStezRoute ? connectToWeeklynet : undefined}
                 />
               </Box>
             </Box>

--- a/V2/tezex/src/components/ui/views/layout/index.tsx
+++ b/V2/tezex/src/components/ui/views/layout/index.tsx
@@ -77,7 +77,7 @@ export const Layout: FC<ILayout> = (props) => {
             <Box sx={styles.bottomSpace}>
               <Typography sx={styles.bottomSpaceText}>
                 {isStezRoute ? (
-                  "sTEZ data read from the selected Tezos RPC"
+                  "sTEZ data read from the current Weeklynet RPC"
                 ) : (
                   <>
                     Data provided by

--- a/V2/tezex/src/components/wallet/Wallet.tsx
+++ b/V2/tezex/src/components/wallet/Wallet.tsx
@@ -28,6 +28,7 @@ interface IWallet {
   children?: string;
   scalingKey?: string;
   visualVariant?: "default" | "dark";
+  connectOverride?: () => Promise<void>;
 }
 
 export const Wallet: FC<IWallet> = (props) => {
@@ -134,6 +135,10 @@ export const Wallet: FC<IWallet> = (props) => {
   };
 
   const connect = async () => {
+    if (props.connectOverride) {
+      await props.connectOverride();
+      return;
+    }
     if (walletInfo) {
       await connectWallet(walletInfo, networkInfo);
     }

--- a/V2/tezex/src/functions/beacon.ts
+++ b/V2/tezex/src/functions/beacon.ts
@@ -49,14 +49,9 @@ export async function getBalance(
  */
 export function createDAppClient(network: INetwork): DAppClient {
   if (network.network === NetworkType.CUSTOM) {
-    return new DAppClient({
-      name: "Tezex",
-      network: {
-        type: NetworkType.CUSTOM,
-        rpcUrl: network.info.tezosServer,
-        name: "Previewnet",
-      },
-      preferredNetwork: NetworkType.CUSTOM,
+    return createCustomDAppClient({
+      rpcUrl: network.info.tezosServer,
+      name: "Previewnet",
     });
   }
   return new DAppClient({
@@ -66,12 +61,29 @@ export function createDAppClient(network: INetwork): DAppClient {
   });
 }
 
-export default async function connectWallet(
-  walletInfo: WalletInfo,
-  network: INetwork
-) {
-  const dAppClient = createDAppClient(network);
+export interface CustomDAppNetwork {
+  rpcUrl: string;
+  name: string;
+}
 
+export function createCustomDAppClient(
+  customNetwork: CustomDAppNetwork
+): DAppClient {
+  return new DAppClient({
+    name: "Tezex",
+    network: {
+      type: NetworkType.CUSTOM,
+      rpcUrl: customNetwork.rpcUrl,
+      name: customNetwork.name,
+    },
+    preferredNetwork: NetworkType.CUSTOM,
+  });
+}
+
+const connectWithClient = async (
+  walletInfo: WalletInfo,
+  dAppClient: DAppClient
+) => {
   let err = false;
   try {
     await dAppClient.subscribeToEvent(
@@ -85,9 +97,8 @@ export default async function connectWallet(
     const activeAccount = await dAppClient.getActiveAccount();
     if (!activeAccount) {
       throw new Error("Could not connect");
-    } else {
-      walletInfo.setAddress(activeAccount.address);
     }
+    walletInfo.setAddress(activeAccount.address);
   } catch (error) {
     console.log("\n", "Error encountered in connectWallet : ", error, "\n");
     err = true;
@@ -98,4 +109,27 @@ export default async function connectWallet(
       walletInfo.setClient(dAppClient);
     }
   }
+};
+
+export async function connectWalletToCustomNetwork(
+  walletInfo: WalletInfo,
+  customNetwork: CustomDAppNetwork
+) {
+  if (walletInfo.client) {
+    try {
+      await walletInfo.client.clearActiveAccount();
+      await walletInfo.client.destroy();
+    } catch (error) {
+      console.warn("Unable to clear the previous wallet network:", error);
+    }
+  }
+
+  await connectWithClient(walletInfo, createCustomDAppClient(customNetwork));
+}
+
+export default async function connectWallet(
+  walletInfo: WalletInfo,
+  network: INetwork
+) {
+  await connectWithClient(walletInfo, createDAppClient(network));
 }

--- a/V2/tezex/src/pages/Stez/index.test.tsx
+++ b/V2/tezex/src/pages/Stez/index.test.tsx
@@ -1,238 +1,175 @@
 import React from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { NetworkType } from "@airgap/beacon-sdk";
 
 import { Stez } from ".";
-import connectWallet from "../../functions/beacon";
-import { loadStezSnapshot, StezSnapshot, USHUAIA_PROTOCOL } from "./rpc";
+import { connectWalletToCustomNetwork } from "../../functions/beacon";
+import { resolveCurrentWeeklynet } from "./network";
+import { loadStezSnapshot, StezSnapshot } from "./rpc";
 
-jest.mock("../../functions/beacon", () => jest.fn());
+jest.mock("../../functions/beacon", () => ({
+  connectWalletToCustomNetwork: jest.fn(),
+}));
 
-const mockNetworkInfo = {
-  tezosServer: "https://rpc.example",
-  rpcFallbacks: [],
-  chainId: "NetXdQprcVkpaWU",
-  pools: [],
-  assets: [],
+const weeklynet = {
+  key: "weeklynet-2026-08-05",
+  name: "Weeklynet" as const,
+  rpcUrl: "https://rpc.weeklynet-2026-08-05.teztnets.com",
+  faucetUrl: "https://faucet.weeklynet-2026-08-05.teztnets.com",
+  chainId: "NetXmT6tP86uFqw",
+  activatedOn: "2026-08-05",
+  info: {
+    tezosServer: "https://rpc.weeklynet-2026-08-05.teztnets.com",
+    rpcFallbacks: [],
+    chainId: "NetXmT6tP86uFqw",
+    pools: [],
+    assets: [],
+  },
+};
+
+const mockClient = {
+  getActiveAccount: jest.fn(),
+  requestOperation: jest.fn(),
 };
 
 const mockWallet: {
   isWalletConnected: boolean;
   address: string | null;
+  client: typeof mockClient | null;
 } = {
   isWalletConnected: false,
   address: null,
+  client: null,
 };
-let mockNetworkType = NetworkType.MAINNET;
 
-jest.mock("../../hooks/network", () => ({
-  useNetwork: () => ({
-    network: mockNetworkType,
-    info: mockNetworkInfo,
-  }),
-}));
 jest.mock("../../hooks/wallet", () => ({
   useWallet: () => mockWallet,
 }));
+jest.mock("./network", () => {
+  const actual = jest.requireActual("./network");
+  return { ...actual, resolveCurrentWeeklynet: jest.fn() };
+});
 jest.mock("./rpc", () => {
   const actual = jest.requireActual("./rpc");
   return { ...actual, loadStezSnapshot: jest.fn() };
 });
 
-const disabledSnapshot: StezSnapshot = {
-  availability: "disabled",
-  endpoint: "https://rpc.example",
-  chainId: "NetXdQprcVkpaWU",
-  protocolHash: USHUAIA_PROTOCOL,
+const baseSnapshot: StezSnapshot = {
+  availability: "available",
+  endpoint: weeklynet.rpcUrl,
+  chainId: weeklynet.chainId,
+  protocolHash: "ProtoALphaALphaALphaALphaALphaALphaALphaALphaDdp3zK",
   blockHash: "BLockHash",
-  blockLevel: BigInt(14_286_000),
-  blockTimestamp: "2026-07-30T12:00:00Z",
-  contractHash: null,
-  totalSupplyUnits: null,
-  totalBackingMutez: null,
-  rateNumeratorMutez: null,
-  rateDenominatorTokenUnits: null,
+  blockLevel: BigInt(2_640),
+  blockTimestamp: "2026-08-10T12:00:00Z",
+  contractHash: "KT1WCsbJx996ebZfutAitHYsZ8FUZFsTdaD7",
+  totalSupplyUnits: BigInt(1_000_000),
+  totalBackingMutez: BigInt(1_100_000),
+  rateNumeratorMutez: BigInt(1_100_000),
+  rateDenominatorTokenUnits: BigInt(1_000_000),
   walletXtzMutez: null,
   walletStezUnits: null,
   redeemedFrozenMutez: null,
   redeemedFinalizableMutez: null,
   checkedAt: Date.now(),
-  detail: "The sTEZ feature is not active.",
-};
-
-const availableSnapshot: StezSnapshot = {
-  ...disabledSnapshot,
-  availability: "available",
-  contractHash: "KT1StezNativeContract",
-  totalSupplyUnits: BigInt(1_000_000),
-  totalBackingMutez: BigInt(1_100_000),
-  rateNumeratorMutez: BigInt(1_100_000),
-  rateDenominatorTokenUnits: BigInt(1_000_000),
-  walletXtzMutez: BigInt(5_000_000),
-  walletStezUnits: BigInt(2_000_000),
-  redeemedFrozenMutez: BigInt(250_000),
-  redeemedFinalizableMutez: BigInt(100_000),
   detail: "sTEZ is active.",
 };
 
 beforeEach(() => {
   jest.clearAllMocks();
-  mockNetworkType = NetworkType.MAINNET;
   mockWallet.isWalletConnected = false;
   mockWallet.address = null;
-  (loadStezSnapshot as jest.Mock).mockResolvedValue(disabledSnapshot);
+  mockWallet.client = null;
+  (resolveCurrentWeeklynet as jest.Mock).mockResolvedValue(weeklynet);
+  (loadStezSnapshot as jest.Mock).mockResolvedValue(baseSnapshot);
 });
 
-test("uses the Mainnet preview copy without showing a testnet faucet", async () => {
+test("loads live Weeklynet data and its matching faucet", async () => {
   render(<Stez />);
 
   expect(screen.getByText("Loading sTEZ data")).toBeInTheDocument();
-  await waitFor(() =>
-    expect(
-      screen.getByText("sTEZ is not active on Mainnet")
-    ).toBeInTheDocument()
-  );
+  await screen.findByText("sTEZ is live on Weeklynet");
+
   expect(
-    screen.getByText(
-      "This page is a read-only preview of the sTEZ staking flow. You can explore staking, redemption, and finalization, but Mainnet transactions are not enabled. Activation would require a future Tezos protocol upgrade."
-    )
+    screen.getByText(/Weeklynet resets every Wednesday/)
   ).toBeInTheDocument();
   expect(screen.getByText("Stake tez, stay liquid.")).toBeInTheDocument();
-  expect(
-    screen.getByText(
-      "sTEZ is Tezos’s protocol-native liquid staking token. Stake XTZ to receive sTEZ, a token you can hold, transfer, or use in supported applications while its backing XTZ earns staking rewards. The protocol automatically assigns the pool’s staking power across participating bakers, so you do not need to choose one."
-    )
-  ).toBeInTheDocument();
   expect(screen.getByText("sTEZ Balance")).toBeInTheDocument();
-  expect(screen.getByText("Wallet XTZ")).toBeInTheDocument();
-  expect(screen.getByText("Pending Redemption")).toBeInTheDocument();
-  expect(screen.getByText("Ready to Finalize")).toBeInTheDocument();
-  expect(screen.getByText(/Staking XTZ mints sTEZ/)).toBeInTheDocument();
   expect(screen.getByText("Total sTEZ supply")).toBeInTheDocument();
-  expect(screen.getByRole("tab", { name: "Stake" })).toBeInTheDocument();
-  expect(
-    screen.queryByRole("tab", { name: "Deposit" })
-  ).not.toBeInTheDocument();
-  expect(
-    screen.queryByRole("link", {
-      name: "Get Shadownet test XTZ from the official faucet",
-    })
-  ).not.toBeInTheDocument();
-  expect(
-    screen.queryByRole("button", { name: /check stez availability again/i })
-  ).not.toBeInTheDocument();
-  expect(screen.getAllByText(/block 14,286,000/i)).toHaveLength(2);
+
+  const faucet = screen.getByRole("link", {
+    name: "Get Weeklynet test XTZ from the official Teztnets faucet",
+  });
+  expect(faucet).toHaveAttribute("href", weeklynet.faucetUrl);
+  expect(faucet.querySelector("svg")).toBeInTheDocument();
 
   fireEvent.click(screen.getByRole("tab", { name: "Redeem" }));
   expect(screen.getByText("YOU REDEEM")).toBeInTheDocument();
   expect(screen.getByText("XTZ ENTERING REDEMPTION")).toBeInTheDocument();
-  expect(
-    screen.getByText(
-      "Redeeming burns sTEZ and begins a delayed withdrawal of the corresponding XTZ. The XTZ remains frozen and slashable until the redemption delay ends, then must be finalized before it returns to your wallet."
-    )
-  ).toBeInTheDocument();
 
   fireEvent.click(screen.getByRole("tab", { name: "Finalize" }));
   expect(screen.getByText("READY TO FINALIZE")).toBeInTheDocument();
-  expect(
-    screen.getByText(
-      "After the redemption delay has elapsed, finalization releases all matured XTZ to the original redeemer. Anyone may submit the operation, but the funds can only be sent to that redeemer."
-    )
-  ).toBeInTheDocument();
 });
 
-test("uses the inactive Mainnet action label after a wallet is connected", async () => {
-  mockWallet.isWalletConnected = true;
-  mockWallet.address = "tz1MainnetWallet";
-
-  render(<Stez />);
-
-  await screen.findByText("sTEZ is not active on Mainnet");
-  expect(
-    screen.getByRole("button", { name: "sTEZ NOT ACTIVE ON MAINNET" })
-  ).toBeDisabled();
-});
-
-test("shows the Shadownet faucet only for an active Shadownet snapshot", async () => {
-  mockNetworkType = NetworkType.SHADOWNET;
-  (loadStezSnapshot as jest.Mock).mockResolvedValue(availableSnapshot);
-
-  render(<Stez />);
-
-  await screen.findByText("sTEZ is active on Shadownet");
-  expect(
-    screen.getByText(
-      "Live sTEZ protocol data was read from block 14,286,000. Transaction signing is not yet enabled in this interface."
-    )
-  ).toBeInTheDocument();
-  const faucetLink = screen.getByRole("link", {
-    name: "Get Shadownet test XTZ from the official faucet",
-  });
-  expect(faucetLink).toHaveAttribute(
-    "href",
-    "https://faucet.shadownet.teztnets.com"
-  );
-  expect(faucetLink.querySelector("svg")).toBeInTheDocument();
-  expect(faucetLink).not.toHaveTextContent("↗");
-  expect(
-    screen.getByText(
-      "Rewards do not increase your sTEZ balance. Instead, they increase the amount of XTZ each sTEZ can redeem for. Baker fees reduce the rewards passed through, and slashing can lower the redemption rate."
-    )
-  ).toBeInTheDocument();
-});
-
-test.each([
-  [
-    "unsupported" as const,
-    "sTEZ is not supported on Mainnet",
-    "The selected network does not expose a compatible sTEZ implementation. No balances, rates, or transaction controls are shown.",
-  ],
-  [
-    "unreachable" as const,
-    "Unable to load sTEZ data",
-    "TEZEX could not verify the sTEZ contract or read its current state from the selected network. No cached or estimated values have been substituted.",
-  ],
-])("renders exact %s state copy", async (availability, title, description) => {
+test("shows an exact inactive-network state without enabling controls", async () => {
   (loadStezSnapshot as jest.Mock).mockResolvedValue({
-    ...disabledSnapshot,
-    availability,
+    ...baseSnapshot,
+    availability: "disabled",
+    contractHash: null,
   });
 
   render(<Stez />);
 
-  await screen.findByText(title);
-  expect(screen.getByText(description)).toBeInTheDocument();
+  await screen.findByText("sTEZ is not active on Weeklynet");
+  expect(
+    screen.getByText(
+      "The selected network includes the sTEZ protocol code, but native sTEZ contracts are not enabled. No balances, rates, or transaction controls are shown."
+    )
+  ).toBeInTheDocument();
 });
 
-test("uses amount and signing-preview states on an active network", async () => {
-  mockNetworkType = NetworkType.SHADOWNET;
+test("enables a stake request only for a wallet connected to current Weeklynet", async () => {
   mockWallet.isWalletConnected = true;
-  mockWallet.address = "tz1ShadownetWallet";
-  (loadStezSnapshot as jest.Mock).mockResolvedValue(availableSnapshot);
+  mockWallet.address = "tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb";
+  mockWallet.client = mockClient;
+  mockClient.getActiveAccount.mockResolvedValue({
+    address: mockWallet.address,
+    network: { type: "custom", rpcUrl: weeklynet.rpcUrl },
+  });
+  (loadStezSnapshot as jest.Mock).mockResolvedValue({
+    ...baseSnapshot,
+    walletXtzMutez: BigInt(5_000_000),
+    walletStezUnits: BigInt(2_000_000),
+    redeemedFrozenMutez: BigInt(250_000),
+    redeemedFinalizableMutez: BigInt(100_000),
+  });
 
   render(<Stez />);
 
-  await screen.findByText("sTEZ is active on Shadownet");
-  expect(
-    screen.getByRole("button", { name: "ENTER AN AMOUNT" })
-  ).toBeDisabled();
+  await screen.findByText("sTEZ is live on Weeklynet");
+  await waitFor(() =>
+    expect(
+      screen.getByRole("button", { name: "ENTER AN AMOUNT" })
+    ).toBeDisabled()
+  );
 
   fireEvent.change(screen.getByLabelText("YOU STAKE"), {
     target: { value: "1" },
   });
-
-  expect(
-    screen.getByRole("button", {
-      name: "TRANSACTIONS NOT ENABLED IN THIS PREVIEW",
-    })
-  ).toBeDisabled();
+  expect(screen.getByRole("button", { name: "STAKE XTZ" })).toBeEnabled();
 });
 
-test("uses the existing wallet connection flow", async () => {
+test("connects a disconnected wallet to the resolved Weeklynet RPC", async () => {
   render(<Stez />);
-  await screen.findByText("sTEZ is not active on Mainnet");
+  await screen.findByText("sTEZ is live on Weeklynet");
 
-  fireEvent.click(screen.getByRole("button", { name: "CONNECT WALLET" }));
+  fireEvent.click(
+    screen.getByRole("button", { name: "CONNECT WALLET TO WEEKLYNET" })
+  );
 
-  expect(connectWallet).toHaveBeenCalledTimes(1);
+  await waitFor(() =>
+    expect(connectWalletToCustomNetwork).toHaveBeenCalledWith(mockWallet, {
+      name: "Weeklynet",
+      rpcUrl: weeklynet.rpcUrl,
+    })
+  );
 });

--- a/V2/tezex/src/pages/Stez/index.tsx
+++ b/V2/tezex/src/pages/Stez/index.tsx
@@ -1,5 +1,4 @@
 import React, { FC, useCallback, useEffect, useMemo, useState } from "react";
-import { NetworkType } from "@airgap/beacon-sdk";
 import AccountBalanceWalletOutlinedIcon from "@mui/icons-material/AccountBalanceWalletOutlined";
 import ArrowDownwardRoundedIcon from "@mui/icons-material/ArrowDownwardRounded";
 import CheckCircleOutlineRoundedIcon from "@mui/icons-material/CheckCircleOutlineRounded";
@@ -7,8 +6,7 @@ import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import LockClockOutlinedIcon from "@mui/icons-material/LockClockOutlined";
 import ArrowOutwardRoundedIcon from "@mui/icons-material/ArrowOutwardRounded";
 
-import connectWallet from "../../functions/beacon";
-import { useNetwork } from "../../hooks/network";
+import { connectWalletToCustomNetwork } from "../../functions/beacon";
 import { useWallet } from "../../hooks/wallet";
 import {
   loadStezSnapshot,
@@ -16,21 +14,27 @@ import {
   quoteStezRedeem,
   StezSnapshot,
   stezUnderlyingValue,
+  waitForStezOperation,
 } from "./rpc";
+import {
+  isWeeklynetAccount,
+  resolveCurrentWeeklynet,
+  WeeklynetNetwork,
+} from "./network";
+import { readableStezError, submitStezOperation } from "./transactions";
 import "./style.css";
 
 type StezAction = "Stake" | "Redeem" | "Finalize";
 
 const ZERO = BigInt(0);
 const TOKEN_SCALE = BigInt(1_000_000);
-const SHADOWNET_FAUCET_URL = "https://faucet.shadownet.teztnets.com";
-const TRANSACTION_SIGNING_ENABLED = false;
 
-const networkName = (network: NetworkType) => {
-  if (network === NetworkType.MAINNET) return "Mainnet";
-  if (network === NetworkType.SHADOWNET) return "Shadownet";
-  return "Previewnet";
-};
+type TransactionStage =
+  | "idle"
+  | "requesting"
+  | "submitted"
+  | "confirmed"
+  | "failed";
 
 const shortAddress = (value?: string | null, front = 7, back = 5) => {
   if (!value) return "";
@@ -74,31 +78,32 @@ const statusCopy = (
   snapshot: StezSnapshot | null,
   loading: boolean,
   selectedNetwork: string,
-  selectedNetworkType: NetworkType
+  networkError: string | null
 ) => {
-  if (loading || !snapshot) {
+  if (loading) {
     return {
       title: "Loading sTEZ data",
       description:
-        "TEZEX is checking the selected network for current sTEZ protocol data.",
+        "TEZEX is resolving the current Weeklynet and checking its native sTEZ contract.",
+    };
+  }
+  if (!snapshot) {
+    return {
+      title: "Unable to resolve Weeklynet",
+      description:
+        networkError ??
+        "The current Weeklynet could not be read from the official Teztnets directory.",
     };
   }
   if (snapshot.availability === "available") {
     return {
-      title: `sTEZ is active on ${selectedNetwork}`,
-      description: `Live sTEZ protocol data was read from block ${snapshot.blockLevel.toLocaleString(
+      title: `sTEZ is live on ${selectedNetwork}`,
+      description: `Use test XTZ to stake, redeem, and finalize against the current experimental protocol. Live data was read from block ${snapshot.blockLevel.toLocaleString(
         "en-US"
-      )}. Transaction signing is not yet enabled in this interface.`,
+      )}. Weeklynet resets every Wednesday, so balances and addresses are temporary.`,
     };
   }
   if (snapshot.availability === "disabled") {
-    if (selectedNetworkType === NetworkType.MAINNET) {
-      return {
-        title: "sTEZ is not active on Mainnet",
-        description:
-          "This page is a read-only preview of the sTEZ staking flow. You can explore staking, redemption, and finalization, but Mainnet transactions are not enabled. Activation would require a future Tezos protocol upgrade.",
-      };
-    }
     return {
       title: `sTEZ is not active on ${selectedNetwork}`,
       description:
@@ -145,27 +150,43 @@ const PositionCell: FC<PositionCellProps> = ({
 );
 
 export const Stez: FC = () => {
-  const network = useNetwork();
   const wallet = useWallet();
-  const selectedNetwork = networkName(network.network);
+  const selectedNetwork = "Weeklynet";
+  const [weeklynet, setWeeklynet] = useState<WeeklynetNetwork | null>(null);
   const [snapshot, setSnapshot] = useState<StezSnapshot | null>(null);
   const [loading, setLoading] = useState(true);
+  const [networkError, setNetworkError] = useState<string | null>(null);
+  const [walletReady, setWalletReady] = useState(false);
   const [activeAction, setActiveAction] = useState<StezAction>("Stake");
   const [amount, setAmount] = useState("");
+  const [transactionStage, setTransactionStage] =
+    useState<TransactionStage>("idle");
+  const [transactionMessage, setTransactionMessage] = useState("");
+  const [operationHash, setOperationHash] = useState("");
 
   useEffect(() => {
     const controller = new AbortController();
     setLoading(true);
     setSnapshot(null);
+    setNetworkError(null);
     setAmount("");
 
-    loadStezSnapshot(network.info, wallet.address, controller.signal)
+    resolveCurrentWeeklynet(controller.signal)
+      .then(async (nextWeeklynet) => {
+        if (!controller.signal.aborted) setWeeklynet(nextWeeklynet);
+        return loadStezSnapshot(
+          nextWeeklynet.info,
+          wallet.address,
+          controller.signal
+        );
+      })
       .then((nextSnapshot) => {
         if (!controller.signal.aborted) setSnapshot(nextSnapshot);
       })
       .catch((error) => {
         if (!controller.signal.aborted) {
           console.error("Unable to load sTEZ state", error);
+          setNetworkError(readableStezError(error));
         }
       })
       .finally(() => {
@@ -173,10 +194,35 @@ export const Stez: FC = () => {
       });
 
     return () => controller.abort();
-  }, [network.info, network.network, wallet.address]);
+  }, [wallet.address]);
+
+  useEffect(() => {
+    let mounted = true;
+
+    if (!wallet.client || !weeklynet) {
+      setWalletReady(false);
+      return () => {
+        mounted = false;
+      };
+    }
+
+    wallet.client
+      .getActiveAccount()
+      .then((account) => {
+        if (mounted) setWalletReady(isWeeklynetAccount(account, weeklynet));
+      })
+      .catch(() => {
+        if (mounted) setWalletReady(false);
+      });
+
+    return () => {
+      mounted = false;
+    };
+  }, [wallet.client, weeklynet]);
 
   const available = snapshot?.availability === "available";
-  const walletConnected = wallet.isWalletConnected && Boolean(wallet.address);
+  const walletConnected =
+    wallet.isWalletConnected && walletReady && Boolean(wallet.address);
   const rate = formatRatio(
     snapshot?.rateNumeratorMutez ?? null,
     snapshot?.rateDenominatorTokenUnits ?? null
@@ -215,11 +261,16 @@ export const Stez: FC = () => {
           snapshot.rateDenominatorTokenUnits
         );
   }, [activeAction, available, inputUnits, snapshot]);
-  const copy = statusCopy(snapshot, loading, selectedNetwork, network.network);
+  const copy = statusCopy(snapshot, loading, selectedNetwork, networkError);
 
   const connect = useCallback(async () => {
-    await connectWallet(wallet, network);
-  }, [network, wallet]);
+    const activeWeeklynet = weeklynet ?? (await resolveCurrentWeeklynet());
+    setWeeklynet(activeWeeklynet);
+    await connectWalletToCustomNetwork(wallet, {
+      name: activeWeeklynet.name,
+      rpcUrl: activeWeeklynet.rpcUrl,
+    });
+  }, [wallet, weeklynet]);
 
   const setMaximum = () => {
     const maximum =
@@ -232,13 +283,10 @@ export const Stez: FC = () => {
   };
 
   const actionButtonCopy = () => {
-    if (!walletConnected) return "CONNECT WALLET";
-    if (
-      snapshot?.availability === "disabled" &&
-      network.network === NetworkType.MAINNET
-    ) {
-      return "sTEZ NOT ACTIVE ON MAINNET";
-    }
+    if (!walletConnected) return "CONNECT WALLET TO WEEKLYNET";
+    if (transactionStage === "requesting") return "CONFIRM IN WALLET";
+    if (transactionStage === "submitted") return "CONFIRMING ON WEEKLYNET";
+    if (transactionStage === "confirmed") return "CONFIRMED";
     if (
       activeAction === "Finalize" &&
       (!snapshot?.redeemedFinalizableMutez ||
@@ -249,13 +297,72 @@ export const Stez: FC = () => {
     if (available && activeAction !== "Finalize" && inputUnits <= ZERO) {
       return "ENTER AN AMOUNT";
     }
-    if (!TRANSACTION_SIGNING_ENABLED) {
-      return "TRANSACTIONS NOT ENABLED IN THIS PREVIEW";
-    }
     if (activeAction === "Stake") return "STAKE XTZ";
     if (activeAction === "Redeem") return "REDEEM sTEZ";
     return "FINALIZE AND CLAIM XTZ";
   };
+
+  const executeAction = useCallback(async () => {
+    if (!walletConnected) {
+      await connect();
+      return;
+    }
+    if (
+      !wallet.client ||
+      !wallet.address ||
+      !weeklynet ||
+      !snapshot?.contractHash
+    ) {
+      return;
+    }
+
+    setTransactionStage("requesting");
+    setTransactionMessage("Review and approve the operation in your wallet.");
+    setOperationHash("");
+
+    try {
+      const hash = await submitStezOperation(wallet.client, {
+        action: activeAction,
+        amountUnits: inputUnits,
+        contractHash: snapshot.contractHash,
+        redeemer: wallet.address,
+      });
+      setOperationHash(hash);
+      setTransactionStage("submitted");
+      setTransactionMessage(
+        "Operation submitted. Waiting for Weeklynet confirmation."
+      );
+      await waitForStezOperation(snapshot.endpoint, hash);
+      const refreshed = await loadStezSnapshot(weeklynet.info, wallet.address);
+      setSnapshot(refreshed);
+      setAmount("");
+      setTransactionStage("confirmed");
+      setTransactionMessage("Operation confirmed on Weeklynet.");
+    } catch (error) {
+      setTransactionStage("failed");
+      setTransactionMessage(readableStezError(error));
+    }
+  }, [
+    activeAction,
+    connect,
+    inputUnits,
+    snapshot,
+    wallet.address,
+    wallet.client,
+    walletConnected,
+    weeklynet,
+  ]);
+
+  const actionDisabled =
+    transactionStage === "requesting" ||
+    transactionStage === "submitted" ||
+    transactionStage === "confirmed" ||
+    (walletConnected &&
+      (!available ||
+        (activeAction === "Finalize"
+          ? !snapshot?.redeemedFinalizableMutez ||
+            snapshot.redeemedFinalizableMutez <= ZERO
+          : inputUnits <= ZERO)));
 
   return (
     <main className="stez-page">
@@ -288,15 +395,15 @@ export const Stez: FC = () => {
           <strong>{copy.title}</strong>
           <p>{copy.description}</p>
         </div>
-        {available && network.network === NetworkType.SHADOWNET && (
+        {weeklynet && (
           <a
             className="stez-availability__faucet-link"
-            href={SHADOWNET_FAUCET_URL}
+            href={weeklynet.faucetUrl}
             target="_blank"
             rel="noreferrer"
-            aria-label="Get Shadownet test XTZ from the official faucet"
+            aria-label="Get Weeklynet test XTZ from the official Teztnets faucet"
           >
-            GET SHADOWNET TEST XTZ
+            GET WEEKLYNET TEST XTZ
             <ArrowOutwardRoundedIcon aria-hidden="true" />
           </a>
         )}
@@ -402,6 +509,9 @@ export const Stez: FC = () => {
                     onClick={() => {
                       setActiveAction(action);
                       setAmount("");
+                      setTransactionStage("idle");
+                      setTransactionMessage("");
+                      setOperationHash("");
                     }}
                   >
                     {action}
@@ -467,6 +577,9 @@ export const Stez: FC = () => {
                       onChange={(event) => {
                         if (/^\d*(?:\.\d{0,6})?$/.test(event.target.value)) {
                           setAmount(event.target.value);
+                          setTransactionStage("idle");
+                          setTransactionMessage("");
+                          setOperationHash("");
                         }
                       }}
                     />
@@ -512,11 +625,27 @@ export const Stez: FC = () => {
             <button
               type="button"
               className="stez-primary-action"
-              disabled={walletConnected}
-              onClick={walletConnected ? undefined : connect}
+              disabled={actionDisabled}
+              aria-busy={
+                transactionStage === "requesting" ||
+                transactionStage === "submitted"
+              }
+              onClick={executeAction}
             >
               {actionButtonCopy()}
             </button>
+
+            {transactionStage !== "idle" && (
+              <div
+                className={`stez-transaction-status is-${transactionStage}`}
+                role={transactionStage === "failed" ? "alert" : "status"}
+              >
+                <span>{transactionMessage}</span>
+                {operationHash && (
+                  <code>{shortAddress(operationHash, 12, 8)}</code>
+                )}
+              </div>
+            )}
 
             <div className="stez-action-explanation">
               <InfoOutlinedIcon aria-hidden="true" />
@@ -590,7 +719,7 @@ export const Stez: FC = () => {
               <dt>Network / chain ID</dt>
               <dd>
                 {selectedNetwork} ·{" "}
-                {shortAddress(snapshot?.chainId || network.info.chainId, 10, 6)}
+                {shortAddress(snapshot?.chainId || weeklynet?.chainId, 10, 6)}
               </dd>
               <dt>Protocol</dt>
               <dd>

--- a/V2/tezex/src/pages/Stez/network.test.ts
+++ b/V2/tezex/src/pages/Stez/network.test.ts
@@ -1,0 +1,80 @@
+import {
+  isWeeklynetAccount,
+  resolveCurrentWeeklynet,
+  TEZTNETS_DIRECTORY_URL,
+} from "./network";
+
+const response = (body: unknown, status = 200) =>
+  Promise.resolve(
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    })
+  );
+
+beforeEach(() => window.localStorage.clear());
+afterEach(() => jest.restoreAllMocks());
+
+test("resolves the newest rotating Weeklynet and its matching faucet", async () => {
+  jest.spyOn(global, "fetch").mockImplementation((input) => {
+    const url = String(input);
+    if (url === TEZTNETS_DIRECTORY_URL) {
+      return response({
+        "weeklynet-2026-07-29": {
+          human_name: "Weeklynet",
+          activated_on: "2026-07-29",
+          rpc_url: "https://rpc.old.example",
+          faucet_url: "https://faucet.old.example",
+        },
+        "weeklynet-2026-08-05": {
+          human_name: "Weeklynet",
+          activated_on: "2026-08-05",
+          rpc_url: "https://rpc.current.example/",
+          faucet_url: "https://faucet.current.example/",
+        },
+      });
+    }
+    if (url === "https://rpc.current.example/chains/main/chain_id") {
+      return response("NetXmT6tP86uFqw");
+    }
+    throw new Error(`Unexpected URL: ${url}`);
+  });
+
+  const network = await resolveCurrentWeeklynet();
+
+  expect(network.key).toBe("weeklynet-2026-08-05");
+  expect(network.rpcUrl).toBe("https://rpc.current.example");
+  expect(network.faucetUrl).toBe("https://faucet.current.example");
+  expect(network.chainId).toBe("NetXmT6tP86uFqw");
+});
+
+test("recognizes only a wallet permission for the resolved Weeklynet RPC", () => {
+  const network = {
+    key: "weeklynet-2026-08-05",
+    name: "Weeklynet" as const,
+    rpcUrl: "https://rpc.current.example",
+    faucetUrl: "https://faucet.current.example",
+    chainId: "NetXTest",
+    activatedOn: "2026-08-05",
+    info: {
+      tezosServer: "https://rpc.current.example",
+      rpcFallbacks: [],
+      chainId: "NetXTest",
+      pools: [],
+      assets: [],
+    },
+  };
+
+  expect(
+    isWeeklynetAccount(
+      { network: { type: "custom", rpcUrl: "https://rpc.current.example/" } },
+      network
+    )
+  ).toBe(true);
+  expect(
+    isWeeklynetAccount(
+      { network: { type: "custom", rpcUrl: "https://rpc.old.example" } },
+      network
+    )
+  ).toBe(false);
+});

--- a/V2/tezex/src/pages/Stez/network.ts
+++ b/V2/tezex/src/pages/Stez/network.ts
@@ -1,0 +1,136 @@
+import { NetworkInfo } from "../../contexts/network";
+
+export const TEZTNETS_DIRECTORY_URL = "https://teztnets.com/teztnets.json";
+
+const WEEKLYNET_CACHE_KEY = "tezex:weeklynet";
+
+interface TeztnetDirectoryEntry {
+  activated_on?: string;
+  faucet_url?: string;
+  human_name?: string;
+  rpc_url?: string;
+}
+
+type TeztnetDirectory = Record<string, TeztnetDirectoryEntry>;
+
+interface CachedWeeklynet {
+  key: string;
+  rpcUrl: string;
+  faucetUrl: string;
+  chainId: string;
+  activatedOn: string;
+  resolvedAt: number;
+}
+
+export interface WeeklynetNetwork {
+  key: string;
+  name: "Weeklynet";
+  rpcUrl: string;
+  faucetUrl: string;
+  chainId: string;
+  activatedOn: string;
+  info: NetworkInfo;
+}
+
+const normalizeEndpoint = (endpoint: string) => endpoint.replace(/\/+$/, "");
+
+const readJson = async <T>(url: string, signal?: AbortSignal): Promise<T> => {
+  const response = await fetch(url, {
+    signal,
+    headers: { Accept: "application/json" },
+  });
+  if (!response.ok) {
+    throw new Error(`Request failed (${response.status})`);
+  }
+  return (await response.json()) as T;
+};
+
+const mostRecentWeeklynet = (directory: TeztnetDirectory) => {
+  const candidates = Object.entries(directory)
+    .filter(([, entry]) => entry.human_name === "Weeklynet")
+    .filter(([, entry]) => Boolean(entry.rpc_url && entry.faucet_url))
+    .sort(([, a], [, b]) =>
+      String(b.activated_on ?? "").localeCompare(String(a.activated_on ?? ""))
+    );
+
+  if (!candidates.length) {
+    throw new Error("The Teztnets directory does not list an active Weeklynet");
+  }
+
+  return candidates[0];
+};
+
+const toWeeklynet = (cached: CachedWeeklynet): WeeklynetNetwork => ({
+  key: cached.key,
+  name: "Weeklynet",
+  rpcUrl: cached.rpcUrl,
+  faucetUrl: cached.faucetUrl,
+  chainId: cached.chainId,
+  activatedOn: cached.activatedOn,
+  info: {
+    tezosServer: cached.rpcUrl,
+    rpcFallbacks: [],
+    chainId: cached.chainId,
+    pools: [],
+    assets: [],
+  },
+});
+
+const readCachedWeeklynet = (): CachedWeeklynet | null => {
+  try {
+    const value = window.localStorage.getItem(WEEKLYNET_CACHE_KEY);
+    if (!value) return null;
+    const parsed = JSON.parse(value) as CachedWeeklynet;
+    return parsed.rpcUrl && parsed.faucetUrl && parsed.chainId ? parsed : null;
+  } catch {
+    return null;
+  }
+};
+
+const writeCachedWeeklynet = (network: CachedWeeklynet) => {
+  try {
+    window.localStorage.setItem(WEEKLYNET_CACHE_KEY, JSON.stringify(network));
+  } catch {
+    // Weeklynet discovery still works when storage is blocked.
+  }
+};
+
+export const resolveCurrentWeeklynet = async (
+  signal?: AbortSignal
+): Promise<WeeklynetNetwork> => {
+  try {
+    const directory = await readJson<TeztnetDirectory>(
+      TEZTNETS_DIRECTORY_URL,
+      signal
+    );
+    const [key, entry] = mostRecentWeeklynet(directory);
+    const rpcUrl = normalizeEndpoint(entry.rpc_url as string);
+    const chainId = await readJson<string>(
+      `${rpcUrl}/chains/main/chain_id`,
+      signal
+    );
+    const resolved: CachedWeeklynet = {
+      key,
+      rpcUrl,
+      faucetUrl: normalizeEndpoint(entry.faucet_url as string),
+      chainId,
+      activatedOn: entry.activated_on ?? key.replace("weeklynet-", ""),
+      resolvedAt: Date.now(),
+    };
+    writeCachedWeeklynet(resolved);
+    return toWeeklynet(resolved);
+  } catch (error) {
+    if (signal?.aborted) throw error;
+    const cached = readCachedWeeklynet();
+    if (cached) return toWeeklynet(cached);
+    throw error;
+  }
+};
+
+export const isWeeklynetAccount = (
+  account: { network?: { type?: string; rpcUrl?: string } } | null | undefined,
+  network: WeeklynetNetwork
+) =>
+  account?.network?.type === "custom" &&
+  normalizeEndpoint(account.network.rpcUrl ?? "") ===
+    normalizeEndpoint(network.rpcUrl);

--- a/V2/tezex/src/pages/Stez/rpc.test.ts
+++ b/V2/tezex/src/pages/Stez/rpc.test.ts
@@ -73,6 +73,15 @@ describe("sTEZ RPC adapter", () => {
         return response({ level: 456, timestamp: "2026-07-30T12:00:00Z" });
       }
       if (url.endsWith("/stez/contract_hash")) return response("KT1Native");
+      if (url.endsWith("/contracts/KT1Native/entrypoints")) {
+        return response({
+          entrypoints: {
+            deposit: { prim: "unit" },
+            redeem: { prim: "nat" },
+            finalize_redeem: { prim: "key_hash" },
+          },
+        });
+      }
       if (url.endsWith("/stez/total_supply")) return response("1000000000");
       if (url.endsWith("/stez/total_amount_of_tez")) {
         return response("1040000000");
@@ -102,6 +111,30 @@ describe("sTEZ RPC adapter", () => {
         .filter((url) => url.includes("/blocks/") && !url.includes("/head/"))
         .every((url) => url.includes("/blocks/BFixedHash/"))
     ).toBe(true);
+  });
+
+  it("rejects a detected contract when its transaction interface changes", async () => {
+    jest.spyOn(global, "fetch").mockImplementation((input) => {
+      const url = String(input);
+      if (url.endsWith("/chain_id")) return response("NetXTest");
+      if (url.endsWith("/head/hash")) return response("BFixedHash");
+      if (url.endsWith("/protocols")) {
+        return response({ protocol: "ProtoAlpha" });
+      }
+      if (url.endsWith("/header")) {
+        return response({ level: 456, timestamp: "2026-08-10T12:00:00Z" });
+      }
+      if (url.endsWith("/stez/contract_hash")) return response("KT1Native");
+      if (url.endsWith("/contracts/KT1Native/entrypoints")) {
+        return response({ entrypoints: { deposit: { prim: "unit" } } });
+      }
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+
+    const snapshot = await loadStezSnapshot(network);
+
+    expect(snapshot.availability).toBe("unsupported");
+    expect(snapshot.contractHash).toBeNull();
   });
 
   it("quotes deposit and redemption using integer floor math", () => {

--- a/V2/tezex/src/pages/Stez/rpc.ts
+++ b/V2/tezex/src/pages/Stez/rpc.ts
@@ -60,6 +60,13 @@ interface ExchangeRate {
   denominator: string | number;
 }
 
+interface ContractEntrypoints {
+  entrypoints?: Record<
+    string,
+    { prim?: string; args?: unknown[]; annots?: string[] }
+  >;
+}
+
 const normalizeEndpoint = (endpoint: string) => endpoint.replace(/\/+$/, "");
 
 const endpointsFor = (info: NetworkInfo) =>
@@ -108,6 +115,15 @@ const isFeatureDisabled = (error: unknown) =>
 const toBigInt = (value: string | number | bigint): bigint => {
   if (typeof value === "bigint") return value;
   return BigInt(String(value));
+};
+
+const hasCompatibleTransactionEntrypoints = (response: ContractEntrypoints) => {
+  const entrypoints = response.entrypoints;
+  return (
+    entrypoints?.deposit?.prim === "unit" &&
+    entrypoints?.redeem?.prim === "nat" &&
+    entrypoints?.finalize_redeem?.prim === "key_hash"
+  );
 };
 
 const unavailableSnapshot = (
@@ -235,15 +251,20 @@ export async function loadStezSnapshot(
     );
   }
 
-  if (metadata.protocolHash !== USHUAIA_PROTOCOL) {
-    return unavailableSnapshot(
-      "unsupported",
-      metadata,
-      "sTEZ was detected, but this protocol revision has not yet passed TEZEX compatibility checks."
-    );
-  }
-
   try {
+    const entrypoints = await fetchRpc<ContractEntrypoints>(
+      metadata.endpoint,
+      `${contextPath}/contracts/${contractHash}/entrypoints`,
+      signal
+    );
+    if (!hasCompatibleTransactionEntrypoints(entrypoints)) {
+      return unavailableSnapshot(
+        "unsupported",
+        metadata,
+        "The detected sTEZ contract does not expose the transaction interface required by TEZEX."
+      );
+    }
+
     const accountPath = walletAddress
       ? `${contextPath}/contracts/${walletAddress}`
       : null;
@@ -333,3 +354,39 @@ export const quoteStezRedeem = (
 ) => (tokenUnits * numeratorMutez) / denominatorUnits;
 
 export const stezUnderlyingValue = quoteStezRedeem;
+
+const pause = (milliseconds: number) =>
+  new Promise((resolve) => window.setTimeout(resolve, milliseconds));
+
+export async function waitForStezOperation(
+  endpoint: string,
+  operationHash: string,
+  attempts = 30
+) {
+  const normalized = normalizeEndpoint(endpoint);
+
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    const recentBlocks = await Promise.all(
+      [0, 1, 2].map(async (depth) => {
+        try {
+          return await fetchRpc<string[][]>(
+            normalized,
+            `/chains/main/blocks/head~${depth}/operation_hashes`
+          );
+        } catch {
+          return [];
+        }
+      })
+    );
+
+    if (recentBlocks.some((passes) => passes.flat().includes(operationHash))) {
+      return;
+    }
+
+    if (attempt < attempts - 1) await pause(4_000);
+  }
+
+  throw new Error(
+    "The operation was submitted, but confirmation has not appeared on Weeklynet yet."
+  );
+}

--- a/V2/tezex/src/pages/Stez/style.css
+++ b/V2/tezex/src/pages/Stez/style.css
@@ -505,6 +505,37 @@
   cursor: default;
 }
 
+.stez-transaction-status {
+  margin-top: 10px;
+  padding: 10px 12px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  color: var(--tezex-muted);
+  background: var(--tezex-panel-subtle);
+  border: 1px solid var(--tezex-line-soft);
+  border-radius: 12px;
+  font-size: 10px;
+  line-height: 1.45;
+}
+
+.stez-transaction-status.is-confirmed {
+  color: var(--tezex-positive);
+}
+
+.stez-transaction-status.is-failed {
+  color: var(--tezex-text-secondary);
+  border-color: var(--tezex-line-strong);
+}
+
+.stez-transaction-status code {
+  flex-shrink: 0;
+  color: inherit;
+  font-family: "Red Hat Mono", monospace;
+  font-size: 9px;
+}
+
 .stez-action-explanation {
   margin-top: 14px;
   display: grid;

--- a/V2/tezex/src/pages/Stez/transactions.test.ts
+++ b/V2/tezex/src/pages/Stez/transactions.test.ts
@@ -1,0 +1,68 @@
+import { TezosOperationType } from "@airgap/beacon-sdk";
+
+import { buildStezOperation } from "./transactions";
+
+const contractHash = "KT1WCsbJx996ebZfutAitHYsZ8FUZFsTdaD7";
+const redeemer = "tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb";
+
+test("encodes an exact-mutez sTEZ deposit", () => {
+  expect(
+    buildStezOperation({
+      action: "Stake",
+      amountUnits: BigInt(1_500_000),
+      contractHash,
+      redeemer,
+    })
+  ).toEqual({
+    kind: TezosOperationType.TRANSACTION,
+    destination: contractHash,
+    amount: "1500000",
+    parameters: { entrypoint: "deposit", value: { prim: "Unit" } },
+  });
+});
+
+test("encodes sTEZ redemption in token units", () => {
+  expect(
+    buildStezOperation({
+      action: "Redeem",
+      amountUnits: BigInt(900_001),
+      contractHash,
+      redeemer,
+    })
+  ).toEqual({
+    kind: TezosOperationType.TRANSACTION,
+    destination: contractHash,
+    amount: "0",
+    parameters: { entrypoint: "redeem", value: { int: "900001" } },
+  });
+});
+
+test("encodes finalization for the connected implicit account", () => {
+  expect(
+    buildStezOperation({
+      action: "Finalize",
+      amountUnits: BigInt(0),
+      contractHash,
+      redeemer,
+    })
+  ).toEqual({
+    kind: TezosOperationType.TRANSACTION,
+    destination: contractHash,
+    amount: "0",
+    parameters: {
+      entrypoint: "finalize_redeem",
+      value: { string: redeemer },
+    },
+  });
+});
+
+test("rejects non-positive stake and redeem requests", () => {
+  expect(() =>
+    buildStezOperation({
+      action: "Stake",
+      amountUnits: BigInt(0),
+      contractHash,
+      redeemer,
+    })
+  ).toThrow("Enter an amount greater than zero");
+});

--- a/V2/tezex/src/pages/Stez/transactions.ts
+++ b/V2/tezex/src/pages/Stez/transactions.ts
@@ -1,0 +1,81 @@
+import {
+  DAppClient,
+  PartialTezosTransactionOperation,
+  TezosOperationType,
+} from "@airgap/beacon-sdk";
+
+export type StezTransactionAction = "Stake" | "Redeem" | "Finalize";
+
+interface BuildStezOperationOptions {
+  action: StezTransactionAction;
+  amountUnits: bigint;
+  contractHash: string;
+  redeemer: string;
+}
+
+export const buildStezOperation = ({
+  action,
+  amountUnits,
+  contractHash,
+  redeemer,
+}: BuildStezOperationOptions): PartialTezosTransactionOperation => {
+  if (!contractHash.startsWith("KT1")) {
+    throw new Error("The native sTEZ contract could not be verified");
+  }
+
+  if (action !== "Finalize" && amountUnits <= BigInt(0)) {
+    throw new Error("Enter an amount greater than zero");
+  }
+
+  if (action === "Stake") {
+    return {
+      kind: TezosOperationType.TRANSACTION,
+      destination: contractHash,
+      amount: amountUnits.toString(),
+      parameters: { entrypoint: "deposit", value: { prim: "Unit" } },
+    };
+  }
+
+  if (action === "Redeem") {
+    return {
+      kind: TezosOperationType.TRANSACTION,
+      destination: contractHash,
+      amount: "0",
+      parameters: {
+        entrypoint: "redeem",
+        value: { int: amountUnits.toString() },
+      },
+    };
+  }
+
+  if (!/^tz[1-4][1-9A-HJ-NP-Za-km-z]{33}$/.test(redeemer)) {
+    throw new Error("A valid implicit Tezos account is required to finalize");
+  }
+
+  return {
+    kind: TezosOperationType.TRANSACTION,
+    destination: contractHash,
+    amount: "0",
+    parameters: {
+      entrypoint: "finalize_redeem",
+      value: { string: redeemer },
+    },
+  };
+};
+
+export const submitStezOperation = async (
+  client: DAppClient,
+  options: BuildStezOperationOptions
+) => {
+  const operation = buildStezOperation(options);
+  const response = await client.requestOperation({
+    operationDetails: [operation],
+  });
+  return response.transactionHash;
+};
+
+export const readableStezError = (error: unknown) => {
+  if (error instanceof Error && error.message) return error.message;
+  if (typeof error === "string") return error;
+  return "The operation was not submitted. Review the request in your wallet and try again.";
+};


### PR DESCRIPTION
## What changed
- resolves the current rotating Weeklynet from the official Teztnets directory
- connects Beacon wallets to that exact custom network
- enables live stake, redeem, and finalize operations after verifying the native contract interface
- links to the matching Weeklynet test-XTZ faucet
- shows live block, rate, position, and confirmation state

## Safety
- validates the current chain, native contract, and required entrypoints before enabling transactions
- uses exact integer token and mutez units
- never substitutes simulated balances, rates, or returns

## Verification
- TypeScript type-check passed
- 28 test suites passed (104 tests)
- optimized production build passed
- desktop and mobile browser verification passed against the current Weeklynet RPC