### PR TITLE
Fix adaptive favicon selection

### DIFF
--- a/V2/tezex/public/404.html
+++ b/V2/tezex/public/404.html
@@ -15,22 +15,22 @@
       media="(prefers-color-scheme: dark)"
     />
     <meta name="robots" content="noindex" />
-    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+    <link rel="icon" href="/favicon.svg?v=20260814" type="image/svg+xml" />
     <link
       rel="icon"
       type="image/png"
       sizes="32x32"
-      href="/favicon-32-on-light.png"
+      href="/favicon-32-on-light.png?v=20260814"
       media="(prefers-color-scheme: light)"
     />
     <link
       rel="icon"
       type="image/png"
       sizes="32x32"
-      href="/favicon-32-on-dark.png"
+      href="/favicon-32-on-dark.png?v=20260814"
       media="(prefers-color-scheme: dark)"
     />
-    <link rel="icon" href="/favicon.ico" sizes="any" />
+    <!-- favicon.ico remains at the site root for implicit legacy fallback. -->
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#0a0a0a" />
     <link rel="manifest" href="/site.webmanifest" />

--- a/V2/tezex/public/index.html
+++ b/V2/tezex/public/index.html
@@ -67,22 +67,26 @@
       content="TEZEX (Tezos Exchange) is liquidity hub for the Tezos blockchain ecosystem — aggregating the largest liquidity sources in Tezos — trade and provide liquidity"
     />
     <meta name="twitter:image" content="%PUBLIC_URL%/assets/tezex_image.png" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.svg" type="image/svg+xml" />
+    <link
+      rel="icon"
+      href="%PUBLIC_URL%/favicon.svg?v=20260814"
+      type="image/svg+xml"
+    />
     <link
       rel="icon"
       type="image/png"
       sizes="32x32"
-      href="%PUBLIC_URL%/favicon-32-on-light.png"
+      href="%PUBLIC_URL%/favicon-32-on-light.png?v=20260814"
       media="(prefers-color-scheme: light)"
     />
     <link
       rel="icon"
       type="image/png"
       sizes="32x32"
-      href="%PUBLIC_URL%/favicon-32-on-dark.png"
+      href="%PUBLIC_URL%/favicon-32-on-dark.png?v=20260814"
       media="(prefers-color-scheme: dark)"
     />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" sizes="any" />
+    <!-- favicon.ico remains at the site root for implicit legacy fallback. -->
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/apple-touch-icon.png" />
     <link
       rel="mask-icon"

--- a/V2/tezex/src/faviconMetadata.test.ts
+++ b/V2/tezex/src/faviconMetadata.test.ts
@@ -11,16 +11,14 @@ describe("TEZEX browser identity", () => {
 
   it("serves an adaptive favicon and scheme-aware browser chrome", () => {
     const appIconOrder = [
-      "%PUBLIC_URL%/favicon.svg",
-      "%PUBLIC_URL%/favicon-32-on-light.png",
-      "%PUBLIC_URL%/favicon-32-on-dark.png",
-      "%PUBLIC_URL%/favicon.ico",
+      "%PUBLIC_URL%/favicon.svg?v=20260814",
+      "%PUBLIC_URL%/favicon-32-on-light.png?v=20260814",
+      "%PUBLIC_URL%/favicon-32-on-dark.png?v=20260814",
     ].map((icon) => indexHtml.indexOf(icon));
     const notFoundIconOrder = [
-      "/favicon.svg",
-      "/favicon-32-on-light.png",
-      "/favicon-32-on-dark.png",
-      "/favicon.ico",
+      "/favicon.svg?v=20260814",
+      "/favicon-32-on-light.png?v=20260814",
+      "/favicon-32-on-dark.png?v=20260814",
     ].map((icon) => notFoundHtml.indexOf(icon));
 
     expect(appIconOrder.every((position) => position >= 0)).toBe(true);
@@ -30,11 +28,15 @@ describe("TEZEX browser identity", () => {
       [...notFoundIconOrder].sort((a, b) => a - b)
     );
     expect(indexHtml).toContain(
-      'href="%PUBLIC_URL%/favicon-32-on-light.png"\n      media="(prefers-color-scheme: light)"'
+      'href="%PUBLIC_URL%/favicon-32-on-light.png?v=20260814"\n      media="(prefers-color-scheme: light)"'
     );
     expect(indexHtml).toContain(
-      'href="%PUBLIC_URL%/favicon-32-on-dark.png"\n      media="(prefers-color-scheme: dark)"'
+      'href="%PUBLIC_URL%/favicon-32-on-dark.png?v=20260814"\n      media="(prefers-color-scheme: dark)"'
     );
+    expect(indexHtml).not.toContain(
+      'rel="icon" href="%PUBLIC_URL%/favicon.ico"'
+    );
+    expect(notFoundHtml).not.toContain('rel="icon" href="/favicon.ico"');
     expect(indexHtml).toContain("%PUBLIC_URL%/safari-pinned-tab.svg");
     expect(indexHtml).toContain("%PUBLIC_URL%/apple-touch-icon.png");
     expect(indexHtml).toContain("%PUBLIC_URL%/site.webmanifest");


### PR DESCRIPTION
## What changed
- stop explicitly advertising the dark-only legacy favicon to modern browsers
- keep the legacy icon at the conventional root path for automatic fallback
- version the adaptive SVG and light/dark PNG URLs so browsers re-evaluate cached favicons
- apply the same metadata to the main app and static 404 page

## Verification
- typecheck
- 40 test suites passed (209 tests, 2 skipped)
- production build passed
- verified in Chrome with a dark color preference: the dark PNG is the matching final candidate and no explicit ICO candidate remains