### PR TITLE
Add generic FA1.2/FA2 token-to-token pool core

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# LIGO emits an intentional blank line after generated Michelson scripts.
+dex/compiled_contracts/*.tz -whitespace

--- a/.github/workflows/token-token-pool-ci.yml
+++ b/.github/workflows/token-token-pool-ci.yml
@@ -1,0 +1,72 @@
+name: Token-to-token pool CI
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/token-token-pool-ci.yml"
+      - "dex/contracts/token_token_pool.mligo"
+      - "dex/contracts/lqt_fa12.mligo"
+      - "dex/compiled_contracts/token_token_pool.tz"
+      - "dex/compiled_contracts/lqt.tz"
+      - "dex/tests/token_token_pool.test.mligo"
+      - "dex/scripts/**"
+      - "dex/TOKEN_TOKEN_POOL*.md"
+  push:
+    branches:
+      - trunk
+    paths:
+      - ".github/workflows/token-token-pool-ci.yml"
+      - "dex/contracts/token_token_pool.mligo"
+      - "dex/contracts/lqt_fa12.mligo"
+      - "dex/compiled_contracts/token_token_pool.tz"
+      - "dex/compiled_contracts/lqt.tz"
+      - "dex/tests/token_token_pool.test.mligo"
+      - "dex/scripts/**"
+      - "dex/TOKEN_TOKEN_POOL*.md"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: token-token-pool-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Reproduce Michelson artifact
+        run: |
+          docker run --rm -v "$PWD:/project" -w /project ligolang/ligo:1.11.5 \
+            compile contract dex/contracts/token_token_pool.mligo \
+            -m TokenTokenPool --no-warn > /tmp/token_token_pool.tz
+          cmp /tmp/token_token_pool.tz dex/compiled_contracts/token_token_pool.tz
+          echo "a7939ae6ee629057d6dca4301a9be8485b19d72efebcdf172cbd4a3a0e48957e  /tmp/token_token_pool.tz" \
+            | sha256sum --check --strict
+
+      - name: Run LIGO tests
+        run: |
+          docker run --rm -v "$PWD:/project" -w /project ligolang/ligo:1.11.5 \
+            run test dex/tests/token_token_pool.test.mligo --no-warn
+
+  deployment-tooling:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: dex/scripts
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: dex/scripts/package-lock.json
+
+      - run: npm ci --ignore-scripts
+      - run: npm run typecheck
+      - run: npm test

--- a/dex/README.md
+++ b/dex/README.md
@@ -1,5 +1,11 @@
 # Dexter v2 DEX
 
+## Token-to-token pool
+
+The generic FA1.2/FA2 single-pair review candidate is documented in [TOKEN_TOKEN_POOL.md](./TOKEN_TOKEN_POOL.md). Its internal security assessment and residual launch gates are in [TOKEN_TOKEN_POOL_SECURITY_REVIEW.md](./TOKEN_TOKEN_POOL_SECURITY_REVIEW.md), with upstream lineage and design differences recorded in [TOKEN_TOKEN_POOL_PROVENANCE.md](./TOKEN_TOKEN_POOL_PROVENANCE.md).
+
+This pool is separate from the native-XTZ Dexter contracts described below. It uses the repository's external FA1.2 LQT, immutable 25 bp LP and 5 bp protocol fees, and contains no hardcoded asset, manager, or fee-recipient address. Its deployment tooling is limited to Previewnet/testnet pending independent review.
+
 Decentralized Exchange (DEX) implementation for Tezos blockchain based on Dexter v2 contracts updated to latest Ligo v1.11.5
 
 ## Project Structure

--- a/dex/TOKEN_TOKEN_POOL.md
+++ b/dex/TOKEN_TOKEN_POOL.md
@@ -1,0 +1,128 @@
+# Token-to-token pool
+
+This package is a generic single-pair constant-product pool for FA1.2 and FA2 assets. One compiled pool artifact supports FA1.2/FA1.2, FA2/FA2, or mixed pairs; the two asset descriptors are immutable origination storage.
+
+It is a review candidate, not a mainnet deployment authorization. The supplied deployment command accepts only Previewnet or testnet.
+
+## Components
+
+- `contracts/token_token_pool.mligo`: pool accounting and custody operations.
+- `contracts/lqt_fa12.mligo`: existing external FA1.2 liquidity token; the pool is its administrator.
+- `tests/token_token_pool.test.mligo`: lifecycle, economics, pair-shape, failure, and adversarial tests.
+- `scripts/src/deploy-token-token.ts`: pinned, resumable non-mainnet origination workflow.
+- `compiled_contracts/token_token_pool.tz`: reproducible Michelson artifact.
+
+The external LQT design preserves the repository's established liquidity-token interface. The pool links an empty LQT contract exactly once before activation. Initialization then mints 1,000 LQT units permanently to the pool and the remaining initial supply to the configured seed receiver.
+
+## Economics
+
+The fee schedule has no setter:
+
+- 25 basis points remain in the tradable reserve for liquidity providers;
+- 5 basis points accrue in a separate per-asset protocol-fee counter; and
+- total swap charge is 30 basis points.
+
+For input `x`, input reserve `Rin`, and output reserve `Rout`:
+
+```text
+weighted input = x * 9,970
+output = weighted input * Rout / (Rin * 10,000 + weighted input)
+protocol fee = floor(x * 5 / 10,000)
+reserve input = x - protocol fee
+```
+
+All arithmetic uses natural numbers. Checked subtraction rejects underflow, output rounds down, and the test suite requires the reserve product not to decrease after completed swaps.
+
+Initial LQT supply is `floor(sqrt(seed A * seed B))`, computed with integer Newton iteration. This avoids decimal assumptions and supports assets with different precisions. The result must exceed the permanent 1,000-unit LQT lock.
+
+## Lifecycle and controls
+
+The pool originates inactive with no LQT address. The temporary manager must link one LQT contract and initialize once. Thereafter:
+
+- deadlines and caller-supplied minimums/maximums protect swaps and liquidity actions;
+- a reentrancy guard remains active until a self-only final operation closes the action;
+- pause blocks initialization, additions, and swaps, but not liquidity removal or fee claims;
+- manager and protocol-fee-recipient changes each require proposal and acceptance and can be canceled; and
+- fee claims are permissionless, but always pay the configured recipient.
+
+Protocol fees are excluded from swap reserves. Direct token transfers to the pool are surplus and do not alter reserves or issue LQT. There is intentionally no reserve sync or rescue entrypoint.
+
+## Token compatibility boundary
+
+The pool issues standard FA1.2 or FA2 transfer operations and relies on normal Tezos atomic rollback. It does not attempt to prove arbitrary token behavior with callbacks.
+
+Every production asset must be allowlisted by exact contract address, FA2 token ID where applicable, and reviewed script-code hash. The deployment tool verifies these hashes and required entrypoints before origination. Compatible assets must:
+
+- debit and credit exactly the requested amount;
+- execute transfers synchronously and atomically;
+- have no transfer tax, rebasing, reflection, blacklist, or administrator balance-seizure behavior that breaks reserve accounting;
+- preserve the reviewed transfer and authorization semantics; and
+- for FA1.2, safely support zero-then-set allowance changes; or, for FA2, standard add/remove operator calls.
+
+Code-hash verification detects deployment against an unreviewed implementation; it does not make an unsafe implementation compatible. Administrative controls, upgrade paths, metadata, token IDs, and ledger behavior still require human review.
+
+## Build and test
+
+Use LIGO 1.11.5:
+
+```sh
+ligo compile contract dex/contracts/token_token_pool.mligo \
+  -m TokenTokenPool --no-warn \
+  -o dex/compiled_contracts/token_token_pool.tz
+
+ligo run test dex/tests/token_token_pool.test.mligo --no-warn
+```
+
+The checked-in pool artifact SHA-256 is:
+
+```text
+a7939ae6ee629057d6dca4301a9be8485b19d72efebcdf172cbd4a3a0e48957e
+```
+
+CI recompiles the source with the pinned compiler, byte-compares the output, checks this digest, runs the LIGO suite, and validates the TypeScript deployment tooling.
+
+## Non-mainnet deployment rehearsal
+
+From `dex/scripts`:
+
+```sh
+npm ci --ignore-scripts
+npm run typecheck
+npm test
+npm run deploy:token-token:previewnet
+```
+
+Configuration is documented in `.env.example`. It contains no live addresses. Before submitting any operation, the deployment workflow verifies the RPC chain ID, exact pool artifact digest, both selected token code hashes, and required token entrypoints.
+
+Generate a deterministic token code hash and list its entrypoints without signing or changing chain state:
+
+```sh
+npm run inspect:token -- --rpc=<RPC_URL> --address=<TOKEN_CONTRACT>
+```
+
+The inspector and deployer share a canonical JSON hash implementation, so equivalent RPC object-key ordering produces the same digest. Hash identity is only the first step; reviewers must still assess the printed contract's code and controls.
+
+The workflow is resumable and records confirmed steps in a gitignored mode-0600 JSON file. It:
+
+1. originates the inactive pool;
+2. originates an empty LQT with the pool as administrator;
+3. links LQT once;
+4. batches temporary token authorization, initialization, and authorization cleanup atomically;
+5. proposes the configured final manager;
+6. verifies source/artifact identity, pool and LQT state, metadata pointers, seed balances, reserve solvency, minimum LQT lock, and pending handoff.
+
+The receipt never contains the private key. The proposed manager must separately call `%accept_manager`; that acceptance is intentionally not automated with the deployer's authority.
+
+## Mainnet gates
+
+Mainnet support is intentionally absent from this workflow. Adding it should be a later reviewed change only after:
+
+- independent review of the final source and compiled Michelson;
+- reproduction of both pool and LQT artifacts;
+- exact selected-token code and administrative-control review;
+- complete Previewnet/testnet rehearsal of both swap directions, add/remove liquidity, fee claims, pause, failed slippage/deadline calls, and manager acceptance;
+- front-end/router integration using explicit pool allowlisting and on-chain fee views;
+- operational monitoring that compares held balances with `reserve + protocol fees`; and
+- confirmation of final metadata, fee recipient, manager, and seed plan outside source control.
+
+See `TOKEN_TOKEN_POOL_SECURITY_REVIEW.md` for the internal assessment and `TOKEN_TOKEN_POOL_PROVENANCE.md` for upstream lineage and deliberate differences.

--- a/dex/TOKEN_TOKEN_POOL_PROVENANCE.md
+++ b/dex/TOKEN_TOKEN_POOL_PROVENANCE.md
@@ -1,0 +1,32 @@
+# Token-to-token pool provenance and design delta
+
+The implementation was informed by two public QuipuSwap code lines pinned for stable review references:
+
+- TTDex commit `41fd4293029e2094a564141fb389fd9a1ef19185`.
+- QuipuSwap Core V2 commit `684f17d42293034764fd2ff70ce1075b912406da`.
+
+The TEZEX contract is a standalone CameLIGO implementation, not a deployment of either full upstream system. It does not claim to inherit an upstream audit. Public audit material does not, by itself, establish which exact commit was reviewed or cover the changes below.
+
+## Retained concepts
+
+- one constant-product pair per pool deployment;
+- two-direction token swaps;
+- proportional liquidity mint/burn;
+- token-standard-specific transfer wrappers;
+- permanently locked minimum liquidity; and
+- external liquidity-token administration by the pool.
+
+## Material TEZEX changes
+
+| Area | TEZEX decision |
+| --- | --- |
+| Asset support | One artifact accepts immutable FA1.2 or FA2 descriptors in any pair combination. |
+| Fees | Fixed 25 bp LP plus 5 bp protocol accounting, with no fee setter. |
+| Protocol fees | Separate per-asset counters and a two-step recipient handoff. |
+| Lifecycle | Inactive origination, one-time external-LQT link, and one-time manager initialization. |
+| Reentrancy | Explicit action guard closed only by a self-call after external operations. |
+| Administration | Pause that preserves exits; two-step/cancelable manager and recipient changes. |
+| Scope | No native tez, baker/reward system, auctions, referrals, flash loans, oracle, router, shared multi-pair custody, or reserve-sync/rescue authority. |
+| Deployment | Exact chain/artifact/token code pinning, resumable receipts, atomic seed authorization cleanup, post-deployment verification, and no mainnet mode. |
+
+Reviewers should assess the TEZEX source and compiled artifact on their own merits. The pinned upstream references are architectural context and comparison anchors, not a substitute for reviewing this implementation.

--- a/dex/TOKEN_TOKEN_POOL_SECURITY_REVIEW.md
+++ b/dex/TOKEN_TOKEN_POOL_SECURITY_REVIEW.md
@@ -1,0 +1,109 @@
+# Token-to-token pool internal security assessment
+
+Scope: pool source and artifact, external LQT integration, tests, configuration parser, storage encoder, and non-mainnet deployment workflow.
+
+Compiler: LIGO 1.11.5.
+
+This is a repository self-assessment, not an independent audit and not a mainnet readiness statement. Public reviews of related upstream contracts do not transfer to this implementation or prove that any particular upstream commit was audited.
+
+## Resolved design risks
+
+| ID | Risk | Treatment |
+| --- | --- | --- |
+| TT-01 | Fee policy changes after users provide liquidity. | LP fee is fixed at 25 bp and protocol fee at 5 bp; no fee setter exists. |
+| TT-02 | Protocol fees become tradable reserves or are claimed twice. | Per-asset fee counters remain outside reserves and are zeroed before the transfer operation is emitted; Tezos rollback restores state on failure. |
+| TT-03 | Rounding or subtraction creates value or wraps underflow. | Output rounds down and every subtraction uses `is_nat`; tests assert nondecreasing reserve product. |
+| TT-04 | The last provider drains the pool to an unusable state. | Initialization mints 1,000 LQT to the pool itself and removal may not reduce supply below that lock. |
+| TT-05 | Pool and external LQT supply drift. | Only the pool administers LQT mint/burn, and each pool action updates reserve/LQT accounting in the same Tezos transaction. Tests compare both totals. |
+| TT-06 | A token contract reenters while accounting is staged. | User actions set `entered = true` before external operations and finish with authenticated self-only `%close`; an adversarial callback test verifies complete rollback. |
+| TT-07 | Emergency pause traps providers. | Pause blocks risk-increasing actions but leaves removal and fee claims available. |
+| TT-08 | A mistaken one-step control transfer loses administration. | Manager and fee-recipient changes are two-step, cancelable handoffs. |
+| TT-09 | Deployment uses the wrong chain, artifact, or token implementation. | Tooling pins chain ID, artifact SHA-256, token script-code SHA-256, and required interfaces before origination. |
+| TT-10 | Interrupted setup leaves operators/allowances unnecessarily active. | Seed authorization, initialization, and cleanup are one atomic batch; the deployment receipt supports resuming confirmed prior steps. |
+| TT-11 | Mainnet is run before review and rehearsal. | Token-to-token scripts expose Previewnet/testnet only; no mainnet command or confirmation bypass exists. |
+
+## Accounting invariants
+
+For each asset after a successful action:
+
+```text
+held balance >= reserve + accrued protocol fee
+```
+
+Equality is expected unless someone directly donated tokens. Donations never change reserves.
+
+For a completed swap:
+
+```text
+new reserve A * new reserve B >= old reserve A * old reserve B
+```
+
+For LQT:
+
+```text
+pool.lqt_total = lqt.total_supply
+lqt.total_supply >= 1,000 after initialization
+lqt.balance(pool) = 1,000 immediately after initialization
+```
+
+For the action guard:
+
+```text
+entered = true  => public state-mutating entrypoints reject
+%close caller != self => reject
+successful external-operation sequence => entered = false
+failed sequence => the entire Tezos transaction rolls back
+```
+
+## Test coverage
+
+The LIGO suite exercises:
+
+- mixed FA2/FA1.2 initialization and independent FA2/FA2 and FA1.2/FA1.2 initialization using the same artifact;
+- integer geometric-mean initial supply and permanent LQT lock;
+- one-time initialization and immutable LQT link;
+- proportional additions/removals and LQT supply synchronization;
+- both swap directions, fee rounding, reserve product, and solvency;
+- expired and excessive-minimum-output rejections before transfers;
+- direct donations as non-reserve surplus;
+- permissionless fee claims paying only the configured recipient;
+- pause behavior and two-step/cancelable administration;
+- nonpayable and unauthorized calls;
+- immutable fee/quote views; and
+- hostile token callback reentrancy with whole-transaction rollback.
+
+The TypeScript suite tests arbitrary-precision math, all supported asset combinations, identical/ambiguous descriptor rejection, same-contract distinct FA2 IDs, immutable IPFS URI requirements, artifact digest validation, storage schema encoding, and absence of a mainnet mode.
+
+Independent recompilation in the pinned LIGO 1.11.5 container produced a byte-identical pool artifact with SHA-256 `a7939ae6ee629057d6dca4301a9be8485b19d72efebcdf172cbd4a3a0e48957e`; `ligo info measure-contract` reports 9,189 bytes. The existing LQT source also reproduced its checked-in artifact (`2df971245f3d468ee2668e1ed48797852eedd280348c753e9f2cd1d1bdf23921`). The full pre-existing LQT and native-pool LIGO regression suites pass alongside the new pool suite. Type checking and all Node tests pass under Taquito 25, and `npm audit --omit=dev` reports zero known production-dependency vulnerabilities at assessment time.
+
+## Residual trust assumptions
+
+### Exact token behavior must be reviewed
+
+The pool cannot make an arbitrary token safe. A taxed, rebasing, upgradeable, malicious, callback-dependent, or administratively drainable asset can invalidate reserve assumptions. A matching code hash establishes identity, not quality. Each selected implementation and its current administrative state remain launch inputs requiring review.
+
+### Balance verification is operational, not per action
+
+To avoid callback liveness hazards, the contract uses strict atomic-transfer assumptions rather than an asynchronous before/after balance state machine. The deployment workflow verifies seed balances after initialization, and monitoring should continue checking solvency. This tradeoff is acceptable only for explicitly allowlisted token implementations.
+
+### External LQT remains part of the trusted system
+
+The pool relies on the repository's existing FA1.2 LQT `%mintOrBurn` semantics. Deploying a different implementation at the linked address could break liquidity operations. The deployer therefore originates the reviewed artifact itself, assigns the pool as administrator, links it once, and verifies both code and storage.
+
+### No oracle protection
+
+Reserve ratio is not a manipulation-resistant price oracle. It must not be used directly for collateral valuation or liquidation decisions. A separate oracle should have independent sources, freshness checks, and failure policy.
+
+### No rescue or reserve synchronization
+
+Direct donations can remain locked. The deliberate absence of rescue/sync authority avoids an administrator path that can mutate user-facing reserve economics, but it means operational mistakes may be unrecoverable.
+
+## Remaining launch blockers
+
+- Independent source and Michelson review.
+- Reproduction of the exact pool and LQT artifacts.
+- Review and allowlisting of the actual asset contracts and IDs.
+- Network rehearsal using the intended metadata, seed ratios, fee recipient, and final manager.
+- Indexer/wallet/router compatibility testing for the external FA1.2 LQT.
+- Front-end and monitoring integration.
+- A separately reviewed change if and when mainnet deployment support is desired.

--- a/dex/compiled_contracts/token_token_pool.tz
+++ b/dex/compiled_contracts/token_token_pool.tz
@@ -1,0 +1,1651 @@
+{ parameter
+    (or (unit %default)
+        (or (unit %close)
+            (or (unit %accept_protocol_fee_recipient)
+                (or (unit %cancel_protocol_fee_recipient)
+                    (or (address %propose_protocol_fee_recipient)
+                        (or (unit %accept_manager)
+                            (or (unit %cancel_manager_transfer)
+                                (or (address %propose_manager)
+                                    (or (bool %set_paused)
+                                        (or (or %claim_protocol_fee (unit %token_a) (unit %token_b))
+                                            (or (pair %swap
+                                                   (or %direction (unit %a_to_b) (unit %b_to_a))
+                                                   (pair (nat %amount_in)
+                                                         (pair (nat %min_amount_out) (pair (address %receiver) (timestamp %deadline)))))
+                                                (or (pair %remove_liquidity
+                                                       (nat %lqt_burned)
+                                                       (pair (nat %min_amount_a)
+                                                             (pair (nat %min_amount_b) (pair (address %receiver) (timestamp %deadline)))))
+                                                    (or (pair %add_liquidity
+                                                           (nat %max_amount_a)
+                                                           (pair (nat %max_amount_b)
+                                                                 (pair (nat %min_lqt_minted) (pair (address %receiver) (timestamp %deadline)))))
+                                                        (or (pair %initialize
+                                                               (nat %amount_a)
+                                                               (pair (nat %amount_b) (pair (address %receiver) (timestamp %deadline))))
+                                                            (address %set_lqt_address))))))))))))))) ;
+  storage
+    (pair (or %token_a (address %fa12) (pair %fa2 (address %token) (nat %id)))
+          (pair (or %token_b (address %fa12) (pair %fa2 (address %token) (nat %id)))
+                (pair (nat %reserve_a)
+                      (pair (nat %reserve_b)
+                            (pair (nat %protocol_fee_a)
+                                  (pair (nat %protocol_fee_b)
+                                        (pair (nat %lqt_total)
+                                              (pair (option %lqt_address address)
+                                                    (pair (bool %active)
+                                                          (pair (bool %paused)
+                                                                (pair (bool %entered)
+                                                                      (pair (address %manager)
+                                                                            (pair (option %pending_manager address)
+                                                                                  (pair (address %protocol_fee_recipient)
+                                                                                        (pair (option %pending_fee_recipient address) (big_map %metadata string bytes)))))))))))))))) ;
+  code { PUSH nat 10000 ;
+         PUSH nat 1000 ;
+         PUSH string "POOL_NOT_PENDING_MANAGER" ;
+         PUSH string "POOL_NOT_PENDING_FEE_RECIPIENT" ;
+         PUSH string "POOL_ALREADY_ACTIVE" ;
+         PUSH string "POOL_ZERO_AMOUNT" ;
+         PUSH string "POOL_ZERO_OUTPUT" ;
+         PUSH string "POOL_SLIPPAGE" ;
+         PUSH string "POOL_INSUFFICIENT_LIQUIDITY" ;
+         PUSH string "POOL_MINIMUM_LQT" ;
+         LAMBDA
+           unit
+           unit
+           { DROP ;
+             PUSH string "POOL_NON_PAYABLE" ;
+             PUSH mutez 0 ;
+             AMOUNT ;
+             COMPARE ;
+             EQ ;
+             IF { DROP } { FAILWITH } ;
+             UNIT } ;
+         LAMBDA
+           (pair (or address (pair address nat))
+                 (pair (or address (pair address nat))
+                       (pair nat
+                             (pair nat
+                                   (pair nat
+                                         (pair nat
+                                               (pair nat
+                                                     (pair (option address)
+                                                           (pair bool
+                                                                 (pair bool
+                                                                       (pair bool
+                                                                             (pair address
+                                                                                   (pair (option address) (pair address (pair (option address) (big_map string bytes))))))))))))))))
+           unit
+           { GET 21 ; IF { PUSH string "POOL_REENTRANCY" ; FAILWITH } {} ; UNIT } ;
+         LAMBDA
+           (pair (or address (pair address nat))
+                 (pair (or address (pair address nat))
+                       (pair nat
+                             (pair nat
+                                   (pair nat
+                                         (pair nat
+                                               (pair nat
+                                                     (pair (option address)
+                                                           (pair bool
+                                                                 (pair bool
+                                                                       (pair bool
+                                                                             (pair address
+                                                                                   (pair (option address) (pair address (pair (option address) (big_map string bytes))))))))))))))))
+           unit
+           { GET 23 ;
+             PUSH string "POOL_NOT_MANAGER" ;
+             SWAP ;
+             SENDER ;
+             COMPARE ;
+             EQ ;
+             IF { DROP } { FAILWITH } ;
+             UNIT } ;
+         LAMBDA
+           (pair (or address (pair address nat))
+                 (pair (or address (pair address nat))
+                       (pair nat
+                             (pair nat
+                                   (pair nat
+                                         (pair nat
+                                               (pair nat
+                                                     (pair (option address)
+                                                           (pair bool
+                                                                 (pair bool
+                                                                       (pair bool
+                                                                             (pair address
+                                                                                   (pair (option address) (pair address (pair (option address) (big_map string bytes))))))))))))))))
+           unit
+           { GET 19 ; IF { PUSH string "POOL_PAUSED" ; FAILWITH } {} ; UNIT } ;
+         LAMBDA
+           (pair nat
+                 (pair (or address (pair address nat))
+                       (pair (or address (pair address nat))
+                             (pair nat
+                                   (pair nat
+                                         (pair nat
+                                               (pair nat
+                                                     (pair nat
+                                                           (pair (option address)
+                                                                 (pair bool
+                                                                       (pair bool
+                                                                             (pair bool
+                                                                                   (pair address
+                                                                                         (pair (option address) (pair address (pair (option address) (big_map string bytes)))))))))))))))))
+           unit
+           { UNPAIR ;
+             DUP 2 ;
+             GET 13 ;
+             COMPARE ;
+             GE ;
+             PUSH nat 0 ;
+             DUP 3 ;
+             GET 7 ;
+             COMPARE ;
+             GT ;
+             PUSH nat 0 ;
+             DUP 4 ;
+             GET 5 ;
+             COMPARE ;
+             GT ;
+             DIG 3 ;
+             GET 17 ;
+             AND ;
+             AND ;
+             AND ;
+             IF {} { PUSH string "POOL_NOT_ACTIVE" ; FAILWITH } ;
+             UNIT } ;
+         DUP 14 ;
+         APPLY ;
+         LAMBDA
+           timestamp
+           unit
+           { PUSH string "POOL_DEADLINE_EXPIRED" ;
+             SWAP ;
+             NOW ;
+             COMPARE ;
+             LE ;
+             IF { DROP } { FAILWITH } ;
+             UNIT } ;
+         LAMBDA
+           address
+           unit
+           { PUSH string "POOL_INVALID_ADDRESS" ;
+             SELF_ADDRESS ;
+             DIG 2 ;
+             COMPARE ;
+             NEQ ;
+             IF { DROP } { FAILWITH } ;
+             UNIT } ;
+         LAMBDA
+           (pair nat nat)
+           nat
+           { UNPAIR ;
+             SUB ;
+             ISNAT ;
+             IF_NONE { PUSH string "POOL_NAT_UNDERFLOW" ; FAILWITH } {} } ;
+         LAMBDA
+           (pair string (pair nat nat))
+           nat
+           { UNPAIR ;
+             SWAP ;
+             UNPAIR ;
+             EDIV ;
+             IF_NONE
+               { FAILWITH }
+               { SWAP ; DROP ; UNPAIR ; SWAP ; INT ; EQ ; IF {} { PUSH nat 1 ; ADD } } } ;
+         DUP 11 ;
+         APPLY ;
+         LAMBDA
+           (pair address (pair address (pair nat (or address (pair address nat)))))
+           operation
+           { UNPAIR 4 ;
+             DIG 3 ;
+             IF_LEFT
+               { CONTRACT %transfer (pair address (pair address nat)) ;
+                 IF_NONE { PUSH string "POOL_MISSING_FA12_TRANSFER" ; FAILWITH } {} ;
+                 PUSH mutez 0 ;
+                 DIG 4 ;
+                 DIG 4 ;
+                 PAIR ;
+                 DIG 3 ;
+                 PAIR ;
+                 TRANSFER_TOKENS }
+               { DUP ;
+                 CAR ;
+                 CONTRACT %transfer
+                   (list (pair (address %from_)
+                               (list %txs (pair (address %to_) (pair (nat %token_id) (nat %amount)))))) ;
+                 IF_NONE { PUSH string "POOL_MISSING_FA2_TRANSFER" ; FAILWITH } {} ;
+                 PUSH mutez 0 ;
+                 NIL (pair address (list (pair address (pair nat nat)))) ;
+                 NIL (pair address (pair nat nat)) ;
+                 DIG 7 ;
+                 DIG 5 ;
+                 CDR ;
+                 DIG 7 ;
+                 PAIR 3 ;
+                 CONS ;
+                 DIG 4 ;
+                 PAIR ;
+                 CONS ;
+                 TRANSFER_TOKENS } } ;
+         LAMBDA
+           (pair (or address (pair address nat))
+                 (pair (or address (pair address nat))
+                       (pair nat
+                             (pair nat
+                                   (pair nat
+                                         (pair nat
+                                               (pair nat
+                                                     (pair (option address)
+                                                           (pair bool
+                                                                 (pair bool
+                                                                       (pair bool
+                                                                             (pair address
+                                                                                   (pair (option address) (pair address (pair (option address) (big_map string bytes))))))))))))))))
+           address
+           { GET 15 ; IF_NONE { PUSH string "POOL_LQT_NOT_SET" ; FAILWITH } {} } ;
+         LAMBDA
+           (pair address (pair address int))
+           operation
+           { UNPAIR 3 ;
+             CONTRACT %mintOrBurn (pair (int %quantity) (address %target)) ;
+             IF_NONE { PUSH string "POOL_MISSING_LQT_MINT_OR_BURN" ; FAILWITH } {} ;
+             PUSH mutez 0 ;
+             DIG 2 ;
+             DIG 3 ;
+             PAIR ;
+             TRANSFER_TOKENS } ;
+         LAMBDA
+           unit
+           operation
+           { DROP ;
+             SELF_ADDRESS ;
+             CONTRACT %close unit ;
+             IF_NONE { PUSH string "POOL_MISSING_CLOSE" ; FAILWITH } {} ;
+             PUSH mutez 0 ;
+             UNIT ;
+             TRANSFER_TOKENS } ;
+         DIG 23 ;
+         UNPAIR ;
+         IF_LEFT
+           { DROP ;
+             DUG 11 ;
+             DROP 11 ;
+             DIG 3 ;
+             DROP ;
+             DIG 3 ;
+             DROP ;
+             DIG 3 ;
+             DROP ;
+             DIG 3 ;
+             DROP ;
+             DIG 3 ;
+             DROP ;
+             DIG 3 ;
+             DROP ;
+             DIG 3 ;
+             DROP ;
+             DIG 3 ;
+             DROP ;
+             DIG 3 ;
+             DROP ;
+             DIG 3 ;
+             DROP ;
+             UNIT ;
+             DIG 3 ;
+             SWAP ;
+             EXEC ;
+             DROP ;
+             DUP ;
+             DIG 2 ;
+             SWAP ;
+             EXEC ;
+             DROP ;
+             NIL operation }
+           { IF_LEFT
+               { DROP ;
+                 DUG 12 ;
+                 DROP 12 ;
+                 DIG 2 ;
+                 DROP ;
+                 DIG 2 ;
+                 DROP ;
+                 DIG 2 ;
+                 DROP ;
+                 DIG 2 ;
+                 DROP ;
+                 DIG 2 ;
+                 DROP ;
+                 DIG 2 ;
+                 DROP ;
+                 DIG 2 ;
+                 DROP ;
+                 DIG 2 ;
+                 DROP ;
+                 DIG 2 ;
+                 DROP ;
+                 DIG 2 ;
+                 DROP ;
+                 UNIT ;
+                 DIG 2 ;
+                 SWAP ;
+                 EXEC ;
+                 DROP ;
+                 DUP ;
+                 GET 21 ;
+                 IF {} { PUSH string "POOL_NOT_ENTERED" ; FAILWITH } ;
+                 PUSH string "POOL_SELF_ONLY" ;
+                 SELF_ADDRESS ;
+                 SENDER ;
+                 COMPARE ;
+                 EQ ;
+                 IF { DROP } { FAILWITH } ;
+                 PUSH bool False ;
+                 UPDATE 21 ;
+                 NIL operation }
+               { IF_LEFT
+                   { DROP ;
+                     DUG 11 ;
+                     DROP 11 ;
+                     DIG 3 ;
+                     DROP ;
+                     DIG 3 ;
+                     DROP ;
+                     DIG 3 ;
+                     DROP ;
+                     DIG 3 ;
+                     DROP ;
+                     DIG 3 ;
+                     DROP ;
+                     DIG 3 ;
+                     DROP ;
+                     DIG 4 ;
+                     DROP ;
+                     DIG 4 ;
+                     DROP ;
+                     DIG 4 ;
+                     DROP ;
+                     UNIT ;
+                     DIG 3 ;
+                     SWAP ;
+                     EXEC ;
+                     DROP ;
+                     DUP ;
+                     DIG 2 ;
+                     SWAP ;
+                     EXEC ;
+                     DROP ;
+                     DUP ;
+                     GET 29 ;
+                     IF_NONE
+                       { SWAP ; FAILWITH }
+                       { DIG 2 ; SWAP ; SENDER ; COMPARE ; EQ ; IF { DROP } { FAILWITH } } ;
+                     SENDER ;
+                     UPDATE 27 ;
+                     NONE address ;
+                     UPDATE 29 ;
+                     NIL operation }
+                   { DIG 21 ;
+                     DROP ;
+                     IF_LEFT
+                       { DROP ;
+                         DUG 10 ;
+                         DROP 10 ;
+                         DIG 4 ;
+                         DROP ;
+                         DIG 4 ;
+                         DROP ;
+                         DIG 4 ;
+                         DROP ;
+                         DIG 4 ;
+                         DROP ;
+                         DIG 4 ;
+                         DROP ;
+                         DIG 4 ;
+                         DROP ;
+                         DIG 4 ;
+                         DROP ;
+                         DIG 4 ;
+                         DROP ;
+                         DIG 4 ;
+                         DROP ;
+                         UNIT ;
+                         DIG 4 ;
+                         SWAP ;
+                         EXEC ;
+                         DROP ;
+                         DUP ;
+                         DIG 3 ;
+                         SWAP ;
+                         EXEC ;
+                         DROP ;
+                         DUP ;
+                         DIG 2 ;
+                         SWAP ;
+                         EXEC ;
+                         DROP ;
+                         NONE address ;
+                         UPDATE 29 ;
+                         NIL operation }
+                       { IF_LEFT
+                           { DIG 2 ;
+                             DROP ;
+                             DIG 2 ;
+                             DROP ;
+                             DIG 2 ;
+                             DROP ;
+                             DIG 2 ;
+                             DROP ;
+                             DIG 2 ;
+                             DROP ;
+                             DIG 2 ;
+                             DROP ;
+                             DIG 3 ;
+                             DROP ;
+                             DIG 3 ;
+                             DROP ;
+                             DIG 3 ;
+                             DROP ;
+                             DIG 6 ;
+                             DROP ;
+                             DIG 6 ;
+                             DROP ;
+                             DIG 6 ;
+                             DROP ;
+                             DIG 6 ;
+                             DROP ;
+                             DIG 6 ;
+                             DROP ;
+                             DIG 6 ;
+                             DROP ;
+                             DIG 6 ;
+                             DROP ;
+                             DIG 6 ;
+                             DROP ;
+                             DIG 6 ;
+                             DROP ;
+                             UNIT ;
+                             DIG 6 ;
+                             SWAP ;
+                             EXEC ;
+                             DROP ;
+                             DUP 2 ;
+                             DIG 5 ;
+                             SWAP ;
+                             EXEC ;
+                             DROP ;
+                             DUP 2 ;
+                             DIG 4 ;
+                             SWAP ;
+                             EXEC ;
+                             DROP ;
+                             DUP ;
+                             DIG 3 ;
+                             SWAP ;
+                             EXEC ;
+                             DROP ;
+                             SOME ;
+                             UPDATE 29 ;
+                             NIL operation }
+                           { IF_LEFT
+                               { DROP ;
+                                 DUG 11 ;
+                                 DROP 11 ;
+                                 DIG 3 ;
+                                 DROP ;
+                                 DIG 3 ;
+                                 DROP ;
+                                 DIG 3 ;
+                                 DROP ;
+                                 DIG 3 ;
+                                 DROP ;
+                                 DIG 3 ;
+                                 DROP ;
+                                 DIG 3 ;
+                                 DROP ;
+                                 DIG 4 ;
+                                 DROP ;
+                                 DIG 4 ;
+                                 DROP ;
+                                 UNIT ;
+                                 DIG 3 ;
+                                 SWAP ;
+                                 EXEC ;
+                                 DROP ;
+                                 DUP ;
+                                 DIG 2 ;
+                                 SWAP ;
+                                 EXEC ;
+                                 DROP ;
+                                 DUP ;
+                                 GET 25 ;
+                                 IF_NONE
+                                   { SWAP ; FAILWITH }
+                                   { DIG 2 ; SWAP ; SENDER ; COMPARE ; EQ ; IF { DROP } { FAILWITH } } ;
+                                 SENDER ;
+                                 UPDATE 23 ;
+                                 NONE address ;
+                                 UPDATE 25 ;
+                                 NIL operation }
+                               { DIG 21 ;
+                                 DROP ;
+                                 IF_LEFT
+                                   { DROP ;
+                                     DUG 10 ;
+                                     DROP 10 ;
+                                     DIG 4 ;
+                                     DROP ;
+                                     DIG 4 ;
+                                     DROP ;
+                                     DIG 4 ;
+                                     DROP ;
+                                     DIG 4 ;
+                                     DROP ;
+                                     DIG 4 ;
+                                     DROP ;
+                                     DIG 4 ;
+                                     DROP ;
+                                     DIG 4 ;
+                                     DROP ;
+                                     DIG 4 ;
+                                     DROP ;
+                                     UNIT ;
+                                     DIG 4 ;
+                                     SWAP ;
+                                     EXEC ;
+                                     DROP ;
+                                     DUP ;
+                                     DIG 3 ;
+                                     SWAP ;
+                                     EXEC ;
+                                     DROP ;
+                                     DUP ;
+                                     DIG 2 ;
+                                     SWAP ;
+                                     EXEC ;
+                                     DROP ;
+                                     NONE address ;
+                                     UPDATE 25 ;
+                                     NIL operation }
+                                   { IF_LEFT
+                                       { DIG 2 ;
+                                         DROP ;
+                                         DIG 2 ;
+                                         DROP ;
+                                         DIG 2 ;
+                                         DROP ;
+                                         DIG 2 ;
+                                         DROP ;
+                                         DIG 2 ;
+                                         DROP ;
+                                         DIG 2 ;
+                                         DROP ;
+                                         DIG 3 ;
+                                         DROP ;
+                                         DIG 3 ;
+                                         DROP ;
+                                         DIG 3 ;
+                                         DROP ;
+                                         DIG 6 ;
+                                         DROP ;
+                                         DIG 6 ;
+                                         DROP ;
+                                         DIG 6 ;
+                                         DROP ;
+                                         DIG 6 ;
+                                         DROP ;
+                                         DIG 6 ;
+                                         DROP ;
+                                         DIG 6 ;
+                                         DROP ;
+                                         DIG 6 ;
+                                         DROP ;
+                                         DIG 6 ;
+                                         DROP ;
+                                         UNIT ;
+                                         DIG 6 ;
+                                         SWAP ;
+                                         EXEC ;
+                                         DROP ;
+                                         DUP 2 ;
+                                         DIG 5 ;
+                                         SWAP ;
+                                         EXEC ;
+                                         DROP ;
+                                         DUP 2 ;
+                                         DIG 4 ;
+                                         SWAP ;
+                                         EXEC ;
+                                         DROP ;
+                                         DUP ;
+                                         DIG 3 ;
+                                         SWAP ;
+                                         EXEC ;
+                                         DROP ;
+                                         SOME ;
+                                         UPDATE 25 ;
+                                         NIL operation }
+                                       { IF_LEFT
+                                           { DIG 2 ;
+                                             DROP ;
+                                             DIG 2 ;
+                                             DROP ;
+                                             DIG 2 ;
+                                             DROP ;
+                                             DIG 2 ;
+                                             DROP ;
+                                             DIG 2 ;
+                                             DROP ;
+                                             DIG 2 ;
+                                             DROP ;
+                                             DIG 2 ;
+                                             DROP ;
+                                             DIG 2 ;
+                                             DROP ;
+                                             DIG 2 ;
+                                             DROP ;
+                                             DIG 2 ;
+                                             DROP ;
+                                             DIG 5 ;
+                                             DROP ;
+                                             DIG 5 ;
+                                             DROP ;
+                                             DIG 5 ;
+                                             DROP ;
+                                             DIG 5 ;
+                                             DROP ;
+                                             DIG 5 ;
+                                             DROP ;
+                                             DIG 5 ;
+                                             DROP ;
+                                             DIG 5 ;
+                                             DROP ;
+                                             DIG 5 ;
+                                             DROP ;
+                                             UNIT ;
+                                             DIG 5 ;
+                                             SWAP ;
+                                             EXEC ;
+                                             DROP ;
+                                             DUP 2 ;
+                                             DIG 4 ;
+                                             SWAP ;
+                                             EXEC ;
+                                             DROP ;
+                                             DUP 2 ;
+                                             DIG 3 ;
+                                             SWAP ;
+                                             EXEC ;
+                                             DROP ;
+                                             UPDATE 19 ;
+                                             NIL operation }
+                                           { IF_LEFT
+                                               { DIG 3 ;
+                                                 DROP ;
+                                                 DIG 3 ;
+                                                 DROP ;
+                                                 DIG 4 ;
+                                                 DROP ;
+                                                 DIG 4 ;
+                                                 DROP ;
+                                                 DIG 4 ;
+                                                 DROP ;
+                                                 DIG 4 ;
+                                                 DROP ;
+                                                 DIG 5 ;
+                                                 DROP ;
+                                                 DIG 5 ;
+                                                 DROP ;
+                                                 DIG 7 ;
+                                                 DROP ;
+                                                 DIG 7 ;
+                                                 DROP ;
+                                                 DIG 7 ;
+                                                 DROP ;
+                                                 DIG 7 ;
+                                                 DROP ;
+                                                 DIG 7 ;
+                                                 DROP ;
+                                                 DIG 7 ;
+                                                 DROP ;
+                                                 DIG 7 ;
+                                                 DROP ;
+                                                 DIG 7 ;
+                                                 DROP ;
+                                                 UNIT ;
+                                                 DIG 7 ;
+                                                 SWAP ;
+                                                 EXEC ;
+                                                 DROP ;
+                                                 DUP 2 ;
+                                                 DIG 6 ;
+                                                 SWAP ;
+                                                 EXEC ;
+                                                 DROP ;
+                                                 DUP 2 ;
+                                                 DIG 5 ;
+                                                 SWAP ;
+                                                 EXEC ;
+                                                 DROP ;
+                                                 SELF_ADDRESS ;
+                                                 SWAP ;
+                                                 IF_LEFT
+                                                   { DROP ;
+                                                     DUP 2 ;
+                                                     PUSH nat 0 ;
+                                                     UPDATE 9 ;
+                                                     PUSH bool True ;
+                                                     UPDATE 21 ;
+                                                     DUP 3 ;
+                                                     GET 9 ;
+                                                     DUP 4 ;
+                                                     CAR }
+                                                   { DROP ;
+                                                     DUP 2 ;
+                                                     PUSH nat 0 ;
+                                                     UPDATE 11 ;
+                                                     PUSH bool True ;
+                                                     UPDATE 21 ;
+                                                     DUP 3 ;
+                                                     GET 11 ;
+                                                     DUP 4 ;
+                                                     GET 3 } ;
+                                                 PAIR 3 ;
+                                                 UNPAIR 3 ;
+                                                 DUP 2 ;
+                                                 INT ;
+                                                 GT ;
+                                                 IF {} { PUSH string "POOL_NO_PROTOCOL_FEE" ; FAILWITH } ;
+                                                 DIG 2 ;
+                                                 NIL operation ;
+                                                 UNIT ;
+                                                 DIG 7 ;
+                                                 SWAP ;
+                                                 EXEC ;
+                                                 CONS ;
+                                                 DIG 2 ;
+                                                 DIG 3 ;
+                                                 DIG 5 ;
+                                                 GET 27 ;
+                                                 DIG 5 ;
+                                                 PAIR 4 ;
+                                                 DIG 3 ;
+                                                 SWAP ;
+                                                 EXEC ;
+                                                 CONS }
+                                               { IF_LEFT
+                                                   { DIG 3 ;
+                                                     DROP ;
+                                                     DIG 3 ;
+                                                     DROP ;
+                                                     DIG 4 ;
+                                                     DROP ;
+                                                     DIG 9 ;
+                                                     DROP ;
+                                                     DIG 11 ;
+                                                     DROP ;
+                                                     DIG 15 ;
+                                                     DROP ;
+                                                     DIG 15 ;
+                                                     DROP ;
+                                                     UNIT ;
+                                                     DIG 11 ;
+                                                     SWAP ;
+                                                     EXEC ;
+                                                     DROP ;
+                                                     DUP 2 ;
+                                                     DIG 10 ;
+                                                     SWAP ;
+                                                     EXEC ;
+                                                     DROP ;
+                                                     DUP 2 ;
+                                                     DIG 9 ;
+                                                     SWAP ;
+                                                     EXEC ;
+                                                     DROP ;
+                                                     DUP 2 ;
+                                                     DIG 8 ;
+                                                     SWAP ;
+                                                     EXEC ;
+                                                     DROP ;
+                                                     DUP ;
+                                                     GET 8 ;
+                                                     DIG 7 ;
+                                                     SWAP ;
+                                                     EXEC ;
+                                                     DROP ;
+                                                     DUP ;
+                                                     GET 7 ;
+                                                     DIG 6 ;
+                                                     SWAP ;
+                                                     EXEC ;
+                                                     DROP ;
+                                                     PUSH nat 0 ;
+                                                     DUP 2 ;
+                                                     GET 3 ;
+                                                     COMPARE ;
+                                                     GT ;
+                                                     IF { DIG 8 ; DROP } { DIG 8 ; FAILWITH } ;
+                                                     DUP ;
+                                                     CAR ;
+                                                     IF_LEFT
+                                                       { DROP ; DUP 2 ; GET 7 ; DUP 3 ; GET 5 ; DUP 4 ; GET 3 ; DUP 5 ; CAR }
+                                                       { DROP ; DUP 2 ; GET 5 ; DUP 3 ; GET 7 ; DUP 4 ; CAR ; DUP 5 ; GET 3 } ;
+                                                     PAIR 4 ;
+                                                     UNPAIR 4 ;
+                                                     DUP 5 ;
+                                                     GET 3 ;
+                                                     DUP 5 ;
+                                                     INT ;
+                                                     EQ ;
+                                                     DUP 5 ;
+                                                     INT ;
+                                                     EQ ;
+                                                     DUP 3 ;
+                                                     INT ;
+                                                     EQ ;
+                                                     OR ;
+                                                     OR ;
+                                                     IF { DROP ; DIG 2 ; DROP ; PUSH nat 0 }
+                                                        { PUSH nat 9970 ;
+                                                          SWAP ;
+                                                          MUL ;
+                                                          DUP ;
+                                                          DUP 15 ;
+                                                          DIG 5 ;
+                                                          MUL ;
+                                                          ADD ;
+                                                          DUP 5 ;
+                                                          DIG 2 ;
+                                                          MUL ;
+                                                          EDIV ;
+                                                          IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } } ;
+                                                     DUP ;
+                                                     INT ;
+                                                     GT ;
+                                                     IF { DIG 11 ; DROP } { DIG 11 ; FAILWITH } ;
+                                                     DIG 3 ;
+                                                     DUP 2 ;
+                                                     COMPARE ;
+                                                     LT ;
+                                                     IF { DIG 8 ; DROP } { DIG 8 ; FAILWITH } ;
+                                                     DUP 4 ;
+                                                     GET 5 ;
+                                                     DUP 2 ;
+                                                     COMPARE ;
+                                                     GE ;
+                                                     IF { DIG 8 ; DROP } { DIG 8 ; FAILWITH } ;
+                                                     DIG 8 ;
+                                                     PUSH nat 5 ;
+                                                     DUP 6 ;
+                                                     GET 3 ;
+                                                     MUL ;
+                                                     EDIV ;
+                                                     IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                     DUP ;
+                                                     DUP 6 ;
+                                                     GET 3 ;
+                                                     PAIR ;
+                                                     DUP 10 ;
+                                                     SWAP ;
+                                                     EXEC ;
+                                                     SELF_ADDRESS ;
+                                                     NIL operation ;
+                                                     UNIT ;
+                                                     DIG 10 ;
+                                                     SWAP ;
+                                                     EXEC ;
+                                                     CONS ;
+                                                     DIG 6 ;
+                                                     DUP 6 ;
+                                                     DUP 9 ;
+                                                     GET 7 ;
+                                                     DUP 5 ;
+                                                     PAIR 4 ;
+                                                     DUP 10 ;
+                                                     SWAP ;
+                                                     EXEC ;
+                                                     CONS ;
+                                                     DIG 5 ;
+                                                     DUP 7 ;
+                                                     GET 3 ;
+                                                     DIG 3 ;
+                                                     SENDER ;
+                                                     PAIR 4 ;
+                                                     DIG 7 ;
+                                                     SWAP ;
+                                                     EXEC ;
+                                                     CONS ;
+                                                     DIG 4 ;
+                                                     CAR ;
+                                                     IF_LEFT
+                                                       { DROP ;
+                                                         DUP 5 ;
+                                                         DIG 2 ;
+                                                         DUP 6 ;
+                                                         GET 5 ;
+                                                         ADD ;
+                                                         UPDATE 5 ;
+                                                         DIG 3 ;
+                                                         DUP 5 ;
+                                                         GET 7 ;
+                                                         PAIR ;
+                                                         DIG 5 ;
+                                                         SWAP ;
+                                                         EXEC ;
+                                                         UPDATE 7 ;
+                                                         DIG 2 ;
+                                                         DIG 3 ;
+                                                         GET 9 ;
+                                                         ADD ;
+                                                         UPDATE 9 ;
+                                                         PUSH bool True ;
+                                                         UPDATE 21 }
+                                                       { DROP ;
+                                                         DUP 5 ;
+                                                         DIG 4 ;
+                                                         DUP 6 ;
+                                                         GET 5 ;
+                                                         PAIR ;
+                                                         DIG 6 ;
+                                                         SWAP ;
+                                                         EXEC ;
+                                                         UPDATE 5 ;
+                                                         DIG 2 ;
+                                                         DUP 5 ;
+                                                         GET 7 ;
+                                                         ADD ;
+                                                         UPDATE 7 ;
+                                                         DIG 2 ;
+                                                         DIG 3 ;
+                                                         GET 11 ;
+                                                         ADD ;
+                                                         UPDATE 11 ;
+                                                         PUSH bool True ;
+                                                         UPDATE 21 } ;
+                                                     SWAP }
+                                                   { DIG 16 ;
+                                                     DROP ;
+                                                     DIG 21 ;
+                                                     DROP ;
+                                                     IF_LEFT
+                                                       { DIG 6 ;
+                                                         DROP ;
+                                                         DIG 10 ;
+                                                         DROP ;
+                                                         DIG 10 ;
+                                                         DROP ;
+                                                         DIG 16 ;
+                                                         DROP ;
+                                                         UNIT ;
+                                                         DIG 12 ;
+                                                         SWAP ;
+                                                         EXEC ;
+                                                         DROP ;
+                                                         DUP 2 ;
+                                                         DIG 11 ;
+                                                         SWAP ;
+                                                         EXEC ;
+                                                         DROP ;
+                                                         DUP 2 ;
+                                                         DIG 10 ;
+                                                         SWAP ;
+                                                         EXEC ;
+                                                         DROP ;
+                                                         DUP ;
+                                                         GET 8 ;
+                                                         DIG 9 ;
+                                                         SWAP ;
+                                                         EXEC ;
+                                                         DROP ;
+                                                         DUP ;
+                                                         GET 7 ;
+                                                         DIG 8 ;
+                                                         SWAP ;
+                                                         EXEC ;
+                                                         DROP ;
+                                                         PUSH nat 0 ;
+                                                         DUP 2 ;
+                                                         CAR ;
+                                                         COMPARE ;
+                                                         GT ;
+                                                         IF { DIG 10 ; DROP } { DIG 10 ; FAILWITH } ;
+                                                         DUP 8 ;
+                                                         DUP 12 ;
+                                                         DUP 4 ;
+                                                         GET 13 ;
+                                                         PAIR ;
+                                                         DUP 9 ;
+                                                         SWAP ;
+                                                         EXEC ;
+                                                         DUP 3 ;
+                                                         CAR ;
+                                                         COMPARE ;
+                                                         LE ;
+                                                         IF { DROP } { FAILWITH } ;
+                                                         DUP 2 ;
+                                                         GET 13 ;
+                                                         DUP 3 ;
+                                                         GET 5 ;
+                                                         DUP 3 ;
+                                                         CAR ;
+                                                         MUL ;
+                                                         EDIV ;
+                                                         IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                         DUP 3 ;
+                                                         GET 13 ;
+                                                         DUP 4 ;
+                                                         GET 7 ;
+                                                         DUP 4 ;
+                                                         CAR ;
+                                                         MUL ;
+                                                         EDIV ;
+                                                         IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                         DUP ;
+                                                         INT ;
+                                                         GT ;
+                                                         DUP 3 ;
+                                                         INT ;
+                                                         GT ;
+                                                         AND ;
+                                                         IF { DIG 11 ; DROP } { DIG 11 ; FAILWITH } ;
+                                                         DUP 3 ;
+                                                         GET 5 ;
+                                                         DUP 2 ;
+                                                         COMPARE ;
+                                                         GE ;
+                                                         DUP 4 ;
+                                                         GET 3 ;
+                                                         DUP 4 ;
+                                                         COMPARE ;
+                                                         GE ;
+                                                         AND ;
+                                                         IF { DIG 10 ; DROP } { DIG 10 ; FAILWITH } ;
+                                                         DUP 2 ;
+                                                         DUP 5 ;
+                                                         GET 5 ;
+                                                         PAIR ;
+                                                         DUP 10 ;
+                                                         SWAP ;
+                                                         EXEC ;
+                                                         DUP 2 ;
+                                                         DUP 6 ;
+                                                         GET 7 ;
+                                                         PAIR ;
+                                                         DUP 11 ;
+                                                         SWAP ;
+                                                         EXEC ;
+                                                         DUP 5 ;
+                                                         CAR ;
+                                                         DUP 7 ;
+                                                         GET 13 ;
+                                                         PAIR ;
+                                                         DIG 11 ;
+                                                         SWAP ;
+                                                         EXEC ;
+                                                         DIG 12 ;
+                                                         DUP 2 ;
+                                                         COMPARE ;
+                                                         GE ;
+                                                         DUP 3 ;
+                                                         INT ;
+                                                         GT ;
+                                                         DUP 5 ;
+                                                         INT ;
+                                                         GT ;
+                                                         AND ;
+                                                         AND ;
+                                                         IF { DIG 11 ; DROP } { DIG 11 ; FAILWITH } ;
+                                                         SELF_ADDRESS ;
+                                                         DUP 8 ;
+                                                         DIG 11 ;
+                                                         SWAP ;
+                                                         EXEC ;
+                                                         NIL operation ;
+                                                         UNIT ;
+                                                         DIG 11 ;
+                                                         SWAP ;
+                                                         EXEC ;
+                                                         CONS ;
+                                                         DUP 10 ;
+                                                         GET 3 ;
+                                                         DIG 7 ;
+                                                         DUP 10 ;
+                                                         GET 7 ;
+                                                         DUP 6 ;
+                                                         PAIR 4 ;
+                                                         DUP 12 ;
+                                                         SWAP ;
+                                                         EXEC ;
+                                                         CONS ;
+                                                         DUP 9 ;
+                                                         CAR ;
+                                                         DIG 7 ;
+                                                         DUP 9 ;
+                                                         GET 7 ;
+                                                         DIG 5 ;
+                                                         PAIR 4 ;
+                                                         DIG 9 ;
+                                                         SWAP ;
+                                                         EXEC ;
+                                                         CONS ;
+                                                         DIG 5 ;
+                                                         CAR ;
+                                                         INT ;
+                                                         PUSH int 0 ;
+                                                         SUB ;
+                                                         SENDER ;
+                                                         DIG 3 ;
+                                                         PAIR 3 ;
+                                                         DIG 6 ;
+                                                         SWAP ;
+                                                         EXEC ;
+                                                         CONS ;
+                                                         DIG 4 ;
+                                                         DIG 4 ;
+                                                         UPDATE 5 ;
+                                                         DIG 3 ;
+                                                         UPDATE 7 ;
+                                                         DIG 2 ;
+                                                         UPDATE 13 ;
+                                                         PUSH bool True ;
+                                                         UPDATE 21 ;
+                                                         SWAP }
+                                                       { DIG 17 ;
+                                                         DROP ;
+                                                         IF_LEFT
+                                                           { DIG 7 ;
+                                                             DROP ;
+                                                             DIG 11 ;
+                                                             DROP ;
+                                                             DIG 13 ;
+                                                             DROP ;
+                                                             DIG 15 ;
+                                                             DROP ;
+                                                             DIG 15 ;
+                                                             DROP ;
+                                                             UNIT ;
+                                                             DIG 13 ;
+                                                             SWAP ;
+                                                             EXEC ;
+                                                             DROP ;
+                                                             DUP 2 ;
+                                                             DIG 12 ;
+                                                             SWAP ;
+                                                             EXEC ;
+                                                             DROP ;
+                                                             DUP 2 ;
+                                                             DIG 11 ;
+                                                             SWAP ;
+                                                             EXEC ;
+                                                             DROP ;
+                                                             DUP 2 ;
+                                                             DIG 10 ;
+                                                             SWAP ;
+                                                             EXEC ;
+                                                             DROP ;
+                                                             DUP ;
+                                                             GET 8 ;
+                                                             DIG 9 ;
+                                                             SWAP ;
+                                                             EXEC ;
+                                                             DROP ;
+                                                             DUP ;
+                                                             GET 7 ;
+                                                             DIG 8 ;
+                                                             SWAP ;
+                                                             EXEC ;
+                                                             DROP ;
+                                                             DUP 2 ;
+                                                             GET 5 ;
+                                                             DUP 3 ;
+                                                             GET 13 ;
+                                                             DUP 3 ;
+                                                             CAR ;
+                                                             MUL ;
+                                                             EDIV ;
+                                                             IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                             DUP 3 ;
+                                                             GET 7 ;
+                                                             DUP 4 ;
+                                                             GET 13 ;
+                                                             DUP 4 ;
+                                                             GET 3 ;
+                                                             MUL ;
+                                                             EDIV ;
+                                                             IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                             DUP ;
+                                                             DUP 3 ;
+                                                             COMPARE ;
+                                                             LT ;
+                                                             IF { DROP } { SWAP ; DROP } ;
+                                                             DUP ;
+                                                             INT ;
+                                                             GT ;
+                                                             IF { DIG 9 ; DROP } { DIG 9 ; FAILWITH } ;
+                                                             DUP 2 ;
+                                                             GET 5 ;
+                                                             DUP 2 ;
+                                                             COMPARE ;
+                                                             GE ;
+                                                             IF {} { DUP 9 ; FAILWITH } ;
+                                                             DUP 3 ;
+                                                             GET 13 ;
+                                                             DUP 4 ;
+                                                             GET 5 ;
+                                                             DUP 3 ;
+                                                             MUL ;
+                                                             PAIR ;
+                                                             DUP 9 ;
+                                                             SWAP ;
+                                                             EXEC ;
+                                                             DUP 4 ;
+                                                             GET 13 ;
+                                                             DUP 5 ;
+                                                             GET 7 ;
+                                                             DUP 4 ;
+                                                             MUL ;
+                                                             PAIR ;
+                                                             DIG 9 ;
+                                                             SWAP ;
+                                                             EXEC ;
+                                                             DUP 4 ;
+                                                             GET 3 ;
+                                                             DUP 2 ;
+                                                             COMPARE ;
+                                                             LE ;
+                                                             DUP 5 ;
+                                                             CAR ;
+                                                             DUP 4 ;
+                                                             COMPARE ;
+                                                             LE ;
+                                                             AND ;
+                                                             IF { DIG 9 ; DROP } { DIG 9 ; FAILWITH } ;
+                                                             SENDER ;
+                                                             SELF_ADDRESS ;
+                                                             DUP 7 ;
+                                                             DIG 10 ;
+                                                             SWAP ;
+                                                             EXEC ;
+                                                             NIL operation ;
+                                                             UNIT ;
+                                                             DIG 10 ;
+                                                             SWAP ;
+                                                             EXEC ;
+                                                             CONS ;
+                                                             DUP 7 ;
+                                                             INT ;
+                                                             DIG 8 ;
+                                                             GET 7 ;
+                                                             DIG 3 ;
+                                                             PAIR 3 ;
+                                                             DIG 8 ;
+                                                             SWAP ;
+                                                             EXEC ;
+                                                             CONS ;
+                                                             DUP 7 ;
+                                                             GET 3 ;
+                                                             DUP 5 ;
+                                                             DUP 4 ;
+                                                             DUP 6 ;
+                                                             PAIR 4 ;
+                                                             DUP 9 ;
+                                                             SWAP ;
+                                                             EXEC ;
+                                                             CONS ;
+                                                             DUP 7 ;
+                                                             CAR ;
+                                                             DUP 6 ;
+                                                             DIG 3 ;
+                                                             DIG 4 ;
+                                                             PAIR 4 ;
+                                                             DIG 6 ;
+                                                             SWAP ;
+                                                             EXEC ;
+                                                             CONS ;
+                                                             DUP 5 ;
+                                                             DIG 3 ;
+                                                             DUP 6 ;
+                                                             GET 5 ;
+                                                             ADD ;
+                                                             UPDATE 5 ;
+                                                             DIG 2 ;
+                                                             DUP 5 ;
+                                                             GET 7 ;
+                                                             ADD ;
+                                                             UPDATE 7 ;
+                                                             DIG 2 ;
+                                                             DIG 3 ;
+                                                             GET 13 ;
+                                                             ADD ;
+                                                             UPDATE 13 ;
+                                                             PUSH bool True ;
+                                                             UPDATE 21 ;
+                                                             SWAP }
+                                                           { DIG 6 ;
+                                                             DROP ;
+                                                             DIG 9 ;
+                                                             DROP ;
+                                                             DIG 14 ;
+                                                             DROP ;
+                                                             IF_LEFT
+                                                               { UNIT ;
+                                                                 DIG 13 ;
+                                                                 SWAP ;
+                                                                 EXEC ;
+                                                                 DROP ;
+                                                                 DUP 2 ;
+                                                                 DIG 12 ;
+                                                                 SWAP ;
+                                                                 EXEC ;
+                                                                 DROP ;
+                                                                 DUP 2 ;
+                                                                 DIG 11 ;
+                                                                 SWAP ;
+                                                                 EXEC ;
+                                                                 DROP ;
+                                                                 DUP 2 ;
+                                                                 DIG 10 ;
+                                                                 SWAP ;
+                                                                 EXEC ;
+                                                                 DROP ;
+                                                                 DUP 2 ;
+                                                                 GET 17 ;
+                                                                 IF { DIG 11 ; FAILWITH } { DIG 11 ; DROP } ;
+                                                                 DUP 2 ;
+                                                                 GET 3 ;
+                                                                 DUP 3 ;
+                                                                 CAR ;
+                                                                 COMPARE ;
+                                                                 NEQ ;
+                                                                 IF {} { PUSH string "POOL_IDENTICAL_ASSETS" ; FAILWITH } ;
+                                                                 DUP 2 ;
+                                                                 DIG 5 ;
+                                                                 SWAP ;
+                                                                 EXEC ;
+                                                                 DUP 2 ;
+                                                                 GET 6 ;
+                                                                 DIG 9 ;
+                                                                 SWAP ;
+                                                                 EXEC ;
+                                                                 DROP ;
+                                                                 DUP 2 ;
+                                                                 GET 5 ;
+                                                                 DIG 8 ;
+                                                                 SWAP ;
+                                                                 EXEC ;
+                                                                 DROP ;
+                                                                 PUSH nat 0 ;
+                                                                 DUP 3 ;
+                                                                 GET 3 ;
+                                                                 COMPARE ;
+                                                                 GT ;
+                                                                 PUSH nat 0 ;
+                                                                 DUP 4 ;
+                                                                 CAR ;
+                                                                 COMPARE ;
+                                                                 GT ;
+                                                                 AND ;
+                                                                 IF { DIG 8 ; DROP } { DIG 8 ; FAILWITH } ;
+                                                                 DUP 2 ;
+                                                                 GET 3 ;
+                                                                 DUP 3 ;
+                                                                 CAR ;
+                                                                 MUL ;
+                                                                 PUSH nat 2 ;
+                                                                 DUP 2 ;
+                                                                 COMPARE ;
+                                                                 LT ;
+                                                                 IF {}
+                                                                    { PUSH nat 1 ;
+                                                                      PUSH nat 2 ;
+                                                                      DUP 3 ;
+                                                                      EDIV ;
+                                                                      IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                      ADD ;
+                                                                      SWAP ;
+                                                                      PAIR ;
+                                                                      LEFT nat ;
+                                                                      LOOP_LEFT
+                                                                        { UNPAIR ;
+                                                                          PUSH nat 2 ;
+                                                                          DUP 3 ;
+                                                                          DUP 3 ;
+                                                                          EDIV ;
+                                                                          IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                          DUP 4 ;
+                                                                          ADD ;
+                                                                          EDIV ;
+                                                                          IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } ;
+                                                                          DUP 3 ;
+                                                                          DUP 2 ;
+                                                                          COMPARE ;
+                                                                          GE ;
+                                                                          IF { DROP 2 ; RIGHT (pair nat nat) }
+                                                                             { DIG 2 ; DROP ; SWAP ; PAIR ; LEFT nat } } } ;
+                                                                 DUP 10 ;
+                                                                 DUP 2 ;
+                                                                 COMPARE ;
+                                                                 GT ;
+                                                                 IF { DIG 8 ; DROP } { DIG 8 ; FAILWITH } ;
+                                                                 DUP 9 ;
+                                                                 DUP 2 ;
+                                                                 PAIR ;
+                                                                 DIG 8 ;
+                                                                 SWAP ;
+                                                                 EXEC ;
+                                                                 SENDER ;
+                                                                 SELF_ADDRESS ;
+                                                                 NIL operation ;
+                                                                 UNIT ;
+                                                                 DIG 9 ;
+                                                                 SWAP ;
+                                                                 EXEC ;
+                                                                 CONS ;
+                                                                 DIG 3 ;
+                                                                 INT ;
+                                                                 DUP 7 ;
+                                                                 GET 5 ;
+                                                                 DUP 7 ;
+                                                                 PAIR 3 ;
+                                                                 DUP 9 ;
+                                                                 SWAP ;
+                                                                 EXEC ;
+                                                                 CONS ;
+                                                                 DIG 9 ;
+                                                                 INT ;
+                                                                 DUP 3 ;
+                                                                 DIG 6 ;
+                                                                 PAIR 3 ;
+                                                                 DIG 7 ;
+                                                                 SWAP ;
+                                                                 EXEC ;
+                                                                 CONS ;
+                                                                 DUP 6 ;
+                                                                 GET 3 ;
+                                                                 DUP 6 ;
+                                                                 GET 3 ;
+                                                                 DUP 4 ;
+                                                                 DUP 6 ;
+                                                                 PAIR 4 ;
+                                                                 DUP 8 ;
+                                                                 SWAP ;
+                                                                 EXEC ;
+                                                                 CONS ;
+                                                                 DUP 6 ;
+                                                                 CAR ;
+                                                                 DUP 6 ;
+                                                                 CAR ;
+                                                                 DIG 3 ;
+                                                                 DIG 4 ;
+                                                                 PAIR 4 ;
+                                                                 DIG 5 ;
+                                                                 SWAP ;
+                                                                 EXEC ;
+                                                                 CONS ;
+                                                                 DIG 3 ;
+                                                                 DUP 4 ;
+                                                                 CAR ;
+                                                                 UPDATE 5 ;
+                                                                 DIG 3 ;
+                                                                 GET 3 ;
+                                                                 UPDATE 7 ;
+                                                                 DIG 2 ;
+                                                                 UPDATE 13 ;
+                                                                 PUSH bool True ;
+                                                                 UPDATE 17 ;
+                                                                 PUSH bool True ;
+                                                                 UPDATE 21 ;
+                                                                 SWAP }
+                                                               { DIG 2 ;
+                                                                 DROP ;
+                                                                 DIG 2 ;
+                                                                 DROP ;
+                                                                 DIG 2 ;
+                                                                 DROP ;
+                                                                 DIG 2 ;
+                                                                 DROP ;
+                                                                 DIG 2 ;
+                                                                 DROP ;
+                                                                 DIG 3 ;
+                                                                 DROP ;
+                                                                 DIG 3 ;
+                                                                 DROP ;
+                                                                 DIG 6 ;
+                                                                 DROP ;
+                                                                 DIG 6 ;
+                                                                 DROP ;
+                                                                 DIG 7 ;
+                                                                 DROP ;
+                                                                 UNIT ;
+                                                                 DIG 6 ;
+                                                                 SWAP ;
+                                                                 EXEC ;
+                                                                 DROP ;
+                                                                 DUP 2 ;
+                                                                 DIG 5 ;
+                                                                 SWAP ;
+                                                                 EXEC ;
+                                                                 DROP ;
+                                                                 DUP 2 ;
+                                                                 DIG 4 ;
+                                                                 SWAP ;
+                                                                 EXEC ;
+                                                                 DROP ;
+                                                                 DUP 2 ;
+                                                                 GET 17 ;
+                                                                 IF { DIG 3 ; FAILWITH } { DIG 3 ; DROP } ;
+                                                                 DUP ;
+                                                                 DIG 3 ;
+                                                                 SWAP ;
+                                                                 EXEC ;
+                                                                 DROP ;
+                                                                 DUP 2 ;
+                                                                 GET 15 ;
+                                                                 IF_NONE {} { PUSH string "POOL_LQT_ALREADY_SET" ; FAILWITH } ;
+                                                                 SOME ;
+                                                                 UPDATE 15 ;
+                                                                 NIL operation } } } } } } } } } } } } } } ;
+         PAIR } ;
+  view "get_assets"
+       unit
+       (pair (or (address %fa12) (pair %fa2 (address %token) (nat %id)))
+             (or (address %fa12) (pair %fa2 (address %token) (nat %id))))
+       { CDR ; DUP ; GET 3 ; SWAP ; CAR ; PAIR } ;
+  view "get_reserves"
+       unit
+       (pair nat nat)
+       { CDR ; DUP ; GET 7 ; SWAP ; GET 5 ; PAIR } ;
+  view "get_protocol_fees"
+       unit
+       (pair nat nat)
+       { CDR ; DUP ; GET 11 ; SWAP ; GET 9 ; PAIR } ;
+  view "get_lqt_total" unit nat { GET 15 } ;
+  view "get_minimum_lqt" unit nat { DROP ; PUSH nat 1000 } ;
+  view "get_fee_bp"
+       unit
+       (pair nat (pair nat nat))
+       { DROP ; PUSH nat 30 ; PUSH nat 5 ; PUSH nat 25 ; PAIR 3 } ;
+  view "is_active" unit bool { GET 19 } ;
+  view "is_paused" unit bool { GET 21 } ;
+  view "quote_a_to_b"
+       nat
+       nat
+       { UNPAIR ;
+         DUP 2 ;
+         GET 19 ;
+         NOT ;
+         DUP 3 ;
+         GET 17 ;
+         AND ;
+         IF { DUP 2 ;
+              GET 7 ;
+              DIG 2 ;
+              GET 5 ;
+              DUP 2 ;
+              INT ;
+              EQ ;
+              DUP 2 ;
+              INT ;
+              EQ ;
+              DUP 5 ;
+              INT ;
+              EQ ;
+              OR ;
+              OR ;
+              IF { DROP 3 ; PUSH nat 0 }
+                 { PUSH nat 9970 ;
+                   DIG 3 ;
+                   MUL ;
+                   DUP ;
+                   PUSH nat 10000 ;
+                   DIG 3 ;
+                   MUL ;
+                   ADD ;
+                   DUG 2 ;
+                   MUL ;
+                   EDIV ;
+                   IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } } }
+            { DROP 2 ; PUSH nat 0 } } ;
+  view "quote_b_to_a"
+       nat
+       nat
+       { UNPAIR ;
+         DUP 2 ;
+         GET 19 ;
+         NOT ;
+         DUP 3 ;
+         GET 17 ;
+         AND ;
+         IF { DUP 2 ;
+              GET 5 ;
+              DIG 2 ;
+              GET 7 ;
+              DUP 2 ;
+              INT ;
+              EQ ;
+              DUP 2 ;
+              INT ;
+              EQ ;
+              DUP 5 ;
+              INT ;
+              EQ ;
+              OR ;
+              OR ;
+              IF { DROP 3 ; PUSH nat 0 }
+                 { PUSH nat 9970 ;
+                   DIG 3 ;
+                   MUL ;
+                   DUP ;
+                   PUSH nat 10000 ;
+                   DIG 3 ;
+                   MUL ;
+                   ADD ;
+                   DUG 2 ;
+                   MUL ;
+                   EDIV ;
+                   IF_NONE { PUSH string "DIV by 0" ; FAILWITH } { CAR } } }
+            { DROP 2 ; PUSH nat 0 } } }
+

--- a/dex/contracts/token_token_pool.mligo
+++ b/dex/contracts/token_token_pool.mligo
@@ -1,0 +1,680 @@
+(*
+  TEZEX single-pair token-to-token constant-product pool.
+
+  Design lineage:
+  - QuipuSwap TTDex commit 41fd4293029e2094a564141fb389fd9a1ef19185
+  - QuipuSwap Core V2 transfer wrappers at
+    684f17d42293034764fd2ff70ce1075b912406da
+  - TEZEX external FA1.2 LQT and hardened inactive initialization lifecycle
+
+  Each deployment serves one immutable FA1.2/FA2 pair. The fee schedule is
+  immutable: 25 bp remains in the AMM reserve for LPs and 5 bp accrues outside
+  the tradable reserve for the protocol recipient.
+*)
+
+module TokenTokenPool = struct
+  (* --------------------------------------------------------------------- *)
+  (* Constants and errors                                                  *)
+  (* --------------------------------------------------------------------- *)
+
+  let fee_denominator : nat = 10000n
+  let lp_fee_bp : nat = 25n
+  let protocol_fee_bp : nat = 5n
+  let total_fee_bp : nat = 30n
+  let swap_fee_numerator : nat = 9970n
+  let minimum_lqt : nat = 1000n
+
+  let err_non_payable = "POOL_NON_PAYABLE"
+  let err_entered = "POOL_REENTRANCY"
+  let err_not_entered = "POOL_NOT_ENTERED"
+  let err_self_only = "POOL_SELF_ONLY"
+  let err_not_manager = "POOL_NOT_MANAGER"
+  let err_not_pending_manager = "POOL_NOT_PENDING_MANAGER"
+  let err_not_pending_fee_recipient = "POOL_NOT_PENDING_FEE_RECIPIENT"
+  let err_invalid_address = "POOL_INVALID_ADDRESS"
+  let err_paused = "POOL_PAUSED"
+  let err_not_active = "POOL_NOT_ACTIVE"
+  let err_already_active = "POOL_ALREADY_ACTIVE"
+  let err_lqt_not_set = "POOL_LQT_NOT_SET"
+  let err_lqt_already_set = "POOL_LQT_ALREADY_SET"
+  let err_same_asset = "POOL_IDENTICAL_ASSETS"
+  let err_expired = "POOL_DEADLINE_EXPIRED"
+  let err_zero_amount = "POOL_ZERO_AMOUNT"
+  let err_zero_output = "POOL_ZERO_OUTPUT"
+  let err_slippage = "POOL_SLIPPAGE"
+  let err_insufficient_liquidity = "POOL_INSUFFICIENT_LIQUIDITY"
+  let err_minimum_lqt = "POOL_MINIMUM_LQT"
+  let err_no_protocol_fee = "POOL_NO_PROTOCOL_FEE"
+  let err_nat_underflow = "POOL_NAT_UNDERFLOW"
+  let err_missing_fa12_transfer = "POOL_MISSING_FA12_TRANSFER"
+  let err_missing_fa2_transfer = "POOL_MISSING_FA2_TRANSFER"
+  let err_missing_lqt_mint_burn = "POOL_MISSING_LQT_MINT_OR_BURN"
+  let err_missing_close = "POOL_MISSING_CLOSE"
+
+  (* --------------------------------------------------------------------- *)
+  (* Asset and external-contract types                                     *)
+  (* --------------------------------------------------------------------- *)
+
+  type fa2_token =
+    [@layout:comb]
+    {
+      token : address;
+      id : nat
+    }
+
+  type token =
+    | Fa12 of address
+    | Fa2 of fa2_token
+
+  type token_side = Token_a | Token_b
+  type swap_direction = A_to_b | B_to_a
+
+  type fa12_transfer = address * (address * nat)
+
+  type fa2_tx =
+    [@layout:comb]
+    {
+      to_ : address;
+      token_id : nat;
+      amount : nat
+    }
+
+  type fa2_transfer_item =
+    [@layout:comb]
+    {
+      from_ : address;
+      txs : fa2_tx list
+    }
+
+  type fa2_transfer = fa2_transfer_item list
+
+  type mint_or_burn =
+    [@layout:comb]
+    {
+      quantity : int;
+      target : address
+    }
+
+  (* --------------------------------------------------------------------- *)
+  (* Public parameters and storage                                         *)
+  (* --------------------------------------------------------------------- *)
+
+  type initialize_param =
+    [@layout:comb]
+    {
+      amount_a : nat;
+      amount_b : nat;
+      receiver : address;
+      deadline : timestamp
+    }
+
+  type add_liquidity_param =
+    [@layout:comb]
+    {
+      max_amount_a : nat;
+      max_amount_b : nat;
+      min_lqt_minted : nat;
+      receiver : address;
+      deadline : timestamp
+    }
+
+  type remove_liquidity_param =
+    [@layout:comb]
+    {
+      lqt_burned : nat;
+      min_amount_a : nat;
+      min_amount_b : nat;
+      receiver : address;
+      deadline : timestamp
+    }
+
+  type swap_param =
+    [@layout:comb]
+    {
+      direction : swap_direction;
+      amount_in : nat;
+      min_amount_out : nat;
+      receiver : address;
+      deadline : timestamp
+    }
+
+  type storage =
+    [@layout:comb]
+    {
+      token_a : token;
+      token_b : token;
+      reserve_a : nat;
+      reserve_b : nat;
+      protocol_fee_a : nat;
+      protocol_fee_b : nat;
+      lqt_total : nat;
+      lqt_address : address option;
+      active : bool;
+      paused : bool;
+      entered : bool;
+      manager : address;
+      pending_manager : address option;
+      protocol_fee_recipient : address;
+      pending_fee_recipient : address option;
+      metadata : (string, bytes) big_map
+    }
+
+  type result = operation list * storage
+
+  (* --------------------------------------------------------------------- *)
+  (* Checked arithmetic and common assertions                              *)
+  (* --------------------------------------------------------------------- *)
+
+  let assert_non_payable () : unit =
+    Assert.Error.assert (Tezos.get_amount () = 0mutez) err_non_payable
+
+  let assert_idle (s : storage) : unit =
+    Assert.Error.assert (not s.entered) err_entered
+
+  let assert_manager (s : storage) : unit =
+    Assert.Error.assert (Tezos.get_sender () = s.manager) err_not_manager
+
+  let assert_live (s : storage) : unit =
+    Assert.Error.assert (not s.paused) err_paused
+
+  let assert_ready (s : storage) : unit =
+    Assert.Error.assert
+      (s.active
+       && s.reserve_a > 0n
+       && s.reserve_b > 0n
+       && s.lqt_total >= minimum_lqt)
+      err_not_active
+
+  let assert_deadline (deadline : timestamp) : unit =
+    Assert.Error.assert (Tezos.get_now () <= deadline) err_expired
+
+  let assert_external_address (candidate : address) : unit =
+    Assert.Error.assert
+      (candidate <> Tezos.get_self_address ())
+      err_invalid_address
+
+  let checked_sub (a : nat) (b : nat) : nat =
+    match is_nat (a - b) with
+    | Some value -> value
+    | None -> failwith err_nat_underflow
+
+  let ceil_div (numerator : nat) (denominator : nat) : nat =
+    match ediv numerator denominator with
+    | Some (quotient, remainder) ->
+        if remainder = 0n then quotient else quotient + 1n
+    | None -> failwith err_insufficient_liquidity
+
+  let min_nat (a : nat) (b : nat) : nat = if a < b then a else b
+
+  [@tailrec]
+  let rec integer_sqrt_step (value : nat) (estimate : nat) : nat =
+    let next = (estimate + (value / estimate)) / 2n in
+    if next >= estimate
+    then estimate
+    else integer_sqrt_step value next
+
+  let integer_sqrt (value : nat) : nat =
+    if value < 2n
+    then value
+    else integer_sqrt_step value ((value / 2n) + 1n)
+
+  let quote_output (amount_in : nat) (reserve_in : nat) (reserve_out : nat) : nat =
+    if amount_in = 0n || reserve_in = 0n || reserve_out = 0n
+    then 0n
+    else
+      let amount_with_fee = amount_in * swap_fee_numerator in
+      (amount_with_fee * reserve_out)
+      / ((reserve_in * fee_denominator) + amount_with_fee)
+
+  let protocol_fee (amount_in : nat) : nat =
+    (amount_in * protocol_fee_bp) / fee_denominator
+
+  (* --------------------------------------------------------------------- *)
+  (* Typed external operations                                             *)
+  (* --------------------------------------------------------------------- *)
+
+  let transfer_fa12
+    (from_ : address)
+    (to_ : address)
+    (amount : nat)
+    (token_address : address)
+  : operation =
+    let transfer_entrypoint : fa12_transfer contract =
+      match
+        (Tezos.get_entrypoint_opt "%transfer" token_address
+          : fa12_transfer contract option)
+      with
+      | Some entrypoint -> entrypoint
+      | None -> failwith err_missing_fa12_transfer in
+    Tezos.transaction (from_, (to_, amount)) 0mutez transfer_entrypoint
+
+  let transfer_fa2
+    (from_ : address)
+    (to_ : address)
+    (amount : nat)
+    (asset : fa2_token)
+  : operation =
+    let transfer_entrypoint : fa2_transfer contract =
+      match
+        (Tezos.get_entrypoint_opt "%transfer" asset.token
+          : fa2_transfer contract option)
+      with
+      | Some entrypoint -> entrypoint
+      | None -> failwith err_missing_fa2_transfer in
+    let parameter : fa2_transfer =
+      [
+        {
+          from_ = from_;
+          txs = [{to_ = to_; token_id = asset.id; amount = amount}]
+        }
+      ] in
+    Tezos.transaction parameter 0mutez transfer_entrypoint
+
+  let transfer_token
+    (from_ : address)
+    (to_ : address)
+    (amount : nat)
+    (asset : token)
+  : operation =
+    match asset with
+    | Fa12 token_address -> transfer_fa12 from_ to_ amount token_address
+    | Fa2 token_info -> transfer_fa2 from_ to_ amount token_info
+
+  let get_lqt_address (s : storage) : address =
+    match s.lqt_address with
+    | Some address -> address
+    | None -> failwith err_lqt_not_set
+
+  let mint_or_burn_lqt
+    (lqt_address : address)
+    (target : address)
+    (quantity : int)
+  : operation =
+    let entrypoint : mint_or_burn contract =
+      match
+        (Tezos.get_entrypoint_opt "%mintOrBurn" lqt_address
+          : mint_or_burn contract option)
+      with
+      | Some entrypoint -> entrypoint
+      | None -> failwith err_missing_lqt_mint_burn in
+    Tezos.transaction {quantity = quantity; target = target} 0mutez entrypoint
+
+  let close_operation () : operation =
+    let entrypoint : unit contract =
+      match
+        (Tezos.get_entrypoint_opt "%close" (Tezos.get_self_address ())
+          : unit contract option)
+      with
+      | Some entrypoint -> entrypoint
+      | None -> failwith err_missing_close in
+    Tezos.transaction () 0mutez entrypoint
+
+  (* --------------------------------------------------------------------- *)
+  (* Pool lifecycle and user actions                                        *)
+  (* --------------------------------------------------------------------- *)
+
+  [@entry]
+  let set_lqt_address (lqt_address : address) (s : storage) : result =
+    let () = assert_non_payable () in
+    let () = assert_idle s in
+    let () = assert_manager s in
+    let () = Assert.Error.assert (not s.active) err_already_active in
+    let () = assert_external_address lqt_address in
+    let () =
+      match s.lqt_address with
+      | None -> ()
+      | Some _ -> failwith err_lqt_already_set in
+    ([], {s with lqt_address = Some lqt_address})
+
+  [@entry]
+  let initialize (param : initialize_param) (s : storage) : result =
+    let () = assert_non_payable () in
+    let () = assert_idle s in
+    let () = assert_manager s in
+    let () = assert_live s in
+    let () = Assert.Error.assert (not s.active) err_already_active in
+    let () = Assert.Error.assert (s.token_a <> s.token_b) err_same_asset in
+    let lqt_address = get_lqt_address s in
+    let () = assert_deadline param.deadline in
+    let () = assert_external_address param.receiver in
+    let () =
+      Assert.Error.assert
+        (param.amount_a > 0n && param.amount_b > 0n)
+        err_zero_amount in
+    let total = integer_sqrt (param.amount_a * param.amount_b) in
+    let () = Assert.Error.assert (total > minimum_lqt) err_minimum_lqt in
+    let provider_lqt = checked_sub total minimum_lqt in
+    let sender = Tezos.get_sender () in
+    let self = Tezos.get_self_address () in
+    let operations =
+      [
+        transfer_token sender self param.amount_a s.token_a;
+        transfer_token sender self param.amount_b s.token_b;
+        mint_or_burn_lqt lqt_address self (int minimum_lqt);
+        mint_or_burn_lqt lqt_address param.receiver (int provider_lqt);
+        close_operation ()
+      ] in
+    (operations,
+     {
+       s with
+       reserve_a = param.amount_a;
+       reserve_b = param.amount_b;
+       lqt_total = total;
+       active = true;
+       entered = true
+     })
+
+  [@entry]
+  let add_liquidity (param : add_liquidity_param) (s : storage) : result =
+    let () = assert_non_payable () in
+    let () = assert_idle s in
+    let () = assert_live s in
+    let () = assert_ready s in
+    let () = assert_deadline param.deadline in
+    let () = assert_external_address param.receiver in
+    let lqt_from_a = (param.max_amount_a * s.lqt_total) / s.reserve_a in
+    let lqt_from_b = (param.max_amount_b * s.lqt_total) / s.reserve_b in
+    let lqt_minted = min_nat lqt_from_a lqt_from_b in
+    let () = Assert.Error.assert (lqt_minted > 0n) err_zero_amount in
+    let () = Assert.Error.assert (lqt_minted >= param.min_lqt_minted) err_slippage in
+    let amount_a = ceil_div (lqt_minted * s.reserve_a) s.lqt_total in
+    let amount_b = ceil_div (lqt_minted * s.reserve_b) s.lqt_total in
+    let () =
+      Assert.Error.assert
+        (amount_a <= param.max_amount_a && amount_b <= param.max_amount_b)
+        err_slippage in
+    let sender = Tezos.get_sender () in
+    let self = Tezos.get_self_address () in
+    let lqt_address = get_lqt_address s in
+    let operations =
+      [
+        transfer_token sender self amount_a s.token_a;
+        transfer_token sender self amount_b s.token_b;
+        mint_or_burn_lqt lqt_address param.receiver (int lqt_minted);
+        close_operation ()
+      ] in
+    (operations,
+     {
+       s with
+       reserve_a = s.reserve_a + amount_a;
+       reserve_b = s.reserve_b + amount_b;
+       lqt_total = s.lqt_total + lqt_minted;
+       entered = true
+     })
+
+  [@entry]
+  let remove_liquidity (param : remove_liquidity_param) (s : storage) : result =
+    let () = assert_non_payable () in
+    let () = assert_idle s in
+    let () = assert_ready s in
+    let () = assert_deadline param.deadline in
+    let () = assert_external_address param.receiver in
+    let () = Assert.Error.assert (param.lqt_burned > 0n) err_zero_amount in
+    let () =
+      Assert.Error.assert
+        (param.lqt_burned <= checked_sub s.lqt_total minimum_lqt)
+        err_minimum_lqt in
+    let amount_a = (param.lqt_burned * s.reserve_a) / s.lqt_total in
+    let amount_b = (param.lqt_burned * s.reserve_b) / s.lqt_total in
+    let () = Assert.Error.assert (amount_a > 0n && amount_b > 0n) err_zero_output in
+    let () =
+      Assert.Error.assert
+        (amount_a >= param.min_amount_a && amount_b >= param.min_amount_b)
+        err_slippage in
+    let new_reserve_a = checked_sub s.reserve_a amount_a in
+    let new_reserve_b = checked_sub s.reserve_b amount_b in
+    let new_total = checked_sub s.lqt_total param.lqt_burned in
+    let () =
+      Assert.Error.assert
+        (new_reserve_a > 0n && new_reserve_b > 0n && new_total >= minimum_lqt)
+        err_minimum_lqt in
+    let self = Tezos.get_self_address () in
+    let lqt_address = get_lqt_address s in
+    let operations =
+      [
+        mint_or_burn_lqt lqt_address (Tezos.get_sender ()) (0 - int param.lqt_burned);
+        transfer_token self param.receiver amount_a s.token_a;
+        transfer_token self param.receiver amount_b s.token_b;
+        close_operation ()
+      ] in
+    (operations,
+     {
+       s with
+       reserve_a = new_reserve_a;
+       reserve_b = new_reserve_b;
+       lqt_total = new_total;
+       entered = true
+     })
+
+  [@entry]
+  let swap (param : swap_param) (s : storage) : result =
+    let () = assert_non_payable () in
+    let () = assert_idle s in
+    let () = assert_live s in
+    let () = assert_ready s in
+    let () = assert_deadline param.deadline in
+    let () = assert_external_address param.receiver in
+    let () = Assert.Error.assert (param.amount_in > 0n) err_zero_amount in
+    let (input_token, output_token, reserve_in, reserve_out) =
+      match param.direction with
+      | A_to_b -> (s.token_a, s.token_b, s.reserve_a, s.reserve_b)
+      | B_to_a -> (s.token_b, s.token_a, s.reserve_b, s.reserve_a) in
+    let amount_out = quote_output param.amount_in reserve_in reserve_out in
+    let () = Assert.Error.assert (amount_out > 0n) err_zero_output in
+    let () = Assert.Error.assert (amount_out < reserve_out) err_insufficient_liquidity in
+    let () = Assert.Error.assert (amount_out >= param.min_amount_out) err_slippage in
+    let protocol_amount = protocol_fee param.amount_in in
+    let reserve_input = checked_sub param.amount_in protocol_amount in
+    let self = Tezos.get_self_address () in
+    let operations =
+      [
+        transfer_token (Tezos.get_sender ()) self param.amount_in input_token;
+        transfer_token self param.receiver amount_out output_token;
+        close_operation ()
+      ] in
+    let updated =
+      match param.direction with
+      | A_to_b ->
+          {
+            s with
+            reserve_a = s.reserve_a + reserve_input;
+            reserve_b = checked_sub s.reserve_b amount_out;
+            protocol_fee_a = s.protocol_fee_a + protocol_amount;
+            entered = true
+          }
+      | B_to_a ->
+          {
+            s with
+            reserve_a = checked_sub s.reserve_a amount_out;
+            reserve_b = s.reserve_b + reserve_input;
+            protocol_fee_b = s.protocol_fee_b + protocol_amount;
+            entered = true
+          } in
+    (operations, updated)
+
+  [@entry]
+  let claim_protocol_fee (side : token_side) (s : storage) : result =
+    let () = assert_non_payable () in
+    let () = assert_idle s in
+    let () = assert_ready s in
+    let self = Tezos.get_self_address () in
+    let (asset, amount, updated) =
+      match side with
+      | Token_a ->
+          (s.token_a, s.protocol_fee_a, {s with protocol_fee_a = 0n; entered = true})
+      | Token_b ->
+          (s.token_b, s.protocol_fee_b, {s with protocol_fee_b = 0n; entered = true}) in
+    let () = Assert.Error.assert (amount > 0n) err_no_protocol_fee in
+    ([transfer_token self s.protocol_fee_recipient amount asset; close_operation ()],
+     updated)
+
+  (* --------------------------------------------------------------------- *)
+  (* Administration                                                        *)
+  (* --------------------------------------------------------------------- *)
+
+  [@entry]
+  let set_paused (paused : bool) (s : storage) : result =
+    let () = assert_non_payable () in
+    let () = assert_idle s in
+    let () = assert_manager s in
+    ([], {s with paused = paused})
+
+  [@entry]
+  let propose_manager (new_manager : address) (s : storage) : result =
+    let () = assert_non_payable () in
+    let () = assert_idle s in
+    let () = assert_manager s in
+    let () = assert_external_address new_manager in
+    ([], {s with pending_manager = Some new_manager})
+
+  [@entry]
+  let cancel_manager_transfer (_ : unit) (s : storage) : result =
+    let () = assert_non_payable () in
+    let () = assert_idle s in
+    let () = assert_manager s in
+    ([], {s with pending_manager = None})
+
+  [@entry]
+  let accept_manager (_ : unit) (s : storage) : result =
+    let () = assert_non_payable () in
+    let () = assert_idle s in
+    let () =
+      match s.pending_manager with
+      | Some pending ->
+          Assert.Error.assert
+            (Tezos.get_sender () = pending)
+            err_not_pending_manager
+      | None -> failwith err_not_pending_manager in
+    ([], {s with manager = Tezos.get_sender (); pending_manager = None})
+
+  [@entry]
+  let propose_protocol_fee_recipient (recipient : address) (s : storage) : result =
+    let () = assert_non_payable () in
+    let () = assert_idle s in
+    let () = assert_manager s in
+    let () = assert_external_address recipient in
+    ([], {s with pending_fee_recipient = Some recipient})
+
+  [@entry]
+  let cancel_protocol_fee_recipient (_ : unit) (s : storage) : result =
+    let () = assert_non_payable () in
+    let () = assert_idle s in
+    let () = assert_manager s in
+    ([], {s with pending_fee_recipient = None})
+
+  [@entry]
+  let accept_protocol_fee_recipient (_ : unit) (s : storage) : result =
+    let () = assert_non_payable () in
+    let () = assert_idle s in
+    let () =
+      match s.pending_fee_recipient with
+      | Some pending ->
+          Assert.Error.assert
+            (Tezos.get_sender () = pending)
+            err_not_pending_fee_recipient
+      | None -> failwith err_not_pending_fee_recipient in
+    ([],
+     {
+       s with
+       protocol_fee_recipient = Tezos.get_sender ();
+       pending_fee_recipient = None
+     })
+
+  [@entry]
+  let close (_ : unit) (s : storage) : result =
+    let () = assert_non_payable () in
+    let () = Assert.Error.assert s.entered err_not_entered in
+    let () =
+      Assert.Error.assert
+        (Tezos.get_sender () = Tezos.get_self_address ())
+        err_self_only in
+    ([], {s with entered = false})
+
+  [@entry]
+  let default (_ : unit) (s : storage) : result =
+    let () = assert_non_payable () in
+    let () = assert_idle s in
+    ([], s)
+
+  (* --------------------------------------------------------------------- *)
+  (* Read-only views                                                        *)
+  (* --------------------------------------------------------------------- *)
+
+  [@view]
+  let get_assets (_ : unit) (s : storage) : token * token =
+    (s.token_a, s.token_b)
+
+  [@view]
+  let get_reserves (_ : unit) (s : storage) : nat * nat =
+    (s.reserve_a, s.reserve_b)
+
+  [@view]
+  let get_protocol_fees (_ : unit) (s : storage) : nat * nat =
+    (s.protocol_fee_a, s.protocol_fee_b)
+
+  [@view]
+  let get_lqt_total (_ : unit) (s : storage) : nat =
+    s.lqt_total
+
+  [@view]
+  let get_minimum_lqt (_ : unit) (_s : storage) : nat =
+    minimum_lqt
+
+  [@view]
+  let get_fee_bp (_ : unit) (_s : storage) : nat * nat * nat =
+    (lp_fee_bp, protocol_fee_bp, total_fee_bp)
+
+  [@view]
+  let is_active (_ : unit) (s : storage) : bool =
+    s.active
+
+  [@view]
+  let is_paused (_ : unit) (s : storage) : bool =
+    s.paused
+
+  [@view]
+  let quote_a_to_b (amount_in : nat) (s : storage) : nat =
+    if s.active && not s.paused
+    then quote_output amount_in s.reserve_a s.reserve_b
+    else 0n
+
+  [@view]
+  let quote_b_to_a (amount_in : nat) (s : storage) : nat =
+    if s.active && not s.paused
+    then quote_output amount_in s.reserve_b s.reserve_a
+    else 0n
+
+  (* --------------------------------------------------------------------- *)
+  (* Origination storage                                                    *)
+  (* --------------------------------------------------------------------- *)
+
+  type build_storage_param =
+    [@layout:comb]
+    {
+      token_a : token;
+      token_b : token;
+      manager : address;
+      protocol_fee_recipient : address;
+      metadata : (string, bytes) big_map
+    }
+
+  let build_storage (param : build_storage_param) : storage =
+    {
+      token_a = param.token_a;
+      token_b = param.token_b;
+      reserve_a = 0n;
+      reserve_b = 0n;
+      protocol_fee_a = 0n;
+      protocol_fee_b = 0n;
+      lqt_total = 0n;
+      lqt_address = None;
+      active = false;
+      paused = false;
+      entered = false;
+      manager = param.manager;
+      pending_manager = None;
+      protocol_fee_recipient = param.protocol_fee_recipient;
+      pending_fee_recipient = None;
+      metadata = param.metadata
+    }
+end

--- a/dex/scripts/.env.example
+++ b/dex/scripts/.env.example
@@ -10,6 +10,11 @@ TESTNET_TZKT_API=
 MAINNET_TZKT_API=
 PREVIEWNET_TZKT_API=
 
+# Expected chain identifiers make the generic token-to-token deployment fail
+# closed if an RPC URL points at the wrong network.
+TESTNET_CHAIN_ID=
+PREVIEWNET_CHAIN_ID=
+
 # Tezos private key for the target network. Seed funds will be taken from this account.
 # PREVIEWNET_PRIVATE_KEY is only required when running deploy:previewnet.
 TESTNET_PRIVATE_KEY=
@@ -65,3 +70,43 @@ TOKEN_ID=
 POOL_TYPE=
 # Modified pools use an immutable 30 bp total swap fee: 25 bp for LPs and
 # 5 bp accumulated for PROTOCOL_FEE_RECIPIENT.
+
+# Token-to-token pool deployment (generic FA1.2/FA2 assets)
+# Previewnet/testnet only. Values are supplied at deployment time; no token,
+# manager, or recipient address is compiled into the pool artifact.
+TOKEN_A_STANDARD=
+TOKEN_A_ADDRESS=
+TOKEN_A_ID=0
+# Canonical script-code SHA-256. Obtain it with:
+# npm run inspect:token -- --rpc=<RPC> --address=<KT1>
+# Review and pin the exact deployed token implementation before setting it.
+TOKEN_A_CODE_SHA256=
+TOKEN_B_STANDARD=
+TOKEN_B_ADDRESS=
+TOKEN_B_ID=0
+TOKEN_B_CODE_SHA256=
+
+# Atomic-unit seed quantities. Initial LQT supply is floor(sqrt(A * B)) and
+# must exceed the permanent 1,000-unit lock.
+SEED_AMOUNT_A=
+SEED_AMOUNT_B=
+# Optional; defaults to the deployment signer.
+SEED_RECEIVER=
+
+# The signer remains temporary manager through setup. This address is proposed
+# after verification and must separately call %accept_manager.
+FINAL_MANAGER=
+
+# Immutable IPFS pointers for this deployment's pool and external FA1.2 LQT.
+TOKEN_TOKEN_POOL_METADATA_URI=ipfs://
+TOKEN_TOKEN_LQT_CONTRACT_METADATA_URI=ipfs://
+TOKEN_TOKEN_LQT_TOKEN_METADATA_URI=ipfs://
+
+# SHA-256 of dex/compiled_contracts/token_token_pool.tz. The deployer rejects
+# any locally compiled artifact that does not match this reviewed digest.
+TOKEN_TOKEN_ARTIFACT_SHA256=
+CONFIRMATIONS=2
+
+# Optional resumable receipt path; mode 0600 and ignored by git. Never contains
+# the private key. Delete only when intentionally abandoning a deployment.
+TOKEN_TOKEN_DEPLOYMENT_STATE=

--- a/dex/scripts/.gitignore
+++ b/dex/scripts/.gitignore
@@ -1,0 +1,2 @@
+deployments/
+dist/

--- a/dex/scripts/package-lock.json
+++ b/dex/scripts/package-lock.json
@@ -9,23 +9,26 @@
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
-                "@taquito/michel-codec": "^23.1.0",
-                "@taquito/michelson-encoder": "^23.1.0",
-                "@taquito/signer": "^23.0.3",
-                "@taquito/taquito": "^23.0.3",
-                "bn.js": "^5.2.2",
+                "@taquito/michel-codec": "^25.0.0",
+                "@taquito/michelson-encoder": "^25.0.0",
+                "@taquito/signer": "^25.0.0",
+                "@taquito/taquito": "^25.0.0",
+                "@taquito/utils": "^25.0.0",
                 "dotenv": "^17.2.3"
             },
             "devDependencies": {
                 "@types/node": "^25.0.0",
                 "tsx": "4.21.0",
                 "typescript": "5.9.3"
+            },
+            "engines": {
+                "node": ">=22"
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
-            "version": "0.27.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.1.tgz",
-            "integrity": "sha512-HHB50pdsBX6k47S4u5g/CaLjqS3qwaOVE5ILsq64jyzgMhLuCuZ8rGzM9yhsAjfjkbgUPMzZEPa7DAp7yz6vuA==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+            "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
             "cpu": [
                 "ppc64"
             ],
@@ -40,9 +43,9 @@
             }
         },
         "node_modules/@esbuild/android-arm": {
-            "version": "0.27.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.1.tgz",
-            "integrity": "sha512-kFqa6/UcaTbGm/NncN9kzVOODjhZW8e+FRdSeypWe6j33gzclHtwlANs26JrupOntlcWmB0u8+8HZo8s7thHvg==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+            "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
             "cpu": [
                 "arm"
             ],
@@ -57,9 +60,9 @@
             }
         },
         "node_modules/@esbuild/android-arm64": {
-            "version": "0.27.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.1.tgz",
-            "integrity": "sha512-45fuKmAJpxnQWixOGCrS+ro4Uvb4Re9+UTieUY2f8AEc+t7d4AaZ6eUJ3Hva7dtrxAAWHtlEFsXFMAgNnGU9uQ==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+            "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
             "cpu": [
                 "arm64"
             ],
@@ -74,9 +77,9 @@
             }
         },
         "node_modules/@esbuild/android-x64": {
-            "version": "0.27.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.1.tgz",
-            "integrity": "sha512-LBEpOz0BsgMEeHgenf5aqmn/lLNTFXVfoWMUox8CtWWYK9X4jmQzWjoGoNb8lmAYml/tQ/Ysvm8q7szu7BoxRQ==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+            "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
             "cpu": [
                 "x64"
             ],
@@ -91,9 +94,9 @@
             }
         },
         "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.27.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.1.tgz",
-            "integrity": "sha512-veg7fL8eMSCVKL7IW4pxb54QERtedFDfY/ASrumK/SbFsXnRazxY4YykN/THYqFnFwJ0aVjiUrVG2PwcdAEqQQ==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+            "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
             "cpu": [
                 "arm64"
             ],
@@ -108,9 +111,9 @@
             }
         },
         "node_modules/@esbuild/darwin-x64": {
-            "version": "0.27.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.1.tgz",
-            "integrity": "sha512-+3ELd+nTzhfWb07Vol7EZ+5PTbJ/u74nC6iv4/lwIU99Ip5uuY6QoIf0Hn4m2HoV0qcnRivN3KSqc+FyCHjoVQ==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+            "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
             "cpu": [
                 "x64"
             ],
@@ -125,9 +128,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.27.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.1.tgz",
-            "integrity": "sha512-/8Rfgns4XD9XOSXlzUDepG8PX+AVWHliYlUkFI3K3GB6tqbdjYqdhcb4BKRd7C0BhZSoaCxhv8kTcBrcZWP+xg==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
             "cpu": [
                 "arm64"
             ],
@@ -142,9 +145,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.27.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.1.tgz",
-            "integrity": "sha512-GITpD8dK9C+r+5yRT/UKVT36h/DQLOHdwGVwwoHidlnA168oD3uxA878XloXebK4Ul3gDBBIvEdL7go9gCUFzQ==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+            "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
             "cpu": [
                 "x64"
             ],
@@ -159,9 +162,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm": {
-            "version": "0.27.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.1.tgz",
-            "integrity": "sha512-ieMID0JRZY/ZeCrsFQ3Y3NlHNCqIhTprJfDgSB3/lv5jJZ8FX3hqPyXWhe+gvS5ARMBJ242PM+VNz/ctNj//eA==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+            "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
             "cpu": [
                 "arm"
             ],
@@ -176,9 +179,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm64": {
-            "version": "0.27.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.1.tgz",
-            "integrity": "sha512-W9//kCrh/6in9rWIBdKaMtuTTzNj6jSeG/haWBADqLLa9P8O5YSRDzgD5y9QBok4AYlzS6ARHifAb75V6G670Q==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+            "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
             "cpu": [
                 "arm64"
             ],
@@ -193,9 +196,9 @@
             }
         },
         "node_modules/@esbuild/linux-ia32": {
-            "version": "0.27.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.1.tgz",
-            "integrity": "sha512-VIUV4z8GD8rtSVMfAj1aXFahsi/+tcoXXNYmXgzISL+KB381vbSTNdeZHHHIYqFyXcoEhu9n5cT+05tRv13rlw==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+            "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
             "cpu": [
                 "ia32"
             ],
@@ -210,9 +213,9 @@
             }
         },
         "node_modules/@esbuild/linux-loong64": {
-            "version": "0.27.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.1.tgz",
-            "integrity": "sha512-l4rfiiJRN7sTNI//ff65zJ9z8U+k6zcCg0LALU5iEWzY+a1mVZ8iWC1k5EsNKThZ7XCQ6YWtsZ8EWYm7r1UEsg==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+            "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
             "cpu": [
                 "loong64"
             ],
@@ -227,9 +230,9 @@
             }
         },
         "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.27.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.1.tgz",
-            "integrity": "sha512-U0bEuAOLvO/DWFdygTHWY8C067FXz+UbzKgxYhXC0fDieFa0kDIra1FAhsAARRJbvEyso8aAqvPdNxzWuStBnA==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+            "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
             "cpu": [
                 "mips64el"
             ],
@@ -244,9 +247,9 @@
             }
         },
         "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.27.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.1.tgz",
-            "integrity": "sha512-NzdQ/Xwu6vPSf/GkdmRNsOfIeSGnh7muundsWItmBsVpMoNPVpM61qNzAVY3pZ1glzzAxLR40UyYM23eaDDbYQ==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+            "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -261,9 +264,9 @@
             }
         },
         "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.27.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.1.tgz",
-            "integrity": "sha512-7zlw8p3IApcsN7mFw0O1Z1PyEk6PlKMu18roImfl3iQHTnr/yAfYv6s4hXPidbDoI2Q0pW+5xeoM4eTCC0UdrQ==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+            "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
             "cpu": [
                 "riscv64"
             ],
@@ -278,9 +281,9 @@
             }
         },
         "node_modules/@esbuild/linux-s390x": {
-            "version": "0.27.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.1.tgz",
-            "integrity": "sha512-cGj5wli+G+nkVQdZo3+7FDKC25Uh4ZVwOAK6A06Hsvgr8WqBBuOy/1s+PUEd/6Je+vjfm6stX0kmib5b/O2Ykw==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+            "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
             "cpu": [
                 "s390x"
             ],
@@ -295,9 +298,9 @@
             }
         },
         "node_modules/@esbuild/linux-x64": {
-            "version": "0.27.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.1.tgz",
-            "integrity": "sha512-z3H/HYI9MM0HTv3hQZ81f+AKb+yEoCRlUby1F80vbQ5XdzEMyY/9iNlAmhqiBKw4MJXwfgsh7ERGEOhrM1niMA==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+            "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
             "cpu": [
                 "x64"
             ],
@@ -312,9 +315,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-arm64": {
-            "version": "0.27.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.1.tgz",
-            "integrity": "sha512-wzC24DxAvk8Em01YmVXyjl96Mr+ecTPyOuADAvjGg+fyBpGmxmcr2E5ttf7Im8D0sXZihpxzO1isus8MdjMCXQ==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
             "cpu": [
                 "arm64"
             ],
@@ -329,9 +332,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.27.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.1.tgz",
-            "integrity": "sha512-1YQ8ybGi2yIXswu6eNzJsrYIGFpnlzEWRl6iR5gMgmsrR0FcNoV1m9k9sc3PuP5rUBLshOZylc9nqSgymI+TYg==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+            "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
             "cpu": [
                 "x64"
             ],
@@ -346,9 +349,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-arm64": {
-            "version": "0.27.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.1.tgz",
-            "integrity": "sha512-5Z+DzLCrq5wmU7RDaMDe2DVXMRm2tTDvX2KU14JJVBN2CT/qov7XVix85QoJqHltpvAOZUAc3ndU56HSMWrv8g==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
             "cpu": [
                 "arm64"
             ],
@@ -363,9 +366,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.27.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.1.tgz",
-            "integrity": "sha512-Q73ENzIdPF5jap4wqLtsfh8YbYSZ8Q0wnxplOlZUOyZy7B4ZKW8DXGWgTCZmF8VWD7Tciwv5F4NsRf6vYlZtqg==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+            "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
             "cpu": [
                 "x64"
             ],
@@ -380,9 +383,9 @@
             }
         },
         "node_modules/@esbuild/openharmony-arm64": {
-            "version": "0.27.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.1.tgz",
-            "integrity": "sha512-ajbHrGM/XiK+sXM0JzEbJAen+0E+JMQZ2l4RR4VFwvV9JEERx+oxtgkpoKv1SevhjavK2z2ReHk32pjzktWbGg==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+            "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
             "cpu": [
                 "arm64"
             ],
@@ -397,9 +400,9 @@
             }
         },
         "node_modules/@esbuild/sunos-x64": {
-            "version": "0.27.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.1.tgz",
-            "integrity": "sha512-IPUW+y4VIjuDVn+OMzHc5FV4GubIwPnsz6ubkvN8cuhEqH81NovB53IUlrlBkPMEPxvNnf79MGBoz8rZ2iW8HA==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+            "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
             "cpu": [
                 "x64"
             ],
@@ -414,9 +417,9 @@
             }
         },
         "node_modules/@esbuild/win32-arm64": {
-            "version": "0.27.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.1.tgz",
-            "integrity": "sha512-RIVRWiljWA6CdVu8zkWcRmGP7iRRIIwvhDKem8UMBjPql2TXM5PkDVvvrzMtj1V+WFPB4K7zkIGM7VzRtFkjdg==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+            "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
             "cpu": [
                 "arm64"
             ],
@@ -431,9 +434,9 @@
             }
         },
         "node_modules/@esbuild/win32-ia32": {
-            "version": "0.27.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.1.tgz",
-            "integrity": "sha512-2BR5M8CPbptC1AK5JbJT1fWrHLvejwZidKx3UMSF0ecHMa+smhi16drIrCEggkgviBwLYd5nwrFLSl5Kho96RQ==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+            "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
             "cpu": [
                 "ia32"
             ],
@@ -448,9 +451,9 @@
             }
         },
         "node_modules/@esbuild/win32-x64": {
-            "version": "0.27.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.1.tgz",
-            "integrity": "sha512-d5X6RMYv6taIymSk8JBP+nxv8DQAMY6A51GPgusqLdK9wBz5wWIXy1KjTck6HnjE9hqJzJRdk+1p/t5soSbCtw==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+            "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
             "cpu": [
                 "x64"
             ],
@@ -491,6 +494,30 @@
                 "url": "https://paulmillr.com/funding/"
             }
         },
+        "node_modules/@scure/bip39": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-2.3.0.tgz",
+            "integrity": "sha512-qdyWuxoYwi3+YmqIsfkpz1I029m980WkVPilj+kG7VxSm+gKQ2BmQru3nv3LbMtpSUXuyZwdFT65JkpKu5OHOQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@noble/hashes": "2.3.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/@scure/bip39/node_modules/@noble/hashes": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.3.0.tgz",
+            "integrity": "sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20.19.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
         "node_modules/@stablelib/binary": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/@stablelib/binary/-/binary-1.0.1.tgz",
@@ -498,17 +525,6 @@
             "license": "MIT",
             "dependencies": {
                 "@stablelib/int": "^1.0.1"
-            }
-        },
-        "node_modules/@stablelib/blake2b": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@stablelib/blake2b/-/blake2b-1.0.1.tgz",
-            "integrity": "sha512-B3KyKoBAjkIFeH7romcF96i+pVFYk7K2SBQ1pZvaxV+epSBXJ+n0C66esUhyz6FF+5FbdQVm77C5fzGFcEZpKA==",
-            "license": "MIT",
-            "dependencies": {
-                "@stablelib/binary": "^1.0.1",
-                "@stablelib/hash": "^1.0.1",
-                "@stablelib/wipe": "^1.0.1"
             }
         },
         "node_modules/@stablelib/bytes": {
@@ -522,34 +538,6 @@
             "resolved": "https://registry.npmjs.org/@stablelib/constant-time/-/constant-time-1.0.1.tgz",
             "integrity": "sha512-tNOs3uD0vSJcK6z1fvef4Y+buN7DXhzHDPqRLSXUel1UfqMB1PWNsnnAezrKfEwTLpN0cGH2p9NNjs6IqeD0eg==",
             "license": "MIT"
-        },
-        "node_modules/@stablelib/ed25519": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@stablelib/ed25519/-/ed25519-1.0.3.tgz",
-            "integrity": "sha512-puIMWaX9QlRsbhxfDc5i+mNPMY+0TmQEskunY1rZEBPi1acBCVQAhnsk/1Hk50DGPtVsZtAWQg4NHGlVaO9Hqg==",
-            "license": "MIT",
-            "dependencies": {
-                "@stablelib/random": "^1.0.2",
-                "@stablelib/sha512": "^1.0.1",
-                "@stablelib/wipe": "^1.0.1"
-            }
-        },
-        "node_modules/@stablelib/hash": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@stablelib/hash/-/hash-1.0.1.tgz",
-            "integrity": "sha512-eTPJc/stDkdtOcrNMZ6mcMK1e6yBbqRBaNW55XA1jU8w/7QdnCF0CmMmOD1m7VSkBR44PWrMHU2l6r8YEQHMgg==",
-            "license": "MIT"
-        },
-        "node_modules/@stablelib/hmac": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@stablelib/hmac/-/hmac-1.0.1.tgz",
-            "integrity": "sha512-V2APD9NSnhVpV/QMYgCVMIYKiYG6LSqw1S65wxVoirhU/51ACio6D4yDVSwMzuTJXWZoVHbDdINioBwKy5kVmA==",
-            "license": "MIT",
-            "dependencies": {
-                "@stablelib/constant-time": "^1.0.1",
-                "@stablelib/hash": "^1.0.1",
-                "@stablelib/wipe": "^1.0.1"
-            }
         },
         "node_modules/@stablelib/int": {
             "version": "1.0.1",
@@ -577,18 +565,6 @@
                 "@stablelib/wipe": "^1.0.1",
                 "@stablelib/x25519": "^1.0.3",
                 "@stablelib/xsalsa20": "^1.0.2"
-            }
-        },
-        "node_modules/@stablelib/pbkdf2": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@stablelib/pbkdf2/-/pbkdf2-1.0.1.tgz",
-            "integrity": "sha512-d5jwK6jW1DkMyzqY8D1Io+fRXcsUVr95lk5LKX9ghaUdAITTc1ZL0bff+R0IrwSixbHluxhnivG7vDw59AZ/Nw==",
-            "license": "MIT",
-            "dependencies": {
-                "@stablelib/binary": "^1.0.1",
-                "@stablelib/hash": "^1.0.1",
-                "@stablelib/hmac": "^1.0.1",
-                "@stablelib/wipe": "^1.0.1"
             }
         },
         "node_modules/@stablelib/poly1305": {
@@ -622,17 +598,6 @@
                 "@stablelib/wipe": "^1.0.1"
             }
         },
-        "node_modules/@stablelib/sha512": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@stablelib/sha512/-/sha512-1.0.1.tgz",
-            "integrity": "sha512-13gl/iawHV9zvDKciLo1fQ8Bgn2Pvf7OV6amaRVKiq3pjQ3UmEpXxWiAfV8tYjUpeZroBxtyrwtdooQT/i3hzw==",
-            "license": "MIT",
-            "dependencies": {
-                "@stablelib/binary": "^1.0.1",
-                "@stablelib/hash": "^1.0.1",
-                "@stablelib/wipe": "^1.0.1"
-            }
-        },
         "node_modules/@stablelib/wipe": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.1.tgz",
@@ -662,154 +627,171 @@
             }
         },
         "node_modules/@taquito/core": {
-            "version": "23.1.0",
-            "resolved": "https://registry.npmjs.org/@taquito/core/-/core-23.1.0.tgz",
-            "integrity": "sha512-7gTcQ2XtyGzXRPuph0mBRd2AfwOzagGrIZ6OPwlurl3RlOvUSInA0v8GOud7JwNVgLJJCz4L4EEfkdOZY9/LIg==",
+            "version": "25.0.0",
+            "resolved": "https://registry.npmjs.org/@taquito/core/-/core-25.0.0.tgz",
+            "integrity": "sha512-TlU+eMEn47mAmIjTFP2U4ReHRU05FsnyVn/c5DQnJC0psZ6LRJXimAIA1KQ94afsCDByewsXLN5fjKwn47l72A==",
             "license": "Apache-2.0",
             "dependencies": {
                 "json-stringify-safe": "^5.0.1"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=22"
             }
         },
         "node_modules/@taquito/http-utils": {
-            "version": "23.1.0",
-            "resolved": "https://registry.npmjs.org/@taquito/http-utils/-/http-utils-23.1.0.tgz",
-            "integrity": "sha512-720BWBvkYAhuRbKYpU7ebNV8EWlUp5eD0/ra2ZfWrLV6iYxDf1tayER/cKYkLvJhw4B0ZK12/G+B3urf8ot+OQ==",
+            "version": "25.0.0",
+            "resolved": "https://registry.npmjs.org/@taquito/http-utils/-/http-utils-25.0.0.tgz",
+            "integrity": "sha512-/nkwDeTXEW10lSQdyTrLgp9GIWQc2yi6wQLjEFvXveevrMjuA+lfFU8QoOOZxXH0GM42KEmU/y/VA1wcgl+gKQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@taquito/core": "^23.1.0",
-                "node-fetch": "^2.7.0"
+                "@taquito/core": "^25.0.0"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=22"
             }
         },
         "node_modules/@taquito/local-forging": {
-            "version": "23.1.0",
-            "resolved": "https://registry.npmjs.org/@taquito/local-forging/-/local-forging-23.1.0.tgz",
-            "integrity": "sha512-6JZTWY60fEfhutXj3xx167tQgluzXdBwov694ESrZ8wi7wGEQYa69F047SGJIQFM53o/iGMVSgaGsPCSOaDf/Q==",
+            "version": "25.0.0",
+            "resolved": "https://registry.npmjs.org/@taquito/local-forging/-/local-forging-25.0.0.tgz",
+            "integrity": "sha512-sFeObpxya59PP5xFFsPWb3zLxASe3QwQqQ1fJWTPCs/Fph7/cxk5Kj0Oco961SC7CVSkG/ayz4/WINmm+oTlPA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@taquito/core": "^23.1.0",
-                "@taquito/utils": "^23.1.0",
-                "bignumber.js": "^9.1.2",
+                "@taquito/core": "^25.0.0",
+                "@taquito/utils": "^25.0.0",
+                "bignumber.js": "^10.0.2",
                 "fast-text-encoding": "^1.0.6"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=22"
             }
         },
         "node_modules/@taquito/michel-codec": {
-            "version": "23.1.0",
-            "resolved": "https://registry.npmjs.org/@taquito/michel-codec/-/michel-codec-23.1.0.tgz",
-            "integrity": "sha512-lrCfw7yrVkONDjw8cq4PwGzi8DycBMp6QpNfqoLB2t7DsCyGBwfudz+iTo+RIRPCXtBi7SP6U9u6GhOK/dWs1Q==",
+            "version": "25.0.0",
+            "resolved": "https://registry.npmjs.org/@taquito/michel-codec/-/michel-codec-25.0.0.tgz",
+            "integrity": "sha512-ITM3lM3tEAblPVdzQk5Rv2nLMMOalrXbnIt5b5St8OVYwqaDyfsH3fxSGIVDPxRQyyBdgJ1403aVu6768/8m4Q==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@taquito/core": "^23.1.0"
+                "@taquito/core": "^25.0.0"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=22"
             }
         },
         "node_modules/@taquito/michelson-encoder": {
-            "version": "23.1.0",
-            "resolved": "https://registry.npmjs.org/@taquito/michelson-encoder/-/michelson-encoder-23.1.0.tgz",
-            "integrity": "sha512-zUYXWUIxaQQlL6GCRLfTdUiguHea7YlJ9Hv5QMayegDu2We97AAOJSD8QttpeKii+YDhhybbvMX7KrXQidSt2g==",
+            "version": "25.0.0",
+            "resolved": "https://registry.npmjs.org/@taquito/michelson-encoder/-/michelson-encoder-25.0.0.tgz",
+            "integrity": "sha512-BWwAAwBhY3zngcMK8SkmBWDZ5aNVRnHlHvi7Xu6jnGW109yM3n9awxxCrFD8jOXPb3dly+/pulGnkv28+EvIIQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@taquito/core": "^23.1.0",
-                "@taquito/rpc": "^23.1.0",
-                "@taquito/signer": "^23.1.0",
-                "@taquito/utils": "^23.1.0",
-                "bignumber.js": "^9.1.2",
+                "@taquito/core": "^25.0.0",
+                "@taquito/rpc": "^25.0.0",
+                "@taquito/signer": "^25.0.0",
+                "@taquito/utils": "^25.0.0",
+                "bignumber.js": "^10.0.2",
                 "fast-json-stable-stringify": "^2.1.0"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=22"
             }
         },
         "node_modules/@taquito/rpc": {
-            "version": "23.1.0",
-            "resolved": "https://registry.npmjs.org/@taquito/rpc/-/rpc-23.1.0.tgz",
-            "integrity": "sha512-daP1M42qC66Wyc91qWVUPfoHNRbv2SFVZvwcAx/jwhrV+Jpd2YkyZUArYJ13PYUEIRAKiFV2ym67cobEShsMkQ==",
+            "version": "25.0.0",
+            "resolved": "https://registry.npmjs.org/@taquito/rpc/-/rpc-25.0.0.tgz",
+            "integrity": "sha512-qqV4boldGOavsM6ZzK6xky4xAEyllYDyIO5C16cvkoUzoMCCsWMpRuXa1csSrQc+0IECkkDurNLTbrMJPne9tA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@taquito/core": "^23.1.0",
-                "@taquito/http-utils": "^23.1.0",
-                "@taquito/utils": "^23.1.0",
-                "bignumber.js": "^9.1.2"
+                "@taquito/core": "^25.0.0",
+                "@taquito/http-utils": "^25.0.0",
+                "@taquito/utils": "^25.0.0",
+                "bignumber.js": "^10.0.2"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=22"
             }
         },
         "node_modules/@taquito/signer": {
-            "version": "23.1.0",
-            "resolved": "https://registry.npmjs.org/@taquito/signer/-/signer-23.1.0.tgz",
-            "integrity": "sha512-eA4Z0L88L57RG6CGzhPFSa2I9VTrMSvycKA3UXi1zBwSnxWh1atL4ndPKUeg+qVFC9k/thOAo7x8eT1C4MZ3RA==",
+            "version": "25.0.0",
+            "resolved": "https://registry.npmjs.org/@taquito/signer/-/signer-25.0.0.tgz",
+            "integrity": "sha512-UDHwWd3O0VwZjbEw0NDsoQoIhoQv+xHxb/XAKW7ruSjUT6OkH5whhHpgTZ+T2eJLPDBZLY1RH8IdSl+6ZFtUXg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@noble/curves": "^1.9.7",
-                "@stablelib/blake2b": "^1.0.1",
-                "@stablelib/ed25519": "^1.0.3",
-                "@stablelib/hmac": "^1.0.1",
+                "@noble/hashes": "^2.2.0",
+                "@scure/bip39": "^2.2.0",
                 "@stablelib/nacl": "^1.0.4",
-                "@stablelib/pbkdf2": "^1.0.1",
-                "@stablelib/sha512": "^1.0.1",
-                "@taquito/core": "^23.1.0",
-                "@taquito/utils": "^23.1.0",
+                "@taquito/core": "^25.0.0",
+                "@taquito/utils": "^25.0.0",
                 "@types/bn.js": "^5.1.5",
-                "bip39": "3.1.0",
-                "pbkdf2": "^3.1.2",
+                "bn.js": "^5.2.2",
                 "typedarray-to-buffer": "^4.0.0"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=22"
+            }
+        },
+        "node_modules/@taquito/signer/node_modules/@noble/hashes": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.3.0.tgz",
+            "integrity": "sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20.19.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
             }
         },
         "node_modules/@taquito/taquito": {
-            "version": "23.1.0",
-            "resolved": "https://registry.npmjs.org/@taquito/taquito/-/taquito-23.1.0.tgz",
-            "integrity": "sha512-M3GtA9ICmZ6KHn3z8jKgzr/5D9cOnjZ/guXm8gtyzmJPyJssL5JRykPQS5H0UdXBvEfSc3GOCqSioqbJFrl6Vg==",
-            "hasInstallScript": true,
+            "version": "25.0.0",
+            "resolved": "https://registry.npmjs.org/@taquito/taquito/-/taquito-25.0.0.tgz",
+            "integrity": "sha512-MBNKXK1CrOlwBrI0IkjWbVcuwY238ZF8B6fuf2qA0uYp+UmVjukUJ4QCvRf+bayWzfiWBbkYP0upY6VGV3C1VQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@taquito/core": "^23.1.0",
-                "@taquito/http-utils": "^23.1.0",
-                "@taquito/local-forging": "^23.1.0",
-                "@taquito/michel-codec": "^23.1.0",
-                "@taquito/michelson-encoder": "^23.1.0",
-                "@taquito/rpc": "^23.1.0",
-                "@taquito/signer": "^23.1.0",
-                "@taquito/utils": "^23.1.0",
-                "bignumber.js": "^9.1.2",
+                "@taquito/core": "^25.0.0",
+                "@taquito/http-utils": "^25.0.0",
+                "@taquito/local-forging": "^25.0.0",
+                "@taquito/michel-codec": "^25.0.0",
+                "@taquito/michelson-encoder": "^25.0.0",
+                "@taquito/rpc": "^25.0.0",
+                "@taquito/signer": "^25.0.0",
+                "@taquito/utils": "^25.0.0",
+                "bignumber.js": "^10.0.2",
                 "rxjs": "^7.8.2"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=22"
             }
         },
         "node_modules/@taquito/utils": {
-            "version": "23.1.0",
-            "resolved": "https://registry.npmjs.org/@taquito/utils/-/utils-23.1.0.tgz",
-            "integrity": "sha512-CC6dLj6Ppjn28HZEok3q/7IjwCAyCUUC9olczz1S9diEAByxgI+XKKbkCXAOjAC8ogpCosHvU3n3crQuCd8ycg==",
+            "version": "25.0.0",
+            "resolved": "https://registry.npmjs.org/@taquito/utils/-/utils-25.0.0.tgz",
+            "integrity": "sha512-I/9hndZcx0yL6f1djPMhgxCpAopbh/E1ta5kYGs3AxDGrYKt0QpbWAvvUV7fwU9kgzHRQlm7fX8DP7zUbz7ntg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@noble/curves": "^1.9.7",
-                "@stablelib/blake2b": "^1.0.1",
-                "@stablelib/ed25519": "^1.0.3",
-                "@taquito/core": "^23.1.0",
+                "@noble/hashes": "^2.2.0",
+                "@taquito/core": "^25.0.0",
                 "@types/bs58check": "^2.1.2",
-                "bignumber.js": "^9.1.2",
+                "bignumber.js": "^10.0.2",
                 "blakejs": "^1.2.1",
                 "bs58check": "^3.0.1",
                 "buffer": "^6.0.3",
                 "typedarray-to-buffer": "^4.0.0"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=22"
+            }
+        },
+        "node_modules/@taquito/utils/node_modules/@noble/hashes": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.3.0.tgz",
+            "integrity": "sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20.19.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
             }
         },
         "node_modules/@types/bn.js": {
@@ -831,27 +813,12 @@
             }
         },
         "node_modules/@types/node": {
-            "version": "25.0.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.1.tgz",
-            "integrity": "sha512-czWPzKIAXucn9PtsttxmumiQ9N0ok9FrBwgRWrwmVLlp86BrMExzvXRLFYRJ+Ex3g6yqj+KuaxfX1JTgV2lpfg==",
+            "version": "25.9.5",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
+            "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
             "license": "MIT",
             "dependencies": {
-                "undici-types": "~7.16.0"
-            }
-        },
-        "node_modules/available-typed-arrays": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
-            "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-            "license": "MIT",
-            "dependencies": {
-                "possible-typed-array-names": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
+                "undici-types": ">=7.24.0 <7.24.7"
             }
         },
         "node_modules/base-x": {
@@ -881,22 +848,10 @@
             "license": "MIT"
         },
         "node_modules/bignumber.js": {
-            "version": "9.3.1",
-            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
-            "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
-            "license": "MIT",
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/bip39": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.1.0.tgz",
-            "integrity": "sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==",
-            "license": "ISC",
-            "dependencies": {
-                "@noble/hashes": "^1.2.0"
-            }
+            "version": "10.0.2",
+            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-10.0.2.tgz",
+            "integrity": "sha512-E8Wp9O06QA6lneJ4aRUXKYf/1GIomqUEmUMwtIOMtDxf1U52ffJY+y7JBk/8wRafA8qOIqLnXQGqonYXZdBnFQ==",
+            "license": "MIT"
         },
         "node_modules/blakejs": {
             "version": "1.2.1",
@@ -905,9 +860,9 @@
             "license": "MIT"
         },
         "node_modules/bn.js": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.2.tgz",
-            "integrity": "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==",
+            "version": "5.2.5",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.5.tgz",
+            "integrity": "sha512-Vq886eXykuP5E6HcKSSStP3bJgrE6In5WKxVUvJ8XGpWWYs2xZHWqUwzCtGgEtBcxyd57KBFDPFoUfNzdaHCNg==",
             "license": "MIT"
         },
         "node_modules/bs58": {
@@ -953,121 +908,10 @@
                 "ieee754": "^1.2.1"
             }
         },
-        "node_modules/call-bind": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-            "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
-            "license": "MIT",
-            "dependencies": {
-                "call-bind-apply-helpers": "^1.0.0",
-                "es-define-property": "^1.0.0",
-                "get-intrinsic": "^1.2.4",
-                "set-function-length": "^1.2.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/call-bind-apply-helpers": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "function-bind": "^1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/call-bound": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-            "license": "MIT",
-            "dependencies": {
-                "call-bind-apply-helpers": "^1.0.2",
-                "get-intrinsic": "^1.3.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/cipher-base": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.7.tgz",
-            "integrity": "sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==",
-            "license": "MIT",
-            "dependencies": {
-                "inherits": "^2.0.4",
-                "safe-buffer": "^5.2.1",
-                "to-buffer": "^1.2.2"
-            },
-            "engines": {
-                "node": ">= 0.10"
-            }
-        },
-        "node_modules/core-util-is": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-            "license": "MIT"
-        },
-        "node_modules/create-hash": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
-            "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-            "license": "MIT",
-            "dependencies": {
-                "cipher-base": "^1.0.1",
-                "inherits": "^2.0.1",
-                "md5.js": "^1.3.4",
-                "ripemd160": "^2.0.1",
-                "sha.js": "^2.4.0"
-            }
-        },
-        "node_modules/create-hmac": {
-            "version": "1.1.7",
-            "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
-            "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-            "license": "MIT",
-            "dependencies": {
-                "cipher-base": "^1.0.3",
-                "create-hash": "^1.1.0",
-                "inherits": "^2.0.1",
-                "ripemd160": "^2.0.0",
-                "safe-buffer": "^5.0.1",
-                "sha.js": "^2.4.8"
-            }
-        },
-        "node_modules/define-data-property": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-            "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-            "license": "MIT",
-            "dependencies": {
-                "es-define-property": "^1.0.0",
-                "es-errors": "^1.3.0",
-                "gopd": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/dotenv": {
-            "version": "17.2.3",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
-            "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
+            "version": "17.4.2",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+            "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=12"
@@ -1076,54 +920,10 @@
                 "url": "https://dotenvx.com"
             }
         },
-        "node_modules/dunder-proto": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-            "license": "MIT",
-            "dependencies": {
-                "call-bind-apply-helpers": "^1.0.1",
-                "es-errors": "^1.3.0",
-                "gopd": "^1.2.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-define-property": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-errors": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-object-atoms": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
         "node_modules/esbuild": {
-            "version": "0.27.1",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.1.tgz",
-            "integrity": "sha512-yY35KZckJJuVVPXpvjgxiCuVEJT67F6zDeVTv4rizyPrfGBUpZQsvmxnN+C371c2esD/hNMjj4tpBhuueLN7aA==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+            "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
@@ -1134,32 +934,32 @@
                 "node": ">=18"
             },
             "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.27.1",
-                "@esbuild/android-arm": "0.27.1",
-                "@esbuild/android-arm64": "0.27.1",
-                "@esbuild/android-x64": "0.27.1",
-                "@esbuild/darwin-arm64": "0.27.1",
-                "@esbuild/darwin-x64": "0.27.1",
-                "@esbuild/freebsd-arm64": "0.27.1",
-                "@esbuild/freebsd-x64": "0.27.1",
-                "@esbuild/linux-arm": "0.27.1",
-                "@esbuild/linux-arm64": "0.27.1",
-                "@esbuild/linux-ia32": "0.27.1",
-                "@esbuild/linux-loong64": "0.27.1",
-                "@esbuild/linux-mips64el": "0.27.1",
-                "@esbuild/linux-ppc64": "0.27.1",
-                "@esbuild/linux-riscv64": "0.27.1",
-                "@esbuild/linux-s390x": "0.27.1",
-                "@esbuild/linux-x64": "0.27.1",
-                "@esbuild/netbsd-arm64": "0.27.1",
-                "@esbuild/netbsd-x64": "0.27.1",
-                "@esbuild/openbsd-arm64": "0.27.1",
-                "@esbuild/openbsd-x64": "0.27.1",
-                "@esbuild/openharmony-arm64": "0.27.1",
-                "@esbuild/sunos-x64": "0.27.1",
-                "@esbuild/win32-arm64": "0.27.1",
-                "@esbuild/win32-ia32": "0.27.1",
-                "@esbuild/win32-x64": "0.27.1"
+                "@esbuild/aix-ppc64": "0.27.7",
+                "@esbuild/android-arm": "0.27.7",
+                "@esbuild/android-arm64": "0.27.7",
+                "@esbuild/android-x64": "0.27.7",
+                "@esbuild/darwin-arm64": "0.27.7",
+                "@esbuild/darwin-x64": "0.27.7",
+                "@esbuild/freebsd-arm64": "0.27.7",
+                "@esbuild/freebsd-x64": "0.27.7",
+                "@esbuild/linux-arm": "0.27.7",
+                "@esbuild/linux-arm64": "0.27.7",
+                "@esbuild/linux-ia32": "0.27.7",
+                "@esbuild/linux-loong64": "0.27.7",
+                "@esbuild/linux-mips64el": "0.27.7",
+                "@esbuild/linux-ppc64": "0.27.7",
+                "@esbuild/linux-riscv64": "0.27.7",
+                "@esbuild/linux-s390x": "0.27.7",
+                "@esbuild/linux-x64": "0.27.7",
+                "@esbuild/netbsd-arm64": "0.27.7",
+                "@esbuild/netbsd-x64": "0.27.7",
+                "@esbuild/openbsd-arm64": "0.27.7",
+                "@esbuild/openbsd-x64": "0.27.7",
+                "@esbuild/openharmony-arm64": "0.27.7",
+                "@esbuild/sunos-x64": "0.27.7",
+                "@esbuild/win32-arm64": "0.27.7",
+                "@esbuild/win32-ia32": "0.27.7",
+                "@esbuild/win32-x64": "0.27.7"
             }
         },
         "node_modules/fast-json-stable-stringify": {
@@ -1173,21 +973,6 @@
             "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz",
             "integrity": "sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==",
             "license": "Apache-2.0"
-        },
-        "node_modules/for-each": {
-            "version": "0.3.5",
-            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
-            "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
-            "license": "MIT",
-            "dependencies": {
-                "is-callable": "^1.2.7"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
         },
         "node_modules/fsevents": {
             "version": "2.3.3",
@@ -1204,56 +989,10 @@
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
         },
-        "node_modules/function-bind": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/get-intrinsic": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-            "license": "MIT",
-            "dependencies": {
-                "call-bind-apply-helpers": "^1.0.2",
-                "es-define-property": "^1.0.1",
-                "es-errors": "^1.3.0",
-                "es-object-atoms": "^1.1.1",
-                "function-bind": "^1.1.2",
-                "get-proto": "^1.0.1",
-                "gopd": "^1.2.0",
-                "has-symbols": "^1.1.0",
-                "hasown": "^2.0.2",
-                "math-intrinsics": "^1.1.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/get-proto": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-            "license": "MIT",
-            "dependencies": {
-                "dunder-proto": "^1.0.1",
-                "es-object-atoms": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
         "node_modules/get-tsconfig": {
-            "version": "4.13.0",
-            "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
-            "integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
+            "version": "4.14.2",
+            "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.2.tgz",
+            "integrity": "sha512-XpwZALwwl/BaKTAyC6+c5T8y6kCg2jk+XGqOVrKIQmW49pNypYLMRjCUXqa28tQgJlhS2RlzP7sc+Rx7W6qsfw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1261,84 +1000,6 @@
             },
             "funding": {
                 "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-            }
-        },
-        "node_modules/gopd": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/has-property-descriptors": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-            "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-            "license": "MIT",
-            "dependencies": {
-                "es-define-property": "^1.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/has-symbols": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/has-tostringtag": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-            "license": "MIT",
-            "dependencies": {
-                "has-symbols": "^1.0.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/hash-base": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.2.tgz",
-            "integrity": "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==",
-            "license": "MIT",
-            "dependencies": {
-                "inherits": "^2.0.4",
-                "readable-stream": "^2.3.8",
-                "safe-buffer": "^5.2.1",
-                "to-buffer": "^1.2.1"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "node_modules/hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-            "license": "MIT",
-            "dependencies": {
-                "function-bind": "^1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
             }
         },
         "node_modules/ieee754": {
@@ -1361,143 +1022,11 @@
             ],
             "license": "BSD-3-Clause"
         },
-        "node_modules/inherits": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "license": "ISC"
-        },
-        "node_modules/is-callable": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-            "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-typed-array": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
-            "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
-            "license": "MIT",
-            "dependencies": {
-                "which-typed-array": "^1.1.16"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/isarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-            "license": "MIT"
-        },
         "node_modules/json-stringify-safe": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
             "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
             "license": "ISC"
-        },
-        "node_modules/math-intrinsics": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/md5.js": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
-            "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
-            "license": "MIT",
-            "dependencies": {
-                "hash-base": "^3.0.0",
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.1.2"
-            }
-        },
-        "node_modules/node-fetch": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-            "license": "MIT",
-            "dependencies": {
-                "whatwg-url": "^5.0.0"
-            },
-            "engines": {
-                "node": "4.x || >=6.0.0"
-            },
-            "peerDependencies": {
-                "encoding": "^0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "encoding": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/pbkdf2": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.5.tgz",
-            "integrity": "sha512-Q3CG/cYvCO1ye4QKkuH7EXxs3VC/rI1/trd+qX2+PolbaKG0H+bgcZzrTt96mMyRtejk+JMCiLUn3y29W8qmFQ==",
-            "license": "MIT",
-            "dependencies": {
-                "create-hash": "^1.2.0",
-                "create-hmac": "^1.1.7",
-                "ripemd160": "^2.0.3",
-                "safe-buffer": "^5.2.1",
-                "sha.js": "^2.4.12",
-                "to-buffer": "^1.2.1"
-            },
-            "engines": {
-                "node": ">= 0.10"
-            }
-        },
-        "node_modules/possible-typed-array-names": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
-            "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/process-nextick-args": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-            "license": "MIT"
-        },
-        "node_modules/readable-stream": {
-            "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-            "license": "MIT",
-            "dependencies": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-            }
-        },
-        "node_modules/readable-stream/node_modules/safe-buffer": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "license": "MIT"
         },
         "node_modules/resolve-pkg-maps": {
             "version": "1.0.0",
@@ -1509,19 +1038,6 @@
                 "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
             }
         },
-        "node_modules/ripemd160": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.3.tgz",
-            "integrity": "sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==",
-            "license": "MIT",
-            "dependencies": {
-                "hash-base": "^3.1.2",
-                "inherits": "^2.0.4"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
         "node_modules/rxjs": {
             "version": "7.8.2",
             "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
@@ -1530,104 +1046,6 @@
             "dependencies": {
                 "tslib": "^2.1.0"
             }
-        },
-        "node_modules/safe-buffer": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT"
-        },
-        "node_modules/set-function-length": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-            "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-            "license": "MIT",
-            "dependencies": {
-                "define-data-property": "^1.1.4",
-                "es-errors": "^1.3.0",
-                "function-bind": "^1.1.2",
-                "get-intrinsic": "^1.2.4",
-                "gopd": "^1.0.1",
-                "has-property-descriptors": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/sha.js": {
-            "version": "2.4.12",
-            "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
-            "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
-            "license": "(MIT AND BSD-3-Clause)",
-            "dependencies": {
-                "inherits": "^2.0.4",
-                "safe-buffer": "^5.2.1",
-                "to-buffer": "^1.2.0"
-            },
-            "bin": {
-                "sha.js": "bin.js"
-            },
-            "engines": {
-                "node": ">= 0.10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/string_decoder": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-            "license": "MIT",
-            "dependencies": {
-                "safe-buffer": "~5.1.0"
-            }
-        },
-        "node_modules/string_decoder/node_modules/safe-buffer": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "license": "MIT"
-        },
-        "node_modules/to-buffer": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
-            "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
-            "license": "MIT",
-            "dependencies": {
-                "isarray": "^2.0.5",
-                "safe-buffer": "^5.2.1",
-                "typed-array-buffer": "^1.0.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/to-buffer/node_modules/isarray": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-            "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-            "license": "MIT"
-        },
-        "node_modules/tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-            "license": "MIT"
         },
         "node_modules/tslib": {
             "version": "2.8.1",
@@ -1653,20 +1071,6 @@
             },
             "optionalDependencies": {
                 "fsevents": "~2.3.3"
-            }
-        },
-        "node_modules/typed-array-buffer": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
-            "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
-            "license": "MIT",
-            "dependencies": {
-                "call-bound": "^1.0.3",
-                "es-errors": "^1.3.0",
-                "is-typed-array": "^1.1.14"
-            },
-            "engines": {
-                "node": ">= 0.4"
             }
         },
         "node_modules/typedarray-to-buffer": {
@@ -1704,53 +1108,10 @@
             }
         },
         "node_modules/undici-types": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-            "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+            "version": "7.24.6",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+            "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
             "license": "MIT"
-        },
-        "node_modules/util-deprecate": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-            "license": "MIT"
-        },
-        "node_modules/webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-            "license": "BSD-2-Clause"
-        },
-        "node_modules/whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-            "license": "MIT",
-            "dependencies": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
-            }
-        },
-        "node_modules/which-typed-array": {
-            "version": "1.1.19",
-            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
-            "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
-            "license": "MIT",
-            "dependencies": {
-                "available-typed-arrays": "^1.0.7",
-                "call-bind": "^1.0.8",
-                "call-bound": "^1.0.4",
-                "for-each": "^0.3.5",
-                "get-proto": "^1.0.1",
-                "gopd": "^1.2.0",
-                "has-tostringtag": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
         }
     }
 }

--- a/dex/scripts/package.json
+++ b/dex/scripts/package.json
@@ -2,12 +2,18 @@
     "name": "scripts",
     "version": "1.0.0",
     "type": "module",
+    "engines": {
+        "node": ">=22"
+    },
     "scripts": {
         "deploy:testnet": "tsx src/deploy.ts --network=testnet",
         "deploy:mainnet": "tsx src/deploy.ts --network=mainnet",
         "deploy:previewnet": "tsx src/deploy.ts --network=previewnet",
         "smoke:previewnet": "tsx src/smoke-test.ts",
         "test": "tsx --test src/*.test.ts",
+        "deploy:token-token:previewnet": "tsx src/deploy-token-token.ts --network=previewnet",
+        "deploy:token-token:testnet": "tsx src/deploy-token-token.ts --network=testnet",
+        "inspect:token": "tsx src/inspect-token-code.ts",
         "typecheck": "tsc --noEmit"
     },
     "keywords": [],
@@ -15,12 +21,11 @@
     "license": "ISC",
     "description": "",
     "dependencies": {
-        "@taquito/michel-codec": "^23.1.0",
-        "@taquito/michelson-encoder": "^23.1.0",
-        "@taquito/signer": "^23.0.3",
-        "@taquito/taquito": "^23.0.3",
-        "@taquito/utils": "^23.1.0",
-        "bn.js": "^5.2.2",
+        "@taquito/michel-codec": "^25.0.0",
+        "@taquito/michelson-encoder": "^25.0.0",
+        "@taquito/signer": "^25.0.0",
+        "@taquito/taquito": "^25.0.0",
+        "@taquito/utils": "^25.0.0",
         "dotenv": "^17.2.3"
     },
     "devDependencies": {

--- a/dex/scripts/src/deploy-token-token.ts
+++ b/dex/scripts/src/deploy-token-token.ts
@@ -1,0 +1,552 @@
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { Parser } from "@taquito/michel-codec";
+import { Schema } from "@taquito/michelson-encoder";
+import { InMemorySigner } from "@taquito/signer";
+import {
+  TezosToolkit,
+  type ContractAbstraction,
+  type ContractProvider,
+  type OperationBatch,
+} from "@taquito/taquito";
+import dotenv from "dotenv";
+
+import {
+  parseTokenTokenConfig,
+  type TokenDescriptor,
+  type TokenTokenDeploymentConfig,
+  type TokenTokenNetwork,
+} from "./token-token-config.js";
+import { calculateInitialLqt } from "./token-token-math.js";
+import { scriptCodeSha256 } from "./token-code-hash.js";
+import {
+  buildEmptyLqtStorage,
+  buildTokenTokenInitialStorage,
+} from "./token-token-storage.js";
+import { getTokenBalance } from "./util.js";
+
+dotenv.config();
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const deploymentVersion = 1;
+const compilerVersion = "1.11.5";
+const minimumLqt = 1_000n;
+
+type Contract = ContractAbstraction<ContractProvider>;
+
+interface DeploymentState {
+  version: number;
+  fingerprint: string;
+  network: TokenTokenNetwork;
+  rpc: string;
+  chainId: string;
+  sourceCommit: string;
+  compilerVersion: string;
+  artifacts: {
+    pool: { path: string; sha256: string; codeSha256: string };
+    lqt: { path: string; sha256: string; codeSha256: string };
+  };
+  deployer: string;
+  config: {
+    tokenA: TokenDescriptor;
+    tokenB: TokenDescriptor;
+    seedAmountA: string;
+    seedAmountB: string;
+    seedReceiver: string;
+    finalManager: string;
+    feeRecipient: string;
+    poolMetadataUri: string;
+    lqtContractMetadataUri: string;
+    lqtTokenMetadataUri: string;
+  };
+  steps: {
+    pool?: { address: string; operation: string };
+    lqt?: { address: string; operation: string };
+    lqtLinked?: { operation: string };
+    initialized?: { operation: string };
+    managerProposed?: { operation: string };
+    verified?: { at: string };
+  };
+}
+
+function parseNetwork(): TokenTokenNetwork {
+  const arg = process.argv.slice(2).find((value) => value.startsWith("--network="));
+  const network = arg?.slice("--network=".length) ?? "previewnet";
+  if (network !== "previewnet" && network !== "testnet") {
+    throw new Error(
+      `Invalid network ${network}; token-to-token deployment is limited to Previewnet/testnet`,
+    );
+  }
+  return network;
+}
+
+function artifactPath(filename: string): string {
+  return path.resolve(scriptDirectory, "..", "..", "compiled_contracts", filename);
+}
+
+function sha256(value: string | Buffer): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function getStorageType(parsedScript: unknown): unknown {
+  if (!Array.isArray(parsedScript)) {
+    throw new Error("Compiled contract did not parse as a Michelson script");
+  }
+  const storage = parsedScript.find(
+    (section) =>
+      typeof section === "object" &&
+      section !== null &&
+      "prim" in section &&
+      section.prim === "storage",
+  ) as { args?: unknown[] } | undefined;
+  if (!storage?.args?.[0]) throw new Error("Compiled contract has no storage type");
+  return storage.args[0];
+}
+
+async function readArtifact(filename: string): Promise<{
+  absolutePath: string;
+  source: string;
+  digest: string;
+  script: NonNullable<ReturnType<Parser["parseScript"]>>;
+}> {
+  const absolutePath = artifactPath(filename);
+  const source = await fs.promises.readFile(absolutePath, "utf8");
+  const script = new Parser().parseScript(source);
+  if (!script) throw new Error(`Could not parse ${absolutePath}`);
+  return { absolutePath, source, digest: sha256(source), script };
+}
+
+function sourceCommit(): string {
+  return execFileSync("git", ["rev-parse", "HEAD"], {
+    cwd: path.resolve(scriptDirectory, "..", "..", ".."),
+    encoding: "utf8",
+  }).trim();
+}
+
+function canonicalConfig(
+  config: TokenTokenDeploymentConfig,
+  deployer: string,
+  seedReceiver: string,
+): DeploymentState["config"] {
+  return {
+    tokenA: config.tokenA,
+    tokenB: config.tokenB,
+    seedAmountA: config.seedAmountA,
+    seedAmountB: config.seedAmountB,
+    seedReceiver,
+    finalManager: config.finalManager,
+    feeRecipient: config.feeRecipient,
+    poolMetadataUri: config.poolMetadataUri,
+    lqtContractMetadataUri: config.lqtContractMetadataUri,
+    lqtTokenMetadataUri: config.lqtTokenMetadataUri,
+  };
+}
+
+function fingerprint(value: unknown): string {
+  return sha256(JSON.stringify(value));
+}
+
+async function persistState(file: string, state: DeploymentState): Promise<void> {
+  const absolute = path.resolve(file);
+  await fs.promises.mkdir(path.dirname(absolute), { recursive: true });
+  const temporary = `${absolute}.${process.pid}.tmp`;
+  await fs.promises.writeFile(temporary, `${JSON.stringify(state, null, 2)}\n`, {
+    mode: 0o600,
+  });
+  await fs.promises.rename(temporary, absolute);
+  await fs.promises.chmod(absolute, 0o600);
+}
+
+async function loadState(file: string): Promise<DeploymentState | undefined> {
+  try {
+    const parsed = JSON.parse(await fs.promises.readFile(path.resolve(file), "utf8"));
+    if (parsed.version !== deploymentVersion) {
+      throw new Error(`Unsupported deployment-state version ${String(parsed.version)}`);
+    }
+    return parsed as DeploymentState;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw error;
+  }
+}
+
+async function contractCodeHash(tezos: TezosToolkit, address: string): Promise<string> {
+  const script = await tezos.rpc.getScript(address);
+  if (!script.code) throw new Error(`Contract ${address} has no script code`);
+  return scriptCodeSha256(script.code);
+}
+
+async function assertTokenContract(
+  tezos: TezosToolkit,
+  label: string,
+  token: TokenDescriptor,
+): Promise<Contract> {
+  const digest = await contractCodeHash(tezos, token.address);
+  if (digest !== token.codeSha256) {
+    throw new Error(
+      `${label} code hash mismatch: expected ${token.codeSha256}, received ${digest}`,
+    );
+  }
+  const contract = await tezos.contract.at(token.address);
+  const entrypoints = contract.entrypoints.entrypoints;
+  const required =
+    token.standard === "FA2"
+      ? ["transfer", "balance_of", "update_operators"]
+      : ["transfer", "approve"];
+  for (const entrypoint of required) {
+    if (!(entrypoint in entrypoints)) {
+      throw new Error(`${label} is missing required ${token.standard} %${entrypoint}`);
+    }
+  }
+  return contract;
+}
+
+function addAuthorization(
+  batch: OperationBatch,
+  contract: Contract,
+  token: TokenDescriptor,
+  owner: string,
+  pool: string,
+  amount: string,
+): void {
+  if (token.standard === "FA2") {
+    batch.withContractCall(
+      contract.methodsObject.update_operators([
+        { add_operator: { owner, operator: pool, token_id: token.tokenId } },
+      ]),
+    );
+    return;
+  }
+  batch.withContractCall(contract.methodsObject.approve({ spender: pool, value: "0" }));
+  batch.withContractCall(contract.methodsObject.approve({ spender: pool, value: amount }));
+}
+
+function addAuthorizationCleanup(
+  batch: OperationBatch,
+  contract: Contract,
+  token: TokenDescriptor,
+  owner: string,
+  pool: string,
+): void {
+  if (token.standard === "FA2") {
+    batch.withContractCall(
+      contract.methodsObject.update_operators([
+        { remove_operator: { owner, operator: pool, token_id: token.tokenId } },
+      ]),
+    );
+    return;
+  }
+  batch.withContractCall(contract.methodsObject.approve({ spender: pool, value: "0" }));
+}
+
+function asNat(value: unknown, label: string): bigint {
+  const candidate = value as { toString?: () => string };
+  const text = candidate?.toString?.() ?? String(value);
+  if (!/^(0|[1-9][0-9]*)$/.test(text)) throw new Error(`${label} is not a nat`);
+  return BigInt(text);
+}
+
+function asOptionAddress(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "string") return value;
+  const candidate = value as { Some?: unknown; some?: unknown };
+  return String(candidate.Some ?? candidate.some ?? value);
+}
+
+async function verifyDeployment(
+  tezos: TezosToolkit,
+  config: TokenTokenDeploymentConfig,
+  state: DeploymentState,
+  expectedCode: { pool: string; lqt: string },
+): Promise<void> {
+  const poolAddress = state.steps.pool?.address;
+  const lqtAddress = state.steps.lqt?.address;
+  if (!poolAddress || !lqtAddress || !state.steps.initialized) {
+    throw new Error("Cannot verify an incomplete deployment");
+  }
+  const [poolCode, lqtCode] = await Promise.all([
+    contractCodeHash(tezos, poolAddress),
+    contractCodeHash(tezos, lqtAddress),
+  ]);
+  if (poolCode !== expectedCode.pool || lqtCode !== expectedCode.lqt) {
+    throw new Error("Originated pool or LQT code does not match the reviewed artifact");
+  }
+  const expectedLqt = BigInt(calculateInitialLqt(config.seedAmountA, config.seedAmountB));
+  const pool = await tezos.contract.at(poolAddress);
+  const storage = (await pool.storage()) as Record<string, unknown>;
+  if (storage.active !== true || storage.paused !== false || storage.entered !== false) {
+    throw new Error("Pool lifecycle flags do not match the initialized state");
+  }
+  if (asNat(storage.reserve_a, "reserve_a") !== BigInt(config.seedAmountA)) {
+    throw new Error("Pool reserve_a does not match the configured seed");
+  }
+  if (asNat(storage.reserve_b, "reserve_b") !== BigInt(config.seedAmountB)) {
+    throw new Error("Pool reserve_b does not match the configured seed");
+  }
+  if (
+    asNat(storage.protocol_fee_a, "protocol_fee_a") !== 0n ||
+    asNat(storage.protocol_fee_b, "protocol_fee_b") !== 0n
+  ) {
+    throw new Error("Protocol fee accumulators are nonzero immediately after initialization");
+  }
+  if (asNat(storage.lqt_total, "lqt_total") !== expectedLqt) {
+    throw new Error("Pool LQT total does not match the integer geometric mean");
+  }
+  if (asOptionAddress(storage.lqt_address) !== lqtAddress) {
+    throw new Error("Pool is linked to an unexpected LQT contract");
+  }
+  if (String(storage.manager) !== state.deployer) {
+    throw new Error("Temporary deployer is no longer pool manager before handoff acceptance");
+  }
+  const metadata = storage.metadata as { get: (key: string) => Promise<unknown> };
+  const poolMetadata = String((await metadata.get("")) ?? "");
+  if (poolMetadata !== Buffer.from(config.poolMetadataUri, "utf8").toString("hex")) {
+    throw new Error("Pool metadata URI does not match the deployment configuration");
+  }
+  const expectedPending =
+    config.finalManager === state.deployer ? null : config.finalManager;
+  if (asOptionAddress(storage.pending_manager) !== expectedPending) {
+    throw new Error("Pending manager does not match FINAL_MANAGER");
+  }
+
+  const lqt = await tezos.contract.at(lqtAddress);
+  const lqtStorage = (await lqt.storage()) as Record<string, unknown>;
+  if (String(lqtStorage.admin) !== poolAddress) {
+    throw new Error("Pool is not the LQT administrator");
+  }
+  if (asNat(lqtStorage.total_supply, "LQT total_supply") !== expectedLqt) {
+    throw new Error("LQT total supply does not match pool accounting");
+  }
+  const lqtMetadata = lqtStorage.metadata as {
+    get: (key: string) => Promise<unknown>;
+  };
+  if (
+    String((await lqtMetadata.get("")) ?? "") !==
+    Buffer.from(config.lqtContractMetadataUri, "utf8").toString("hex")
+  ) {
+    throw new Error("LQT contract metadata URI does not match configuration");
+  }
+  const tokenMetadataMap = lqtStorage.token_metadata as {
+    get: (key: string) => Promise<unknown>;
+  };
+  const tokenMetadata = (await tokenMetadataMap.get("0")) as
+    | { token_info?: { get: (key: string) => unknown } }
+    | undefined;
+  const tokenUri = tokenMetadata?.token_info?.get("");
+  if (
+    String(tokenUri ?? "") !==
+    Buffer.from(config.lqtTokenMetadataUri, "utf8").toString("hex")
+  ) {
+    throw new Error("LQT token metadata URI does not match configuration");
+  }
+  const tokens = lqtStorage.tokens as { get: (key: string) => Promise<unknown> };
+  const locked = asNat((await tokens.get(poolAddress)) ?? 0, "locked LQT");
+  const provider = asNat(
+    (await tokens.get(state.config.seedReceiver)) ?? 0,
+    "provider LQT",
+  );
+  if (locked !== minimumLqt || provider !== expectedLqt - minimumLqt) {
+    throw new Error("LQT minimum lock or provider balance is incorrect");
+  }
+
+  const [balanceA, balanceB] = await Promise.all([
+    getTokenBalance(
+      tezos,
+      config.tokenA.address,
+      poolAddress,
+      config.tokenA.standard,
+      config.tokenA.tokenId,
+      config.tzktApiUrl,
+    ),
+    getTokenBalance(
+      tezos,
+      config.tokenB.address,
+      poolAddress,
+      config.tokenB.standard,
+      config.tokenB.tokenId,
+      config.tzktApiUrl,
+    ),
+  ]);
+  if (balanceA < BigInt(config.seedAmountA) || balanceB < BigInt(config.seedAmountB)) {
+    throw new Error("Pool token balances do not cover its recorded reserves");
+  }
+}
+
+async function main(): Promise<void> {
+  const config = parseTokenTokenConfig(parseNetwork());
+  const [poolArtifact, lqtArtifact] = await Promise.all([
+    readArtifact("token_token_pool.tz"),
+    readArtifact("lqt.tz"),
+  ]);
+  if (poolArtifact.digest !== config.artifactSha256) {
+    throw new Error(
+      `Pool artifact hash mismatch: expected ${config.artifactSha256}, received ${poolArtifact.digest}`,
+    );
+  }
+
+  const tezos = new TezosToolkit(config.rpc);
+  tezos.setProvider({ signer: await InMemorySigner.fromSecretKey(config.privateKey) });
+  const [deployer, chainId] = await Promise.all([
+    tezos.signer.publicKeyHash(),
+    tezos.rpc.getChainId(),
+  ]);
+  if (chainId !== config.expectedChainId) {
+    throw new Error(`RPC chain ID mismatch: expected ${config.expectedChainId}, received ${chainId}`);
+  }
+  const seedReceiver = config.seedReceiver ?? deployer;
+  const stateConfig = canonicalConfig(config, deployer, seedReceiver);
+  const stateFingerprint = fingerprint({
+    network: config.network,
+    chainId,
+    poolArtifact: poolArtifact.digest,
+    lqtArtifact: lqtArtifact.digest,
+    ...stateConfig,
+  });
+  const existing = await loadState(config.stateFile);
+  const state: DeploymentState =
+    existing ?? {
+      version: deploymentVersion,
+      fingerprint: stateFingerprint,
+      network: config.network,
+      rpc: config.rpc,
+      chainId,
+      sourceCommit: sourceCommit(),
+      compilerVersion,
+      artifacts: {
+        pool: {
+          path: poolArtifact.absolutePath,
+          sha256: poolArtifact.digest,
+          codeSha256: scriptCodeSha256(poolArtifact.script),
+        },
+        lqt: {
+          path: lqtArtifact.absolutePath,
+          sha256: lqtArtifact.digest,
+          codeSha256: scriptCodeSha256(lqtArtifact.script),
+        },
+      },
+      deployer,
+      config: stateConfig,
+      steps: {},
+    };
+  if (state.fingerprint !== stateFingerprint || state.deployer !== deployer) {
+    throw new Error(
+      `Deployment state ${config.stateFile} belongs to different code, configuration, or deployer`,
+    );
+  }
+  await persistState(config.stateFile, state);
+
+  console.log(`Network: ${config.network} (${chainId})`);
+  console.log(`Deployer: ${deployer}`);
+  console.log(`State: ${path.resolve(config.stateFile)}`);
+  console.log("Verifying pinned token contracts...");
+  const [tokenA, tokenB] = await Promise.all([
+    assertTokenContract(tezos, "TOKEN_A", config.tokenA),
+    assertTokenContract(tezos, "TOKEN_B", config.tokenB),
+  ]);
+
+  if (!state.steps.pool) {
+    const storage = new Schema(getStorageType(poolArtifact.script) as never).Encode(
+      buildTokenTokenInitialStorage(config, deployer),
+    );
+    const operation = await tezos.contract.originate({
+      code: poolArtifact.script,
+      init: storage,
+    });
+    const pool = await operation.contract(config.confirmations);
+    state.steps.pool = { address: pool.address, operation: operation.hash };
+    await persistState(config.stateFile, state);
+    console.log(`Pool originated: ${pool.address}`);
+  }
+  const pool = await tezos.contract.at(state.steps.pool.address);
+
+  if (!state.steps.lqt) {
+    const storage = new Schema(getStorageType(lqtArtifact.script) as never).Encode(
+      buildEmptyLqtStorage(config, pool.address),
+    );
+    const operation = await tezos.contract.originate({
+      code: lqtArtifact.script,
+      init: storage,
+    });
+    const lqt = await operation.contract(config.confirmations);
+    state.steps.lqt = { address: lqt.address, operation: operation.hash };
+    await persistState(config.stateFile, state);
+    console.log(`LQT originated: ${lqt.address}`);
+  }
+
+  if (!state.steps.lqtLinked) {
+    const operation = await pool.methodsObject
+      .set_lqt_address(state.steps.lqt.address)
+      .send();
+    await operation.confirmation(config.confirmations);
+    state.steps.lqtLinked = { operation: operation.hash };
+    await persistState(config.stateFile, state);
+    console.log("LQT address linked to pool.");
+  }
+
+  if (!state.steps.initialized) {
+    const batch = tezos.contract.batch();
+    addAuthorization(
+      batch,
+      tokenA,
+      config.tokenA,
+      deployer,
+      pool.address,
+      config.seedAmountA,
+    );
+    addAuthorization(
+      batch,
+      tokenB,
+      config.tokenB,
+      deployer,
+      pool.address,
+      config.seedAmountB,
+    );
+    batch.withContractCall(
+      pool.methodsObject.initialize({
+        amount_a: config.seedAmountA,
+        amount_b: config.seedAmountB,
+        receiver: seedReceiver,
+        deadline: new Date(Date.now() + 60 * 60 * 1_000).toISOString(),
+      }),
+    );
+    addAuthorizationCleanup(batch, tokenA, config.tokenA, deployer, pool.address);
+    addAuthorizationCleanup(batch, tokenB, config.tokenB, deployer, pool.address);
+    const operation = await batch.send();
+    await operation.confirmation(config.confirmations);
+    state.steps.initialized = { operation: operation.hash };
+    await persistState(config.stateFile, state);
+    console.log("Pool initialized and temporary token authorizations removed.");
+  }
+
+  if (config.finalManager !== deployer && !state.steps.managerProposed) {
+    const operation = await pool.methodsObject
+      .propose_manager(config.finalManager)
+      .send();
+    await operation.confirmation(config.confirmations);
+    state.steps.managerProposed = { operation: operation.hash };
+    await persistState(config.stateFile, state);
+    console.log(`Manager proposed: ${config.finalManager}`);
+  }
+
+  await verifyDeployment(tezos, config, state, {
+    pool: scriptCodeSha256(poolArtifact.script),
+    lqt: scriptCodeSha256(lqtArtifact.script),
+  });
+  state.steps.verified = { at: new Date().toISOString() };
+  await persistState(config.stateFile, state);
+  console.log("Deployment verification passed.");
+  if (config.finalManager !== deployer) {
+    console.log("FINAL_MANAGER must call %accept_manager to complete the handoff.");
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error(
+    `Token-to-token deployment failed: ${error instanceof Error ? error.message : String(error)}`,
+  );
+  process.exitCode = 1;
+});

--- a/dex/scripts/src/deploy-token-token.ts
+++ b/dex/scripts/src/deploy-token-token.ts
@@ -16,6 +16,7 @@ import {
 import dotenv from "dotenv";
 
 import {
+  assertTokenTokenDeploymentChain,
   parseTokenTokenConfig,
   type TokenDescriptor,
   type TokenTokenDeploymentConfig,
@@ -24,6 +25,7 @@ import {
 import { calculateInitialLqt } from "./token-token-math.js";
 import { scriptCodeSha256 } from "./token-code-hash.js";
 import {
+  assertPoolIdentityStorage,
   buildEmptyLqtStorage,
   buildTokenTokenInitialStorage,
 } from "./token-token-storage.js";
@@ -278,6 +280,7 @@ async function verifyDeployment(
   const expectedLqt = BigInt(calculateInitialLqt(config.seedAmountA, config.seedAmountB));
   const pool = await tezos.contract.at(poolAddress);
   const storage = (await pool.storage()) as Record<string, unknown>;
+  assertPoolIdentityStorage(storage, config);
   if (storage.active !== true || storage.paused !== false || storage.entered !== false) {
     throw new Error("Pool lifecycle flags do not match the initialized state");
   }
@@ -394,9 +397,7 @@ async function main(): Promise<void> {
     tezos.signer.publicKeyHash(),
     tezos.rpc.getChainId(),
   ]);
-  if (chainId !== config.expectedChainId) {
-    throw new Error(`RPC chain ID mismatch: expected ${config.expectedChainId}, received ${chainId}`);
-  }
+  assertTokenTokenDeploymentChain(config.expectedChainId, chainId);
   const seedReceiver = config.seedReceiver ?? deployer;
   const stateConfig = canonicalConfig(config, deployer, seedReceiver);
   const stateFingerprint = fingerprint({

--- a/dex/scripts/src/inspect-token-code.ts
+++ b/dex/scripts/src/inspect-token-code.ts
@@ -1,0 +1,45 @@
+import { TezosToolkit } from "@taquito/taquito";
+import { ValidationResult, validateContractAddress } from "@taquito/utils";
+
+import { scriptCodeSha256 } from "./token-code-hash.js";
+
+function argument(name: string): string {
+  const prefix = `--${name}=`;
+  const value = process.argv.slice(2).find((item) => item.startsWith(prefix));
+  if (!value || value.length === prefix.length) {
+    throw new Error(`Missing required ${prefix}<value>`);
+  }
+  return value.slice(prefix.length);
+}
+
+async function main(): Promise<void> {
+  const rpc = argument("rpc");
+  const address = argument("address");
+  if (validateContractAddress(address) !== ValidationResult.VALID) {
+    throw new Error("--address must be a valid originated Tezos contract address");
+  }
+  const tezos = new TezosToolkit(rpc);
+  const [chainId, script, entrypoints] = await Promise.all([
+    tezos.rpc.getChainId(),
+    tezos.rpc.getScript(address),
+    tezos.rpc.getEntrypoints(address),
+  ]);
+  if (!script.code) throw new Error(`Contract ${address} has no script code`);
+  console.log(
+    JSON.stringify(
+      {
+        chainId,
+        address,
+        codeSha256: scriptCodeSha256(script.code),
+        entrypoints: Object.keys(entrypoints.entrypoints).sort(),
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/dex/scripts/src/token-code-hash.test.ts
+++ b/dex/scripts/src/token-code-hash.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { canonicalJson, scriptCodeSha256 } from "./token-code-hash.js";
+
+test("canonical script hashing ignores JSON object property order", () => {
+  const left = [{ prim: "pair", args: [{ int: "0" }], annots: ["%value"] }];
+  const right = [{ annots: ["%value"], args: [{ int: "0" }], prim: "pair" }];
+  assert.equal(canonicalJson(left), canonicalJson(right));
+  assert.equal(scriptCodeSha256(left), scriptCodeSha256(right));
+});
+
+test("canonical script hashing preserves array order and values", () => {
+  assert.notEqual(scriptCodeSha256(["a", "b"]), scriptCodeSha256(["b", "a"]));
+  assert.notEqual(scriptCodeSha256({ int: "1" }), scriptCodeSha256({ int: "2" }));
+});

--- a/dex/scripts/src/token-code-hash.ts
+++ b/dex/scripts/src/token-code-hash.ts
@@ -1,0 +1,19 @@
+import { createHash } from "node:crypto";
+
+function normalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(normalize);
+  if (typeof value !== "object" || value === null) return value;
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, item]) => [key, normalize(item)]),
+  );
+}
+
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(normalize(value));
+}
+
+export function scriptCodeSha256(code: unknown): string {
+  return createHash("sha256").update(canonicalJson(code)).digest("hex");
+}

--- a/dex/scripts/src/token-token-config.test.ts
+++ b/dex/scripts/src/token-token-config.test.ts
@@ -1,0 +1,194 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+import { Parser } from "@taquito/michel-codec";
+import { Schema } from "@taquito/michelson-encoder";
+import { b58Encode, PrefixV2 } from "@taquito/utils";
+
+import { parseTokenTokenConfig } from "./token-token-config.js";
+import {
+  calculateInitialLqt,
+  integerSquareRoot,
+  protocolFee,
+  quoteOutput,
+} from "./token-token-math.js";
+import {
+  buildEmptyLqtStorage,
+  buildTokenTokenInitialStorage,
+} from "./token-token-storage.js";
+
+const contractAddress = (byte: number): string =>
+  b58Encode(new Uint8Array(20).fill(byte), PrefixV2.ContractHash);
+const implicitAddress = (byte: number): string =>
+  b58Encode(new Uint8Array(20).fill(byte), PrefixV2.Ed25519PublicKeyHash);
+
+function validEnv(): NodeJS.ProcessEnv {
+  return {
+    PREVIEWNET_RPC: "https://preview.example.invalid",
+    PREVIEWNET_CHAIN_ID: "NetXPreview",
+    PREVIEWNET_PRIVATE_KEY: "unencrypted:test-only-placeholder",
+    TOKEN_A_STANDARD: "FA2",
+    TOKEN_A_ADDRESS: contractAddress(1),
+    TOKEN_A_ID: "0",
+    TOKEN_A_CODE_SHA256: "b".repeat(64),
+    TOKEN_B_STANDARD: "FA1.2",
+    TOKEN_B_ADDRESS: contractAddress(2),
+    TOKEN_B_CODE_SHA256: "c".repeat(64),
+    SEED_AMOUNT_A: "1000000",
+    SEED_AMOUNT_B: "100000000",
+    FINAL_MANAGER: implicitAddress(3),
+    PROTOCOL_FEE_RECIPIENT: implicitAddress(4),
+    TOKEN_TOKEN_POOL_METADATA_URI: "ipfs://poolcid",
+    TOKEN_TOKEN_LQT_CONTRACT_METADATA_URI: "ipfs://contractcid",
+    TOKEN_TOKEN_LQT_TOKEN_METADATA_URI: "ipfs://tokencid",
+    TOKEN_TOKEN_ARTIFACT_SHA256: "a".repeat(64),
+  };
+}
+
+function storageType(filename: string): unknown {
+  const source = fs.readFileSync(path.join("..", "compiled_contracts", filename), "utf8");
+  const script = new Parser().parseScript(source);
+  assert.ok(Array.isArray(script));
+  const section = script.find(
+    (item) =>
+      typeof item === "object" &&
+      item !== null &&
+      "prim" in item &&
+      item.prim === "storage",
+  ) as { args?: unknown[] } | undefined;
+  assert.ok(section?.args?.[0]);
+  return section.args[0];
+}
+
+test("parses a generic mixed-standard Previewnet configuration", () => {
+  const config = parseTokenTokenConfig("previewnet", validEnv());
+  assert.deepEqual(config.tokenA, {
+    standard: "FA2",
+    address: contractAddress(1),
+    tokenId: "0",
+    codeSha256: "b".repeat(64),
+  });
+  assert.deepEqual(config.tokenB, {
+    standard: "FA1.2",
+    address: contractAddress(2),
+    tokenId: "0",
+    codeSha256: "c".repeat(64),
+  });
+  assert.equal(config.finalManager, implicitAddress(3));
+  assert.equal(config.confirmations, 2);
+});
+
+test("accepts FA1.2/FA1.2 and FA2/FA2 without changing the artifact", () => {
+  const fa12 = validEnv();
+  fa12.TOKEN_A_STANDARD = "FA1.2";
+  delete fa12.TOKEN_A_ID;
+  assert.equal(parseTokenTokenConfig("previewnet", fa12).tokenA.tokenId, "0");
+
+  const fa2 = validEnv();
+  fa2.TOKEN_B_STANDARD = "FA2";
+  fa2.TOKEN_B_ID = "7";
+  assert.equal(parseTokenTokenConfig("previewnet", fa2).tokenB.tokenId, "7");
+});
+
+test("rejects identical assets and incompatible same-address descriptors", () => {
+  const env = validEnv();
+  env.TOKEN_B_ADDRESS = env.TOKEN_A_ADDRESS;
+  assert.throws(
+    () => parseTokenTokenConfig("previewnet", env),
+    /incompatible token standards/,
+  );
+
+  const identical = validEnv();
+  identical.TOKEN_B_STANDARD = "FA2";
+  identical.TOKEN_B_ADDRESS = identical.TOKEN_A_ADDRESS;
+  identical.TOKEN_B_ID = identical.TOKEN_A_ID;
+  assert.throws(
+    () => parseTokenTokenConfig("previewnet", identical),
+    /distinct assets/,
+  );
+});
+
+test("accepts distinct FA2 token IDs from the same reviewed contract", () => {
+  const env = validEnv();
+  env.TOKEN_B_STANDARD = "FA2";
+  env.TOKEN_B_ADDRESS = env.TOKEN_A_ADDRESS;
+  env.TOKEN_B_ID = "7";
+  env.TOKEN_B_CODE_SHA256 = env.TOKEN_A_CODE_SHA256;
+  const config = parseTokenTokenConfig("previewnet", env);
+  assert.equal(config.tokenA.address, config.tokenB.address);
+  assert.equal(config.tokenB.tokenId, "7");
+});
+
+test("validates geometric-mean minimum liquidity instead of each seed", () => {
+  const env = validEnv();
+  env.SEED_AMOUNT_A = "1";
+  env.SEED_AMOUNT_B = "1000000";
+  assert.throws(
+    () => parseTokenTokenConfig("previewnet", env),
+    /geometric-mean LQT supply/,
+  );
+  env.SEED_AMOUNT_B = "1004004";
+  assert.equal(calculateInitialLqt(env.SEED_AMOUNT_A, env.SEED_AMOUNT_B), "1002");
+  assert.doesNotThrow(() => parseTokenTokenConfig("previewnet", env));
+});
+
+test("requires immutable IPFS metadata and exact artifact hash", () => {
+  const metadata = validEnv();
+  metadata.TOKEN_TOKEN_POOL_METADATA_URI = "https://mutable.invalid/pool.json";
+  assert.throws(
+    () => parseTokenTokenConfig("previewnet", metadata),
+    /immutable ipfs/,
+  );
+  const hash = validEnv();
+  hash.TOKEN_TOKEN_ARTIFACT_SHA256 = "not-a-hash";
+  assert.throws(
+    () => parseTokenTokenConfig("previewnet", hash),
+    /SHA-256/,
+  );
+});
+
+test("rejects malformed token and control addresses before any RPC call", () => {
+  const token = validEnv();
+  token.TOKEN_A_ADDRESS = "not-a-contract";
+  assert.throws(() => parseTokenTokenConfig("previewnet", token), /originated contract/);
+  const manager = validEnv();
+  manager.FINAL_MANAGER = "not-an-address";
+  assert.throws(() => parseTokenTokenConfig("previewnet", manager), /valid Tezos address/);
+  const receiver = validEnv();
+  receiver.SEED_RECEIVER = "not-an-address";
+  assert.throws(() => parseTokenTokenConfig("previewnet", receiver), /valid Tezos address/);
+});
+
+test("integer square root and fee math match contract ordering", () => {
+  assert.equal(integerSquareRoot(0n), 0n);
+  assert.equal(integerSquareRoot(1n), 1n);
+  assert.equal(integerSquareRoot(100_000_000_000_000n), 10_000_000n);
+  assert.equal(integerSquareRoot(100_000_000_000_001n), 10_000_000n);
+  assert.equal(protocolFee(1_999n), 0n);
+  assert.equal(protocolFee(2_000n), 1n);
+  const output = quoteOutput(100_000n, 1_000_000n, 100_000_000n);
+  assert.equal(output, 9_066_108n);
+});
+
+test("encodes pool and empty external LQT storage against compiled schemas", () => {
+  const config = parseTokenTokenConfig("previewnet", validEnv());
+  const deployer = implicitAddress(5);
+  const poolSchema = new Schema(storageType("token_token_pool.tz") as never);
+  const lqtSchema = new Schema(storageType("lqt.tz") as never);
+  assert.doesNotThrow(() =>
+    poolSchema.Encode(buildTokenTokenInitialStorage(config, deployer)),
+  );
+  assert.doesNotThrow(() =>
+    lqtSchema.Encode(buildEmptyLqtStorage(config, contractAddress(6))),
+  );
+});
+
+test("does not expose a mainnet deployment mode", () => {
+  const parse = parseTokenTokenConfig as unknown as (
+    network: string,
+    env: NodeJS.ProcessEnv,
+  ) => unknown;
+  assert.throws(() => parse("mainnet", validEnv()), /limited to Previewnet\/testnet/);
+});

--- a/dex/scripts/src/token-token-config.test.ts
+++ b/dex/scripts/src/token-token-config.test.ts
@@ -7,7 +7,11 @@ import { Parser } from "@taquito/michel-codec";
 import { Schema } from "@taquito/michelson-encoder";
 import { b58Encode, PrefixV2 } from "@taquito/utils";
 
-import { parseTokenTokenConfig } from "./token-token-config.js";
+import {
+  assertTokenTokenDeploymentChain,
+  parseTokenTokenConfig,
+  TEZOS_MAINNET_CHAIN_ID,
+} from "./token-token-config.js";
 import {
   calculateInitialLqt,
   integerSquareRoot,
@@ -15,6 +19,7 @@ import {
   quoteOutput,
 } from "./token-token-math.js";
 import {
+  assertPoolIdentityStorage,
   buildEmptyLqtStorage,
   buildTokenTokenInitialStorage,
 } from "./token-token-storage.js";
@@ -185,10 +190,75 @@ test("encodes pool and empty external LQT storage against compiled schemas", () 
   );
 });
 
+test("verifies immutable pool assets and protocol-fee recipient storage", () => {
+  const config = parseTokenTokenConfig("previewnet", validEnv());
+  const poolSchema = new Schema(storageType("token_token_pool.tz") as never);
+  const encodedStorage = poolSchema.Encode(
+    buildTokenTokenInitialStorage(config, implicitAddress(5)),
+  );
+  const storage = poolSchema.Execute(encodedStorage) as Record<string, unknown>;
+  assert.doesNotThrow(() => assertPoolIdentityStorage(storage, config));
+
+  assert.throws(
+    () =>
+      assertPoolIdentityStorage(
+        { ...storage, token_a: storage.token_b },
+        config,
+      ),
+    /token_a does not match/,
+  );
+  assert.throws(
+    () =>
+      assertPoolIdentityStorage(
+        { ...storage, token_b: storage.token_a },
+        config,
+      ),
+    /token_b does not match/,
+  );
+  assert.throws(
+    () =>
+      assertPoolIdentityStorage(
+        { ...storage, protocol_fee_recipient: implicitAddress(6) },
+        config,
+      ),
+    /protocol_fee_recipient does not match/,
+  );
+  assert.throws(
+    () =>
+      assertPoolIdentityStorage(
+        { ...storage, pending_fee_recipient: implicitAddress(7) },
+        config,
+      ),
+    /pending_fee_recipient is unexpectedly set/,
+  );
+});
+
 test("does not expose a mainnet deployment mode", () => {
   const parse = parseTokenTokenConfig as unknown as (
     network: string,
     env: NodeJS.ProcessEnv,
   ) => unknown;
   assert.throws(() => parse("mainnet", validEnv()), /limited to Previewnet\/testnet/);
+});
+
+test("rejects Mainnet even when hidden behind Previewnet environment names", () => {
+  const env = validEnv();
+  env.PREVIEWNET_RPC = "https://rpc.tzkt.io/mainnet";
+  env.PREVIEWNET_CHAIN_ID = TEZOS_MAINNET_CHAIN_ID;
+  assert.throws(
+    () => parseTokenTokenConfig("previewnet", env),
+    /refuses Tezos Mainnet/,
+  );
+
+  assert.throws(
+    () => assertTokenTokenDeploymentChain("NetXPreview", TEZOS_MAINNET_CHAIN_ID),
+    /refuses Tezos Mainnet/,
+  );
+  assert.throws(
+    () => assertTokenTokenDeploymentChain("NetXPreview", "NetXWrong"),
+    /RPC chain ID mismatch/,
+  );
+  assert.doesNotThrow(() =>
+    assertTokenTokenDeploymentChain("NetXPreview", "NetXPreview"),
+  );
 });

--- a/dex/scripts/src/token-token-config.ts
+++ b/dex/scripts/src/token-token-config.ts
@@ -11,6 +11,11 @@ import { calculateInitialLqt } from "./token-token-math.js";
 export type TokenTokenNetwork = "previewnet" | "testnet";
 export type TokenStandard = "FA1.2" | "FA2";
 
+// The Tezos Mainnet chain ID is permanent. This deployment workflow is
+// intentionally test-only, so reject it independently of user-supplied RPC
+// and expected-chain configuration.
+export const TEZOS_MAINNET_CHAIN_ID = "NetXdQprcVkpaWU";
+
 export interface TokenDescriptor {
   standard: TokenStandard;
   address: string;
@@ -120,6 +125,23 @@ function address(env: NodeJS.ProcessEnv, key: string, requiredValue = true): str
   return value;
 }
 
+export function assertTokenTokenDeploymentChain(
+  expectedChainId: string,
+  actualChainId: string = expectedChainId,
+): void {
+  if (
+    expectedChainId === TEZOS_MAINNET_CHAIN_ID ||
+    actualChainId === TEZOS_MAINNET_CHAIN_ID
+  ) {
+    throw new Error("Token-to-token test deployment refuses Tezos Mainnet");
+  }
+  if (actualChainId !== expectedChainId) {
+    throw new Error(
+      `RPC chain ID mismatch: expected ${expectedChainId}, received ${actualChainId}`,
+    );
+  }
+}
+
 export function parseTokenTokenConfig(
   network: TokenTokenNetwork,
   env: NodeJS.ProcessEnv = process.env,
@@ -128,6 +150,8 @@ export function parseTokenTokenConfig(
     throw new Error("Token-to-token deployment is limited to Previewnet/testnet");
   }
   const prefix = network === "previewnet" ? "PREVIEWNET" : "TESTNET";
+  const expectedChainId = required(env, `${prefix}_CHAIN_ID`);
+  assertTokenTokenDeploymentChain(expectedChainId);
   const tokenA = tokenDescriptor(env, "A");
   const tokenB = tokenDescriptor(env, "B");
   if (canonicalAsset(tokenA) === canonicalAsset(tokenB)) {
@@ -159,7 +183,7 @@ export function parseTokenTokenConfig(
   return {
     network,
     rpc: required(env, `${prefix}_RPC`),
-    expectedChainId: required(env, `${prefix}_CHAIN_ID`),
+    expectedChainId,
     tzktApiUrl: optional(env, `${prefix}_TZKT_API`),
     privateKey: required(env, `${prefix}_PRIVATE_KEY`),
     tokenA,

--- a/dex/scripts/src/token-token-config.ts
+++ b/dex/scripts/src/token-token-config.ts
@@ -1,0 +1,190 @@
+import path from "node:path";
+
+import {
+  ValidationResult,
+  validateAddress,
+  validateContractAddress,
+} from "@taquito/utils";
+
+import { calculateInitialLqt } from "./token-token-math.js";
+
+export type TokenTokenNetwork = "previewnet" | "testnet";
+export type TokenStandard = "FA1.2" | "FA2";
+
+export interface TokenDescriptor {
+  standard: TokenStandard;
+  address: string;
+  tokenId: string;
+  codeSha256: string;
+}
+
+export interface TokenTokenDeploymentConfig {
+  network: TokenTokenNetwork;
+  rpc: string;
+  expectedChainId: string;
+  tzktApiUrl?: string;
+  privateKey: string;
+  tokenA: TokenDescriptor;
+  tokenB: TokenDescriptor;
+  seedAmountA: string;
+  seedAmountB: string;
+  seedReceiver?: string;
+  finalManager: string;
+  feeRecipient: string;
+  poolMetadataUri: string;
+  lqtContractMetadataUri: string;
+  lqtTokenMetadataUri: string;
+  artifactSha256: string;
+  confirmations: number;
+  stateFile: string;
+}
+
+const NAT_PATTERN = /^(0|[1-9][0-9]*)$/;
+const SHA256_PATTERN = /^[0-9a-f]{64}$/;
+
+function required(env: NodeJS.ProcessEnv, key: string): string {
+  const value = env[key]?.trim();
+  if (!value) throw new Error(`Required environment variable ${key} is not set`);
+  return value;
+}
+
+function optional(env: NodeJS.ProcessEnv, key: string): string | undefined {
+  return env[key]?.trim() || undefined;
+}
+
+function natural(env: NodeJS.ProcessEnv, key: string, fallback?: string): string {
+  const value = optional(env, key) ?? fallback;
+  if (value === undefined || !NAT_PATTERN.test(value)) {
+    throw new Error(`${key} must be an unsigned base-10 integer`);
+  }
+  return BigInt(value).toString();
+}
+
+function positiveInteger(env: NodeJS.ProcessEnv, key: string, fallback: number): number {
+  const value = optional(env, key);
+  if (!value) return fallback;
+  if (!NAT_PATTERN.test(value) || BigInt(value) === 0n) {
+    throw new Error(`${key} must be a positive integer`);
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) throw new Error(`${key} is too large`);
+  return parsed;
+}
+
+function tokenStandard(env: NodeJS.ProcessEnv, key: string): TokenStandard {
+  const value = required(env, key).toUpperCase();
+  if (value === "FA1.2" || value === "FA12") return "FA1.2";
+  if (value === "FA2") return "FA2";
+  throw new Error(`${key} must be FA1.2 or FA2`);
+}
+
+function tokenDescriptor(env: NodeJS.ProcessEnv, label: "A" | "B"): TokenDescriptor {
+  const standard = tokenStandard(env, `TOKEN_${label}_STANDARD`);
+  const codeSha256 = required(env, `TOKEN_${label}_CODE_SHA256`).toLowerCase();
+  if (!SHA256_PATTERN.test(codeSha256)) {
+    throw new Error(`TOKEN_${label}_CODE_SHA256 must be a lowercase SHA-256 digest`);
+  }
+  const address = required(env, `TOKEN_${label}_ADDRESS`);
+  if (validateContractAddress(address) !== ValidationResult.VALID) {
+    throw new Error(`TOKEN_${label}_ADDRESS must be a valid originated contract address`);
+  }
+  return {
+    standard,
+    address,
+    tokenId:
+      standard === "FA2"
+        ? natural(env, `TOKEN_${label}_ID`)
+        : "0",
+    codeSha256,
+  };
+}
+
+function assertIpfsUri(value: string, key: string): string {
+  if (!/^ipfs:\/\/[a-zA-Z0-9]+$/.test(value)) {
+    throw new Error(`${key} must be an immutable ipfs:// CID URI`);
+  }
+  return value;
+}
+
+function canonicalAsset(asset: TokenDescriptor): string {
+  return asset.standard === "FA2"
+    ? `${asset.address}:fa2:${asset.tokenId}`
+    : `${asset.address}:fa12`;
+}
+
+function address(env: NodeJS.ProcessEnv, key: string, requiredValue = true): string | undefined {
+  const value = requiredValue ? required(env, key) : optional(env, key);
+  if (value && validateAddress(value) !== ValidationResult.VALID) {
+    throw new Error(`${key} must be a valid Tezos address`);
+  }
+  return value;
+}
+
+export function parseTokenTokenConfig(
+  network: TokenTokenNetwork,
+  env: NodeJS.ProcessEnv = process.env,
+): TokenTokenDeploymentConfig {
+  if (network !== "previewnet" && network !== "testnet") {
+    throw new Error("Token-to-token deployment is limited to Previewnet/testnet");
+  }
+  const prefix = network === "previewnet" ? "PREVIEWNET" : "TESTNET";
+  const tokenA = tokenDescriptor(env, "A");
+  const tokenB = tokenDescriptor(env, "B");
+  if (canonicalAsset(tokenA) === canonicalAsset(tokenB)) {
+    throw new Error("TOKEN_A and TOKEN_B must describe distinct assets");
+  }
+  if (
+    tokenA.address === tokenB.address &&
+    (tokenA.standard !== "FA2" || tokenB.standard !== "FA2")
+  ) {
+    throw new Error(
+      "One contract address cannot be described under incompatible token standards",
+    );
+  }
+
+  const seedAmountA = natural(env, "SEED_AMOUNT_A");
+  const seedAmountB = natural(env, "SEED_AMOUNT_B");
+  if (BigInt(seedAmountA) === 0n || BigInt(seedAmountB) === 0n) {
+    throw new Error("Both seed amounts must be greater than zero");
+  }
+  if (BigInt(calculateInitialLqt(seedAmountA, seedAmountB)) <= 1000n) {
+    throw new Error("The geometric-mean LQT supply must exceed the 1,000-unit lock");
+  }
+
+  const artifactSha256 = required(env, "TOKEN_TOKEN_ARTIFACT_SHA256").toLowerCase();
+  if (!SHA256_PATTERN.test(artifactSha256)) {
+    throw new Error("TOKEN_TOKEN_ARTIFACT_SHA256 must be a lowercase SHA-256 digest");
+  }
+
+  return {
+    network,
+    rpc: required(env, `${prefix}_RPC`),
+    expectedChainId: required(env, `${prefix}_CHAIN_ID`),
+    tzktApiUrl: optional(env, `${prefix}_TZKT_API`),
+    privateKey: required(env, `${prefix}_PRIVATE_KEY`),
+    tokenA,
+    tokenB,
+    seedAmountA,
+    seedAmountB,
+    seedReceiver: address(env, "SEED_RECEIVER", false),
+    finalManager: address(env, "FINAL_MANAGER")!,
+    feeRecipient: address(env, "PROTOCOL_FEE_RECIPIENT")!,
+    poolMetadataUri: assertIpfsUri(
+      required(env, "TOKEN_TOKEN_POOL_METADATA_URI"),
+      "TOKEN_TOKEN_POOL_METADATA_URI",
+    ),
+    lqtContractMetadataUri: assertIpfsUri(
+      required(env, "TOKEN_TOKEN_LQT_CONTRACT_METADATA_URI"),
+      "TOKEN_TOKEN_LQT_CONTRACT_METADATA_URI",
+    ),
+    lqtTokenMetadataUri: assertIpfsUri(
+      required(env, "TOKEN_TOKEN_LQT_TOKEN_METADATA_URI"),
+      "TOKEN_TOKEN_LQT_TOKEN_METADATA_URI",
+    ),
+    artifactSha256,
+    confirmations: positiveInteger(env, "CONFIRMATIONS", 2),
+    stateFile:
+      optional(env, "TOKEN_TOKEN_DEPLOYMENT_STATE") ??
+      path.join("deployments", "token-token", `${network}-in-progress.json`),
+  };
+}

--- a/dex/scripts/src/token-token-math.ts
+++ b/dex/scripts/src/token-token-math.ts
@@ -1,0 +1,44 @@
+const NAT_PATTERN = /^(0|[1-9][0-9]*)$/;
+
+export const MINIMUM_LQT = 1000n;
+export const LP_FEE_BP = 25n;
+export const PROTOCOL_FEE_BP = 5n;
+export const TOTAL_FEE_BP = 30n;
+export const FEE_DENOMINATOR = 10_000n;
+export const SWAP_FEE_NUMERATOR = FEE_DENOMINATOR - TOTAL_FEE_BP;
+
+export function parseNat(value: string, label: string): bigint {
+  if (!NAT_PATTERN.test(value)) throw new Error(`${label} must be a natural number`);
+  return BigInt(value);
+}
+
+export function integerSquareRoot(value: bigint): bigint {
+  if (value < 0n) throw new Error("Cannot calculate a negative square root");
+  if (value < 2n) return value;
+  let estimate = value / 2n + 1n;
+  while (true) {
+    const next = (estimate + value / estimate) / 2n;
+    if (next >= estimate) return estimate;
+    estimate = next;
+  }
+}
+
+export function calculateInitialLqt(amountA: string, amountB: string): string {
+  const product = parseNat(amountA, "amount A") * parseNat(amountB, "amount B");
+  return integerSquareRoot(product).toString();
+}
+
+export function quoteOutput(
+  amountIn: bigint,
+  reserveIn: bigint,
+  reserveOut: bigint,
+): bigint {
+  if (amountIn === 0n || reserveIn === 0n || reserveOut === 0n) return 0n;
+  const amountWithFee = amountIn * SWAP_FEE_NUMERATOR;
+  return (amountWithFee * reserveOut) /
+    (reserveIn * FEE_DENOMINATOR + amountWithFee);
+}
+
+export function protocolFee(amountIn: bigint): bigint {
+  return (amountIn * PROTOCOL_FEE_BP) / FEE_DENOMINATOR;
+}

--- a/dex/scripts/src/token-token-storage.ts
+++ b/dex/scripts/src/token-token-storage.ts
@@ -1,0 +1,62 @@
+import { MichelsonMap } from "@taquito/michelson-encoder";
+
+import type {
+  TokenDescriptor,
+  TokenTokenDeploymentConfig,
+} from "./token-token-config.js";
+
+function bytes(value: string): string {
+  return Buffer.from(value, "utf8").toString("hex");
+}
+
+export function encodeTokenDescriptor(token: TokenDescriptor): Record<string, unknown> {
+  return token.standard === "FA2"
+    ? { fa2: { token: token.address, id: token.tokenId } }
+    : { fa12: token.address };
+}
+
+export function buildTokenTokenInitialStorage(
+  config: TokenTokenDeploymentConfig,
+  deployer: string,
+): Record<string, unknown> {
+  const metadata = new MichelsonMap<string, string>();
+  metadata.set("", bytes(config.poolMetadataUri));
+  return {
+    token_a: encodeTokenDescriptor(config.tokenA),
+    token_b: encodeTokenDescriptor(config.tokenB),
+    reserve_a: "0",
+    reserve_b: "0",
+    protocol_fee_a: "0",
+    protocol_fee_b: "0",
+    lqt_total: "0",
+    lqt_address: null,
+    active: false,
+    paused: false,
+    entered: false,
+    manager: deployer,
+    pending_manager: null,
+    protocol_fee_recipient: config.feeRecipient,
+    pending_fee_recipient: null,
+    metadata,
+  };
+}
+
+export function buildEmptyLqtStorage(
+  config: TokenTokenDeploymentConfig,
+  poolAddress: string,
+): Record<string, unknown> {
+  const metadata = new MichelsonMap<string, string>();
+  metadata.set("", bytes(config.lqtContractMetadataUri));
+  const tokenInfo = new MichelsonMap<string, string>();
+  tokenInfo.set("", bytes(config.lqtTokenMetadataUri));
+  const tokenMetadata = new MichelsonMap<number, Record<string, unknown>>();
+  tokenMetadata.set(0, { token_id: "0", token_info: tokenInfo });
+  return {
+    tokens: new MichelsonMap(),
+    allowances: new MichelsonMap(),
+    admin: poolAddress,
+    total_supply: "0",
+    metadata,
+    token_metadata: tokenMetadata,
+  };
+}

--- a/dex/scripts/src/token-token-storage.ts
+++ b/dex/scripts/src/token-token-storage.ts
@@ -15,6 +15,60 @@ export function encodeTokenDescriptor(token: TokenDescriptor): Record<string, un
     : { fa12: token.address };
 }
 
+type TokenIdentity = Pick<TokenDescriptor, "standard" | "address" | "tokenId">;
+
+function decodeTokenDescriptor(value: unknown, label: string): TokenIdentity {
+  if (typeof value !== "object" || value === null) {
+    throw new Error(`${label} is not a token descriptor`);
+  }
+  const candidate = value as { fa12?: unknown; fa2?: unknown };
+  if (candidate.fa12 !== undefined) {
+    return {
+      standard: "FA1.2",
+      address: String(candidate.fa12),
+      tokenId: "0",
+    };
+  }
+  if (typeof candidate.fa2 === "object" && candidate.fa2 !== null) {
+    const fa2 = candidate.fa2 as { token?: unknown; id?: unknown };
+    if (fa2.token === undefined || fa2.id === undefined) {
+      throw new Error(`${label} FA2 descriptor is incomplete`);
+    }
+    return {
+      standard: "FA2",
+      address: String(fa2.token),
+      tokenId: String(fa2.id),
+    };
+  }
+  throw new Error(`${label} has an unknown token descriptor variant`);
+}
+
+function tokenIdentity(value: TokenIdentity): string {
+  return `${value.standard}:${value.address}:${value.tokenId}`;
+}
+
+export function assertPoolIdentityStorage(
+  storage: Record<string, unknown>,
+  config: Pick<TokenTokenDeploymentConfig, "tokenA" | "tokenB" | "feeRecipient">,
+): void {
+  const actualTokenA = decodeTokenDescriptor(storage.token_a, "token_a");
+  const actualTokenB = decodeTokenDescriptor(storage.token_b, "token_b");
+  if (tokenIdentity(actualTokenA) !== tokenIdentity(config.tokenA)) {
+    throw new Error("Pool token_a does not match the deployment configuration");
+  }
+  if (tokenIdentity(actualTokenB) !== tokenIdentity(config.tokenB)) {
+    throw new Error("Pool token_b does not match the deployment configuration");
+  }
+  if (String(storage.protocol_fee_recipient) !== config.feeRecipient) {
+    throw new Error(
+      "Pool protocol_fee_recipient does not match the deployment configuration",
+    );
+  }
+  if (storage.pending_fee_recipient !== null && storage.pending_fee_recipient !== undefined) {
+    throw new Error("Pool pending_fee_recipient is unexpectedly set");
+  }
+}
+
 export function buildTokenTokenInitialStorage(
   config: TokenTokenDeploymentConfig,
   deployer: string,

--- a/dex/tests/token_token_pool.test.mligo
+++ b/dex/tests/token_token_pool.test.mligo
@@ -1,0 +1,911 @@
+#include "../contracts/token_token_pool.mligo"
+#import "../contracts/helpers/fa2_token.mligo" "FA2"
+#import "../contracts/lqt_fa12.mligo" "LQT"
+
+module Test = Test.Next
+module LegacyTezos = Tezos
+module Tezos = Tezos.Next
+module Contract = TokenTokenPool
+
+module FA12 = struct
+  type transfer = address * (address * nat)
+  type approve = address * nat
+  type storage =
+    {
+      ledger : (address, nat) big_map;
+      allowances : ((address * address), nat) big_map
+    }
+  type result = operation list * storage
+
+  let balance (owner : address) (s : storage) : nat =
+    match Big_map.find_opt owner s.ledger with
+    | Some amount -> amount
+    | None -> 0n
+
+  let allowance (owner : address) (spender : address) (s : storage) : nat =
+    match Big_map.find_opt (owner, spender) s.allowances with
+    | Some amount -> amount
+    | None -> 0n
+
+  let checked_sub (a : nat) (b : nat) : nat =
+    match is_nat (a - b) with
+    | Some amount -> amount
+    | None -> failwith "FA12_UNDERFLOW"
+
+  [@entry]
+  let transfer ((from_, (to_, amount)) : transfer) (s : storage) : result =
+    let sender = Tezos.get_sender () in
+    let allowances =
+      if sender = from_
+      then s.allowances
+      else
+        let remaining = checked_sub (allowance from_ sender s) amount in
+        Big_map.update (from_, sender) (Some remaining) s.allowances in
+    let from_balance = checked_sub (balance from_ s) amount in
+    let to_balance = balance to_ s + amount in
+    ([],
+     {
+       ledger =
+         Big_map.update to_ (Some to_balance)
+           (Big_map.update from_ (Some from_balance) s.ledger);
+       allowances = allowances
+     })
+
+  [@entry]
+  let approve ((spender, amount) : approve) (s : storage) : result =
+    let owner = Tezos.get_sender () in
+    let previous = allowance owner spender s in
+    let () =
+      Assert.Error.assert
+        (previous = 0n || amount = 0n)
+        "FA12_UNSAFE_ALLOWANCE_CHANGE" in
+    ([],
+     {
+       s with
+       allowances = Big_map.update (owner, spender) (Some amount) s.allowances
+     })
+end
+
+(* A deliberately hostile FA1.2 test double. Once armed, every transfer calls
+   back into the pool before its self-only close operation can run. *)
+module ReentrantFA12 = struct
+  type transfer = address * (address * nat)
+  type approve = address * nat
+  type storage =
+    {
+      ledger : (address, nat) big_map;
+      allowances : ((address * address), nat) big_map;
+      attack_target : address option
+    }
+  type result = operation list * storage
+
+  let balance (owner : address) (s : storage) : nat =
+    match Big_map.find_opt owner s.ledger with
+    | Some amount -> amount
+    | None -> 0n
+
+  let allowance (owner : address) (spender : address) (s : storage) : nat =
+    match Big_map.find_opt (owner, spender) s.allowances with
+    | Some amount -> amount
+    | None -> 0n
+
+  let checked_sub (a : nat) (b : nat) : nat =
+    match is_nat (a - b) with
+    | Some amount -> amount
+    | None -> failwith "REENTRANT_FA12_UNDERFLOW"
+
+  [@entry]
+  let transfer ((from_, (to_, amount)) : transfer) (s : storage) : result =
+    let sender = Tezos.get_sender () in
+    let allowances =
+      if sender = from_
+      then s.allowances
+      else
+        let remaining = checked_sub (allowance from_ sender s) amount in
+        Big_map.update (from_, sender) (Some remaining) s.allowances in
+    let ledger =
+      Big_map.update to_ (Some (balance to_ s + amount))
+        (Big_map.update from_ (Some (checked_sub (balance from_ s) amount)) s.ledger) in
+    let operations : operation list =
+      match s.attack_target with
+      | None -> []
+      | Some target ->
+          let callback : bool contract =
+            match
+              (LegacyTezos.get_entrypoint_opt "%set_paused" target : bool contract option)
+            with
+            | Some entrypoint -> entrypoint
+            | None -> failwith "REENTRANT_FA12_MISSING_TARGET" in
+          [LegacyTezos.transaction true 0mutez callback] in
+    (operations, {s with ledger = ledger; allowances = allowances})
+
+  [@entry]
+  let approve ((spender, amount) : approve) (s : storage) : result =
+    let owner = Tezos.get_sender () in
+    let previous = allowance owner spender s in
+    let () =
+      Assert.Error.assert
+        (previous = 0n || amount = 0n)
+        "REENTRANT_FA12_UNSAFE_ALLOWANCE_CHANGE" in
+    ([],
+     {
+       s with
+       allowances = Big_map.update (owner, spender) (Some amount) s.allowances
+     })
+
+  [@entry]
+  let arm (target : address) (s : storage) : result =
+    ([], {s with attack_target = Some target})
+end
+
+type pool_parameter = TokenTokenPool parameter_of
+type fa2_parameter = FA2 parameter_of
+type fa12_parameter = FA12 parameter_of
+type lqt_parameter = LQT.LQT parameter_of
+type reentrant_fa12_parameter = ReentrantFA12 parameter_of
+type pool_typed_address = (pool_parameter, Contract.storage) typed_address
+type fa2_typed_address = (fa2_parameter, FA2.storage) typed_address
+type fa12_typed_address = (fa12_parameter, FA12.storage) typed_address
+type lqt_typed_address = (lqt_parameter, LQT.LQT.storage) typed_address
+type reentrant_fa12_typed_address =
+  (reentrant_fa12_parameter, ReentrantFA12.storage) typed_address
+
+let manager () = Test.Account.address 0n
+let trader () = Test.Account.address 1n
+let fee_recipient () = Test.Account.address 2n
+let successor () = Test.Account.address 3n
+let replacement_fee_recipient () = Test.Account.address 4n
+
+let future = ("1970-01-01T01:00:00Z" : timestamp)
+let initial_fa2_balance = 1000000000000n
+let initial_fa12_balance = 100000000000000n
+let seed_a = 1000000n
+let seed_b = 100000000n
+let expected_initial_lqt = 10000000n
+
+let clean () : unit =
+  Test.State.reset
+    5n
+    [1000000tez; 1000000tez; 1000000tez; 1000000tez; 1000000tez]
+
+let assert_nat (label : string) (actual : nat) (expected : nat) : unit =
+  if actual = expected
+  then ()
+  else
+    failwith
+      (label ^ ": expected " ^ Test.String.show expected
+       ^ ", got " ^ Test.String.show actual)
+
+let assert_true (label : string) (condition : bool) : unit =
+  Assert.Error.assert condition label
+
+let assert_string_failure
+  (label : string)
+  (expected : string)
+  (result : test_exec_result)
+: unit =
+  match result with
+  | Success _ -> failwith (label ^ ": expected failure")
+  | Fail failure ->
+      (match failure with
+       | Rejected (actual, _) ->
+           let expected_value = Test.Michelson.eval (expected : string) in
+           if Test.Compare.eq actual expected_value
+           then ()
+           else failwith (label ^ ": wrong failure")
+       | _ -> failwith (label ^ ": unexpected failure type"))
+
+let deploy_fa2 (owner : address) =
+  Test.Originate.contract
+    (contract_of FA2)
+    (FA2.make_storage owner initial_fa2_balance 0n)
+    0tez
+
+let deploy_fa12 (owner : address) =
+  let storage : FA12.storage =
+    {
+      ledger = Big_map.literal [(owner, initial_fa12_balance)];
+      allowances = (Big_map.empty : ((address * address), nat) big_map)
+    } in
+  Test.Originate.contract (contract_of FA12) storage 0tez
+
+let deploy_reentrant_fa12 (owner : address) =
+  let storage : ReentrantFA12.storage =
+    {
+      ledger = Big_map.literal [(owner, initial_fa12_balance)];
+      allowances = (Big_map.empty : ((address * address), nat) big_map);
+      attack_target = None
+    } in
+  Test.Originate.contract (contract_of ReentrantFA12) storage 0tez
+
+let deploy_pool (token_a : Contract.token) (token_b : Contract.token) =
+  let storage : Contract.storage =
+    Contract.build_storage
+      {
+        token_a = token_a;
+        token_b = token_b;
+        manager = manager ();
+        protocol_fee_recipient = fee_recipient ();
+        metadata = (Big_map.empty : (string, bytes) big_map)
+      } in
+  Test.Originate.contract (contract_of Contract) storage 0tez
+
+let deploy_lqt (pool_address : address) =
+  let storage : LQT.LQT.storage =
+    {
+      tokens = (Big_map.empty : LQT.LQT.tokens);
+      allowances = (Big_map.empty : LQT.LQT.allowances);
+      admin = pool_address;
+      total_supply = 0n;
+      metadata = (Big_map.empty : (string, bytes) big_map);
+      token_metadata =
+        Big_map.literal
+          [
+            (0n,
+             {
+               token_id = 0n;
+               token_info =
+                 Map.literal
+                   [
+                     ("name", Bytes.pack ("Token Pair Liquidity" : string));
+                     ("symbol", Bytes.pack ("TPLP" : string));
+                     ("decimals", Bytes.pack ("7" : string))
+                   ]
+             })
+          ]
+    } in
+  Test.Originate.contract (contract_of LQT.LQT) storage 0tez
+
+let set_lqt (pool : pool_typed_address) (lqt : lqt_typed_address) : unit =
+  let _ : nat =
+    Test.Contract.transfer_exn
+      (Test.Typed_address.get_entrypoint "set_lqt_address" pool)
+      (Test.Typed_address.to_address lqt)
+      0tez in
+  ()
+
+let add_fa2_operator
+  (token : fa2_typed_address)
+  (owner : address)
+  (operator : address)
+: unit =
+  let update : FA2.update_operators =
+    [Add_operator {owner = owner; operator = operator; token_id = 0n}] in
+  let _ : nat =
+    Test.Contract.transfer_exn
+      (Test.Typed_address.get_entrypoint "update_operators" token)
+      update
+      0tez in
+  ()
+
+let approve_fa12
+  (token : fa12_typed_address)
+  (spender : address)
+  (amount : nat)
+: unit =
+  let _ : nat =
+    Test.Contract.transfer_exn
+      (Test.Typed_address.get_entrypoint "approve" token)
+      (spender, amount)
+      0tez in
+  ()
+
+let approve_reentrant_fa12
+  (token : reentrant_fa12_typed_address)
+  (spender : address)
+  (amount : nat)
+: unit =
+  let _ : nat =
+    Test.Contract.transfer_exn
+      (Test.Typed_address.get_entrypoint "approve" token)
+      (spender, amount)
+      0tez in
+  ()
+
+let transfer_fa2
+  (token : fa2_typed_address)
+  (from_ : address)
+  (to_ : address)
+  (amount : nat)
+: unit =
+  let parameter : FA2.transfer =
+    [{from_ = from_; txs = [{to_ = to_; token_id = 0n; amount = amount}]}] in
+  let _ : nat =
+    Test.Contract.transfer_exn
+      (Test.Typed_address.get_entrypoint "transfer" token)
+      parameter
+      0tez in
+  ()
+
+let transfer_fa12
+  (token : fa12_typed_address)
+  (from_ : address)
+  (to_ : address)
+  (amount : nat)
+: unit =
+  let _ : nat =
+    Test.Contract.transfer_exn
+      (Test.Typed_address.get_entrypoint "transfer" token)
+      (from_, (to_, amount))
+      0tez in
+  ()
+
+let fa2_balance (token : fa2_typed_address) (owner : address) : nat =
+  let storage : FA2.storage = Test.Typed_address.get_storage token in
+  match Big_map.find_opt owner storage.ledger with
+  | Some amount -> amount
+  | None -> 0n
+
+let fa12_balance (token : fa12_typed_address) (owner : address) : nat =
+  let storage : FA12.storage = Test.Typed_address.get_storage token in
+  FA12.balance owner storage
+
+let lqt_balance (lqt : lqt_typed_address) (owner : address) : nat =
+  let storage : LQT.LQT.storage = Test.Typed_address.get_storage lqt in
+  match Big_map.find_opt owner storage.tokens with
+  | Some amount -> amount
+  | None -> 0n
+
+let authorize_pair
+  (pool : pool_typed_address)
+  (fa2 : fa2_typed_address)
+  (fa12 : fa12_typed_address)
+  (owner : address)
+  (amount_a : nat)
+  (amount_b : nat)
+: unit =
+  let pool_address = Test.Typed_address.to_address pool in
+  let () = add_fa2_operator fa2 owner pool_address in
+  approve_fa12 fa12 pool_address amount_b
+
+let initialize_pool
+  (pool : pool_typed_address)
+  (receiver : address)
+  (amount_a : nat)
+  (amount_b : nat)
+: unit =
+  let parameter : Contract.initialize_param =
+    {
+      amount_a = amount_a;
+      amount_b = amount_b;
+      receiver = receiver;
+      deadline = future
+    } in
+  let _ : nat =
+    Test.Contract.transfer_exn
+      (Test.Typed_address.get_entrypoint "initialize" pool)
+      parameter
+      0tez in
+  ()
+
+let setup_pool () =
+  let () = clean () in
+  let () = Test.State.set_source (manager ()) in
+  let fa2 = deploy_fa2 (manager ()) in
+  let fa12 = deploy_fa12 (manager ()) in
+  let pool =
+    deploy_pool
+      (Fa2 {token = Test.Typed_address.to_address fa2.taddr; id = 0n})
+      (Fa12 (Test.Typed_address.to_address fa12.taddr)) in
+  let lqt = deploy_lqt (Test.Typed_address.to_address pool.taddr) in
+  let () = set_lqt pool.taddr lqt.taddr in
+  let () = authorize_pair pool.taddr fa2.taddr fa12.taddr (manager ()) seed_a seed_b in
+  let () = initialize_pool pool.taddr (manager ()) seed_a seed_b in
+  (pool, lqt, fa2, fa12)
+
+let fund_and_authorize_trader
+  (pool : pool_typed_address)
+  (fa2 : fa2_typed_address)
+  (fa12 : fa12_typed_address)
+  (amount_a : nat)
+  (amount_b : nat)
+: unit =
+  let pool_address = Test.Typed_address.to_address pool in
+  let () = Test.State.set_source (manager ()) in
+  let () = transfer_fa2 fa2 (manager ()) (trader ()) amount_a in
+  let () = transfer_fa12 fa12 (manager ()) (trader ()) amount_b in
+  let () = Test.State.set_source (trader ()) in
+  let () = add_fa2_operator fa2 (trader ()) pool_address in
+  approve_fa12 fa12 pool_address amount_b
+
+let assert_solvency
+  (label : string)
+  (pool : pool_typed_address)
+  (fa2 : fa2_typed_address)
+  (fa12 : fa12_typed_address)
+: unit =
+  let storage : Contract.storage = Test.Typed_address.get_storage pool in
+  let pool_address = Test.Typed_address.to_address pool in
+  let held_a = fa2_balance fa2 pool_address in
+  let held_b = fa12_balance fa12 pool_address in
+  let () =
+    assert_true
+      (label ^ ": token A insolvent")
+      (held_a >= storage.reserve_a + storage.protocol_fee_a) in
+  assert_true
+    (label ^ ": token B insolvent")
+    (held_b >= storage.reserve_b + storage.protocol_fee_b)
+
+(* ----------------------------------------------------------------------- *)
+(* Initialization and LP lifecycle                                         *)
+(* ----------------------------------------------------------------------- *)
+
+let test_initialization_uses_integer_square_root_and_external_lqt =
+  let (pool, lqt, fa2, fa12) = setup_pool () in
+  let storage : Contract.storage = Test.Typed_address.get_storage pool.taddr in
+  let lqt_storage : LQT.LQT.storage = Test.Typed_address.get_storage lqt.taddr in
+  let pool_address = Test.Typed_address.to_address pool.taddr in
+  let () = assert_nat "reserve A" storage.reserve_a seed_a in
+  let () = assert_nat "reserve B" storage.reserve_b seed_b in
+  let () = assert_nat "geometric mean" storage.lqt_total expected_initial_lqt in
+  let () = assert_nat "LQT total" lqt_storage.total_supply expected_initial_lqt in
+  let () = assert_nat "locked LQT" (lqt_balance lqt.taddr pool_address) 1000n in
+  let () =
+    assert_nat
+      "provider LQT"
+      (lqt_balance lqt.taddr (manager ()))
+      9999000n in
+  let () = assert_true "LQT admin mismatch" (lqt_storage.admin = pool_address) in
+  let () = assert_true "pool not active" (storage.active && not storage.entered) in
+  assert_solvency "initialization" pool.taddr fa2.taddr fa12.taddr
+
+let test_initialization_is_one_time_and_lqt_address_is_immutable =
+  let (pool, lqt, _fa2, _fa12) = setup_pool () in
+  let initialize_result =
+    Test.Contract.transfer
+      (Test.Typed_address.get_entrypoint "initialize" pool.taddr)
+      ({amount_a = seed_a; amount_b = seed_b; receiver = manager (); deadline = future}
+        : Contract.initialize_param)
+      0tez in
+  let () =
+    assert_string_failure
+      "second initialization"
+      Contract.err_already_active
+      initialize_result in
+  let lqt_result =
+    Test.Contract.transfer
+      (Test.Typed_address.get_entrypoint "set_lqt_address" pool.taddr)
+      (Test.Typed_address.to_address lqt.taddr)
+      0tez in
+  assert_string_failure "second LQT address" Contract.err_already_active lqt_result
+
+let test_same_artifact_initializes_an_fa2_to_fa2_pair =
+  let () = clean () in
+  let () = Test.State.set_source (manager ()) in
+  let token_a = deploy_fa2 (manager ()) in
+  let token_b = deploy_fa2 (manager ()) in
+  let pool =
+    deploy_pool
+      (Fa2 {token = Test.Typed_address.to_address token_a.taddr; id = 0n})
+      (Fa2 {token = Test.Typed_address.to_address token_b.taddr; id = 0n}) in
+  let lqt = deploy_lqt (Test.Typed_address.to_address pool.taddr) in
+  let pool_address = Test.Typed_address.to_address pool.taddr in
+  let () = set_lqt pool.taddr lqt.taddr in
+  let () = add_fa2_operator token_a.taddr (manager ()) pool_address in
+  let () = add_fa2_operator token_b.taddr (manager ()) pool_address in
+  let () = initialize_pool pool.taddr (manager ()) seed_a seed_b in
+  let storage : Contract.storage = Test.Typed_address.get_storage pool.taddr in
+  let () = assert_nat "FA2/FA2 reserve A" storage.reserve_a seed_a in
+  let () = assert_nat "FA2/FA2 reserve B" storage.reserve_b seed_b in
+  let () = assert_nat "FA2/FA2 held A" (fa2_balance token_a.taddr pool_address) seed_a in
+  assert_nat "FA2/FA2 held B" (fa2_balance token_b.taddr pool_address) seed_b
+
+let test_same_artifact_initializes_an_fa12_to_fa12_pair =
+  let () = clean () in
+  let () = Test.State.set_source (manager ()) in
+  let token_a = deploy_fa12 (manager ()) in
+  let token_b = deploy_fa12 (manager ()) in
+  let pool =
+    deploy_pool
+      (Fa12 (Test.Typed_address.to_address token_a.taddr))
+      (Fa12 (Test.Typed_address.to_address token_b.taddr)) in
+  let lqt = deploy_lqt (Test.Typed_address.to_address pool.taddr) in
+  let pool_address = Test.Typed_address.to_address pool.taddr in
+  let () = set_lqt pool.taddr lqt.taddr in
+  let () = approve_fa12 token_a.taddr pool_address seed_a in
+  let () = approve_fa12 token_b.taddr pool_address seed_b in
+  let () = initialize_pool pool.taddr (manager ()) seed_a seed_b in
+  let storage : Contract.storage = Test.Typed_address.get_storage pool.taddr in
+  let () = assert_nat "FA1.2/FA1.2 reserve A" storage.reserve_a seed_a in
+  let () = assert_nat "FA1.2/FA1.2 reserve B" storage.reserve_b seed_b in
+  let () = assert_nat "FA1.2/FA1.2 held A" (fa12_balance token_a.taddr pool_address) seed_a in
+  assert_nat "FA1.2/FA1.2 held B" (fa12_balance token_b.taddr pool_address) seed_b
+
+let test_proportional_add_and_remove_liquidity =
+  let (pool, lqt, fa2, fa12) = setup_pool () in
+  let () =
+    fund_and_authorize_trader pool.taddr fa2.taddr fa12.taddr 200000n 20000000n in
+  let add : Contract.add_liquidity_param =
+    {
+      max_amount_a = 100000n;
+      max_amount_b = 10000000n;
+      min_lqt_minted = 1000000n;
+      receiver = trader ();
+      deadline = future
+    } in
+  let _ : nat =
+    Test.Contract.transfer_exn
+      (Test.Typed_address.get_entrypoint "add_liquidity" pool.taddr)
+      add
+      0tez in
+  let () = assert_nat "minted trader LQT" (lqt_balance lqt.taddr (trader ())) 1000000n in
+  let remove : Contract.remove_liquidity_param =
+    {
+      lqt_burned = 500000n;
+      min_amount_a = 49999n;
+      min_amount_b = 4999999n;
+      receiver = trader ();
+      deadline = future
+    } in
+  let _ : nat =
+    Test.Contract.transfer_exn
+      (Test.Typed_address.get_entrypoint "remove_liquidity" pool.taddr)
+      remove
+      0tez in
+  let storage : Contract.storage = Test.Typed_address.get_storage pool.taddr in
+  let lqt_storage : LQT.LQT.storage = Test.Typed_address.get_storage lqt.taddr in
+  let () = assert_nat "burned trader LQT" (lqt_balance lqt.taddr (trader ())) 500000n in
+  let () = assert_nat "synchronized LQT total" storage.lqt_total lqt_storage.total_supply in
+  assert_solvency "liquidity" pool.taddr fa2.taddr fa12.taddr
+
+let test_minimum_lqt_cannot_be_redeemed =
+  let (pool, _lqt, _fa2, _fa12) = setup_pool () in
+  let burn_too_much : Contract.remove_liquidity_param =
+    {
+      lqt_burned = expected_initial_lqt;
+      min_amount_a = 0n;
+      min_amount_b = 0n;
+      receiver = manager ();
+      deadline = future
+    } in
+  let result =
+    Test.Contract.transfer
+      (Test.Typed_address.get_entrypoint "remove_liquidity" pool.taddr)
+      burn_too_much
+      0tez in
+  assert_string_failure "minimum LQT" Contract.err_minimum_lqt result
+
+(* ----------------------------------------------------------------------- *)
+(* Swap economics, rounding, surplus, and fees                              *)
+(* ----------------------------------------------------------------------- *)
+
+let test_bidirectional_swaps_preserve_accounting_and_product =
+  let (pool, _lqt, fa2, fa12) = setup_pool () in
+  let () =
+    fund_and_authorize_trader pool.taddr fa2.taddr fa12.taddr 1000000n 100000000n in
+  let before : Contract.storage = Test.Typed_address.get_storage pool.taddr in
+  let old_product = before.reserve_a * before.reserve_b in
+  let amount_a_in = 100000n in
+  let expected_b_out = Contract.quote_output amount_a_in before.reserve_a before.reserve_b in
+  let swap_a : Contract.swap_param =
+    {
+      direction = A_to_b;
+      amount_in = amount_a_in;
+      min_amount_out = expected_b_out;
+      receiver = trader ();
+      deadline = future
+    } in
+  let _ : nat =
+    Test.Contract.transfer_exn
+      (Test.Typed_address.get_entrypoint "swap" pool.taddr)
+      swap_a
+      0tez in
+  let middle : Contract.storage = Test.Typed_address.get_storage pool.taddr in
+  let () = assert_nat "A protocol fee" middle.protocol_fee_a 50n in
+  let () =
+    assert_true
+      "A-to-B product decreased"
+      (middle.reserve_a * middle.reserve_b >= old_product) in
+  let amount_b_in = 10000000n in
+  let expected_a_out =
+    Contract.quote_output amount_b_in middle.reserve_b middle.reserve_a in
+  let swap_b : Contract.swap_param =
+    {
+      direction = B_to_a;
+      amount_in = amount_b_in;
+      min_amount_out = expected_a_out;
+      receiver = trader ();
+      deadline = future
+    } in
+  let _ : nat =
+    Test.Contract.transfer_exn
+      (Test.Typed_address.get_entrypoint "swap" pool.taddr)
+      swap_b
+      0tez in
+  let final : Contract.storage = Test.Typed_address.get_storage pool.taddr in
+  let () = assert_nat "B protocol fee" final.protocol_fee_b 5000n in
+  let () =
+    assert_true
+      "B-to-A product decreased"
+      (final.reserve_a * final.reserve_b >= middle.reserve_a * middle.reserve_b) in
+  assert_solvency "bidirectional swaps" pool.taddr fa2.taddr fa12.taddr
+
+let test_swap_deadline_and_minimum_output_fail_before_transfers =
+  let (pool, _lqt, fa2, fa12) = setup_pool () in
+  let () =
+    fund_and_authorize_trader pool.taddr fa2.taddr fa12.taddr 100000n 0n in
+  let before : Contract.storage = Test.Typed_address.get_storage pool.taddr in
+  let expired =
+    Test.Contract.transfer
+      (Test.Typed_address.get_entrypoint "swap" pool.taddr)
+      ({
+         direction = A_to_b;
+         amount_in = 100000n;
+         min_amount_out = 0n;
+         receiver = trader ();
+         deadline = ("1969-12-31T23:59:59Z" : timestamp)
+       } : Contract.swap_param)
+      0tez in
+  let () = assert_string_failure "expired swap" Contract.err_expired expired in
+  let quote = Contract.quote_output 100000n before.reserve_a before.reserve_b in
+  let slipped =
+    Test.Contract.transfer
+      (Test.Typed_address.get_entrypoint "swap" pool.taddr)
+      ({
+         direction = A_to_b;
+         amount_in = 100000n;
+         min_amount_out = quote + 1n;
+         receiver = trader ();
+         deadline = future
+       } : Contract.swap_param)
+      0tez in
+  let () = assert_string_failure "swap slippage" Contract.err_slippage slipped in
+  let after : Contract.storage = Test.Typed_address.get_storage pool.taddr in
+  let () = assert_nat "rejected swap reserve A" after.reserve_a before.reserve_a in
+  let () = assert_nat "rejected swap reserve B" after.reserve_b before.reserve_b in
+  assert_solvency "rejected swaps" pool.taddr fa2.taddr fa12.taddr
+
+let test_reentrant_token_callback_reverts_the_whole_swap =
+  let () = clean () in
+  let () = Test.State.set_source (manager ()) in
+  let hostile = deploy_reentrant_fa12 (manager ()) in
+  let token_b = deploy_fa12 (manager ()) in
+  let pool =
+    deploy_pool
+      (Fa12 (Test.Typed_address.to_address hostile.taddr))
+      (Fa12 (Test.Typed_address.to_address token_b.taddr)) in
+  let lqt = deploy_lqt (Test.Typed_address.to_address pool.taddr) in
+  let pool_address = Test.Typed_address.to_address pool.taddr in
+  let () = set_lqt pool.taddr lqt.taddr in
+  let () = approve_reentrant_fa12 hostile.taddr pool_address seed_a in
+  let () = approve_fa12 token_b.taddr pool_address seed_b in
+  let () = initialize_pool pool.taddr (manager ()) seed_a seed_b in
+  let _ : nat =
+    Test.Contract.transfer_exn
+      (Test.Typed_address.get_entrypoint "transfer" hostile.taddr)
+      ((manager ()), ((trader ()), 100000n))
+      0tez in
+  let () = Test.State.set_source (trader ()) in
+  let () = approve_reentrant_fa12 hostile.taddr pool_address 100000n in
+  let () = Test.State.set_source (manager ()) in
+  let _ : nat =
+    Test.Contract.transfer_exn
+      (Test.Typed_address.get_entrypoint "arm" hostile.taddr)
+      pool_address
+      0tez in
+  let before : Contract.storage = Test.Typed_address.get_storage pool.taddr in
+  let () = Test.State.set_source (trader ()) in
+  let result =
+    Test.Contract.transfer
+      (Test.Typed_address.get_entrypoint "swap" pool.taddr)
+      ({direction = A_to_b; amount_in = 100000n; min_amount_out = 1n;
+        receiver = trader (); deadline = future} : Contract.swap_param)
+      0tez in
+  let () =
+    assert_string_failure
+      "reentrant token callback"
+      Contract.err_entered
+      result in
+  let after : Contract.storage = Test.Typed_address.get_storage pool.taddr in
+  let () = assert_nat "reentrant reserve A" after.reserve_a before.reserve_a in
+  let () = assert_nat "reentrant reserve B" after.reserve_b before.reserve_b in
+  assert_true "reentrant swap left guard active" (not after.entered)
+
+let test_tiny_input_rounding_never_overcharges_protocol_fee =
+  let () = assert_nat "tiny fee" (Contract.protocol_fee 1999n) 0n in
+  let () = assert_nat "fee threshold" (Contract.protocol_fee 2000n) 1n in
+  let out = Contract.quote_output 1n 1000000n 100000000n in
+  assert_true "tiny quote must be bounded" (out < 100n)
+
+let test_direct_donations_are_surplus_not_reserves =
+  let (pool, _lqt, fa2, fa12) = setup_pool () in
+  let pool_address = Test.Typed_address.to_address pool.taddr in
+  let before : Contract.storage = Test.Typed_address.get_storage pool.taddr in
+  let () = Test.State.set_source (manager ()) in
+  let () = transfer_fa2 fa2.taddr (manager ()) pool_address 777n in
+  let () = transfer_fa12 fa12.taddr (manager ()) pool_address 888n in
+  let after : Contract.storage = Test.Typed_address.get_storage pool.taddr in
+  let () = assert_nat "donated A changed reserve" after.reserve_a before.reserve_a in
+  let () = assert_nat "donated B changed reserve" after.reserve_b before.reserve_b in
+  assert_solvency "donation surplus" pool.taddr fa2.taddr fa12.taddr
+
+let test_claim_is_permissionless_but_pays_only_configured_recipient =
+  let (pool, _lqt, fa2, fa12) = setup_pool () in
+  let () =
+    fund_and_authorize_trader pool.taddr fa2.taddr fa12.taddr 1000000n 0n in
+  let swap : Contract.swap_param =
+    {
+      direction = A_to_b;
+      amount_in = 100000n;
+      min_amount_out = 1n;
+      receiver = trader ();
+      deadline = future
+    } in
+  let _ : nat =
+    Test.Contract.transfer_exn
+      (Test.Typed_address.get_entrypoint "swap" pool.taddr)
+      swap
+      0tez in
+  let recipient_before = fa2_balance fa2.taddr (fee_recipient ()) in
+  let () = Test.State.set_source (successor ()) in
+  let _ : nat =
+    Test.Contract.transfer_exn
+      (Test.Typed_address.get_entrypoint "claim_protocol_fee" pool.taddr)
+      Token_a
+      0tez in
+  let storage : Contract.storage = Test.Typed_address.get_storage pool.taddr in
+  let () = assert_nat "fee not zeroed" storage.protocol_fee_a 0n in
+  let () =
+    assert_nat
+      "wrong fee destination"
+      (fa2_balance fa2.taddr (fee_recipient ()))
+      (recipient_before + 50n) in
+  assert_solvency "fee claim" pool.taddr fa2.taddr fa12.taddr
+
+(* ----------------------------------------------------------------------- *)
+(* Pause and administration                                                 *)
+(* ----------------------------------------------------------------------- *)
+
+let test_pause_blocks_swaps_and_adds_but_not_removal =
+  let (pool, _lqt, fa2, fa12) = setup_pool () in
+  let () =
+    fund_and_authorize_trader pool.taddr fa2.taddr fa12.taddr 100000n 10000000n in
+  let add : Contract.add_liquidity_param =
+    {
+      max_amount_a = 100000n;
+      max_amount_b = 10000000n;
+      min_lqt_minted = 1n;
+      receiver = trader ();
+      deadline = future
+    } in
+  let _ : nat =
+    Test.Contract.transfer_exn
+      (Test.Typed_address.get_entrypoint "add_liquidity" pool.taddr)
+      add
+      0tez in
+  let () = Test.State.set_source (manager ()) in
+  let _ : nat =
+    Test.Contract.transfer_exn
+      (Test.Typed_address.get_entrypoint "set_paused" pool.taddr)
+      true
+      0tez in
+  let () = Test.State.set_source (trader ()) in
+  let swap_result =
+    Test.Contract.transfer
+      (Test.Typed_address.get_entrypoint "swap" pool.taddr)
+      ({direction = A_to_b; amount_in = 1n; min_amount_out = 0n;
+        receiver = trader (); deadline = future} : Contract.swap_param)
+      0tez in
+  let () = assert_string_failure "paused swap" Contract.err_paused swap_result in
+  let add_result =
+    Test.Contract.transfer
+      (Test.Typed_address.get_entrypoint "add_liquidity" pool.taddr)
+      add
+      0tez in
+  let () = assert_string_failure "paused add" Contract.err_paused add_result in
+  let remove : Contract.remove_liquidity_param =
+    {
+      lqt_burned = 100000n;
+      min_amount_a = 1n;
+      min_amount_b = 1n;
+      receiver = trader ();
+      deadline = future
+    } in
+  let _ : nat =
+    Test.Contract.transfer_exn
+      (Test.Typed_address.get_entrypoint "remove_liquidity" pool.taddr)
+      remove
+      0tez in
+  assert_solvency "paused removal" pool.taddr fa2.taddr fa12.taddr
+
+let test_manager_transfer_is_two_step_and_cancelable =
+  let (pool, _lqt, _fa2, _fa12) = setup_pool () in
+  let () = Test.State.set_source (manager ()) in
+  let _ : nat =
+    Test.Contract.transfer_exn
+      (Test.Typed_address.get_entrypoint "propose_manager" pool.taddr)
+      (successor ())
+      0tez in
+  let _ : nat =
+    Test.Contract.transfer_exn
+      (Test.Typed_address.get_entrypoint "cancel_manager_transfer" pool.taddr)
+      ()
+      0tez in
+  let () = Test.State.set_source (successor ()) in
+  let canceled =
+    Test.Contract.transfer
+      (Test.Typed_address.get_entrypoint "accept_manager" pool.taddr)
+      ()
+      0tez in
+  let () =
+    assert_string_failure
+      "canceled manager acceptance"
+      Contract.err_not_pending_manager
+      canceled in
+  let () = Test.State.set_source (manager ()) in
+  let _ : nat =
+    Test.Contract.transfer_exn
+      (Test.Typed_address.get_entrypoint "propose_manager" pool.taddr)
+      (successor ())
+      0tez in
+  let () = Test.State.set_source (successor ()) in
+  let _ : nat =
+    Test.Contract.transfer_exn
+      (Test.Typed_address.get_entrypoint "accept_manager" pool.taddr)
+      ()
+      0tez in
+  let storage : Contract.storage = Test.Typed_address.get_storage pool.taddr in
+  assert_true "manager not transferred" (storage.manager = successor ())
+
+let test_fee_recipient_change_is_two_step =
+  let (pool, _lqt, _fa2, _fa12) = setup_pool () in
+  let () = Test.State.set_source (manager ()) in
+  let _ : nat =
+    Test.Contract.transfer_exn
+      (Test.Typed_address.get_entrypoint "propose_protocol_fee_recipient" pool.taddr)
+      (replacement_fee_recipient ())
+      0tez in
+  let () = Test.State.set_source (replacement_fee_recipient ()) in
+  let _ : nat =
+    Test.Contract.transfer_exn
+      (Test.Typed_address.get_entrypoint "accept_protocol_fee_recipient" pool.taddr)
+      ()
+      0tez in
+  let storage : Contract.storage = Test.Typed_address.get_storage pool.taddr in
+  assert_true
+    "fee recipient not transferred"
+    (storage.protocol_fee_recipient = replacement_fee_recipient ())
+
+let test_non_payable_and_unauthorized_admin_calls_fail_closed =
+  let (pool, _lqt, _fa2, _fa12) = setup_pool () in
+  let () = Test.State.set_source (trader ()) in
+  let unauthorized =
+    Test.Contract.transfer
+      (Test.Typed_address.get_entrypoint "set_paused" pool.taddr)
+      true
+      0tez in
+  let () =
+    assert_string_failure
+      "unauthorized pause"
+      Contract.err_not_manager
+      unauthorized in
+  let payable =
+    Test.Contract.transfer
+      (Test.Typed_address.get_entrypoint "default" pool.taddr)
+      ()
+      1mutez in
+  assert_string_failure "payable default" Contract.err_non_payable payable
+
+(* ----------------------------------------------------------------------- *)
+(* Views and immutable economics                                            *)
+(* ----------------------------------------------------------------------- *)
+
+let test_views_match_execution_math_and_immutable_fee_split =
+  let (pool, _lqt, _fa2, _fa12) = setup_pool () in
+  let pool_address = Test.Typed_address.to_address pool.taddr in
+  let fee_view : (nat * nat * nat) option =
+    Tezos.View.call "get_fee_bp" () pool_address in
+  let quote_view : nat option =
+    Tezos.View.call "quote_a_to_b" 100000n pool_address in
+  let () =
+    match fee_view with
+    | Some (lp, protocol, total) ->
+        assert_true "wrong fee view" (lp = 25n && protocol = 5n && total = 30n)
+    | None -> failwith "fee view unavailable" in
+  match quote_view with
+  | Some quote ->
+      assert_nat
+        "quote view mismatch"
+        quote
+        (Contract.quote_output 100000n seed_a seed_b)
+  | None -> failwith "quote view unavailable"


### PR DESCRIPTION
## Summary

- add one generic single-pair constant-product artifact for FA1.2/FA1.2, FA2/FA2, and mixed pairs
- keep both asset descriptors immutable and use the repository's external FA1.2 LQT with a permanent 1,000-unit minimum lock
- fix swap economics at 25 bp for LPs plus 5 bp for the protocol, with separate per-asset fee accounting
- add deadlines, slippage bounds, checked arithmetic, a self-closed reentrancy guard, pause-safe exits, and two-step/cancelable manager and fee-recipient handoffs
- add exact-chain, artifact, token-code, metadata, solvency, and LQT verification to a resumable Previewnet/testnet-only deployment workflow
- add deterministic read-only token code inspection, reproducible CI, provenance/delta documentation, and an explicit internal security assessment

## Architectural change from #255

This supersedes the earlier draft #255 rather than extending it. The earlier integrated-LP, FA2-only callback state machine has been replaced with:

- the established external FA1.2 LQT interface
- generic FA1.2/FA2 assets
- strict reviewed-token atomic-transfer assumptions instead of callback-driven pending actions
- a smaller 9,189-byte pool artifact
- non-mainnet deployment tooling with atomic seed authorization cleanup
- explicit upstream provenance without claiming inherited audit coverage

Because this is a new commit head and material architecture, it requires a fresh review; prior approvals on #255 should not be treated as approval of this PR.

## Security boundary

The pool must only be deployed with exact, reviewed, non-taxed token implementations. The deployment tooling pins canonical script-code hashes and required entrypoints, but identity does not make an unsafe token compatible. Rebasing, transfer taxes, administrator balance seizure, non-atomic transfer behavior, and incompatible authorization semantics remain disallowed.

This is a review candidate. Mainnet is not exposed by the token-to-token scripts, and the internal assessment is not an independent audit.

## Validation

- LIGO 1.11.5 pool suite: 17 tests passed, including all three pair shapes, bidirectional swaps, liquidity lifecycle, fee claims, pause/administration, deadline/slippage rollback, and hostile callback reentrancy
- existing external LQT and all four native-pool LIGO regression suites passed
- pool artifact rebuilt byte-for-byte; SHA-256 `a7939ae6ee629057d6dca4301a9be8485b19d72efebcdf172cbd4a3a0e48957e`
- existing LQT artifact rebuilt byte-for-byte; SHA-256 `2df971245f3d468ee2668e1ed48797852eedd280348c753e9f2cd1d1bdf23921`
- clean `npm ci --ignore-scripts` passed
- TypeScript passed
- 25 Node/configuration/schema/hash tests passed
- `npm audit --omit=dev` reports zero known production-dependency vulnerabilities after upgrading the scripts package to Taquito 25
- `git diff --check` passed

The checked-in Husky wrapper could not start locally because its bootstrap file and referenced `V2/tezex` directory are absent. The commit was made after the checks above were run manually; CI independently repeats the scoped release gates.

## Review focus

Please review:

1. reserve/protocol-fee and integer-rounding invariants
2. external-operation ordering and the `entered` / self-only `%close` guard
3. LQT mint/burn synchronization and minimum lock
4. strict FA1.2/FA2 compatibility assumptions
5. initialization, resumability, manager handoff, and post-deployment verification
6. the exact compiled Michelson artifact and pinned hashes
