### PR TITLE
Rename primary navigation item to Swap

### DIFF
--- a/V2/tezex/src/components/nav/NavApp.test.tsx
+++ b/V2/tezex/src/components/nav/NavApp.test.tsx
@@ -47,7 +47,7 @@ test("marks the current primary destination without using a body-style pill", ()
     "aria-selected",
     "true"
   );
-  expect(screen.getByRole("tab", { name: "Home" })).not.toHaveAttribute(
+  expect(screen.getByRole("tab", { name: "Swap" })).not.toHaveAttribute(
     "aria-current"
   );
 });
@@ -55,21 +55,21 @@ test("marks the current primary destination without using a body-style pill", ()
 test("navigates between primary destinations", () => {
   renderNavigation("/stez");
 
-  fireEvent.click(screen.getByRole("tab", { name: "Home" }));
+  fireEvent.click(screen.getByRole("tab", { name: "Swap" }));
 
   expect(screen.getByTestId("location")).toHaveTextContent(
     "/swap/xtz-to-tzbtc"
   );
 });
 
-test("does not mark Home active on the not-found route", () => {
+test("does not mark Swap active on the not-found route", () => {
   renderNavigation("/missing");
 
-  expect(screen.getByRole("tab", { name: "Home" })).toHaveAttribute(
+  expect(screen.getByRole("tab", { name: "Swap" })).toHaveAttribute(
     "aria-selected",
     "false"
   );
-  expect(screen.getByRole("tab", { name: "Home" })).not.toHaveAttribute(
+  expect(screen.getByRole("tab", { name: "Swap" })).not.toHaveAttribute(
     "aria-current"
   );
 });

--- a/V2/tezex/src/components/nav/NavApp.tsx
+++ b/V2/tezex/src/components/nav/NavApp.tsx
@@ -80,7 +80,7 @@ export const NavApp: FC<INavApp> = (props) => {
         style: { display: "none" },
       }}
     >
-      <NavTab label="Home" href={homePath} active={value === 0} />
+      <NavTab label="Swap" href={homePath} active={value === 0} />
       <NavTab label="Analytics" href="/analytics" active={value === 1} />
       <NavTab label="sTEZ" href="/stez" active={value === 2} />
       <NavTabExternal label="About" href={aboutRedirectUrl} />


### PR DESCRIPTION
## What changed
- rename the first primary navigation item from Home to Swap
- preserve its existing route and selected-state behavior
- update the navigation regression tests

## Validation
- TypeScript typecheck
- navigation component tests
- production build
- verified the label and selected state in a real browser