### PR TITLE
Move sTEZ testing to persistent Snet

### DIFF
--- a/V2/tezex/src/components/ui/elements/selectors/networkSelector/NetworkSelector.tsx
+++ b/V2/tezex/src/components/ui/elements/selectors/networkSelector/NetworkSelector.tsx
@@ -153,12 +153,12 @@ export const NetworkSelector: FC = () => {
     return (
       <Box
         component="div"
-        aria-label="Network: Weeklynet, live"
+        aria-label="Network: Snet, live"
         sx={{ ...styles.button, cursor: "default" }}
       >
         <Box aria-hidden="true" sx={styles.liveSignal} />
         <Box data-network-label sx={styles.networkIdentity}>
-          <Typography sx={styles.networkLabel}>Weeklynet</Typography>
+          <Typography sx={styles.networkLabel}>Snet</Typography>
         </Box>
       </Box>
     );

--- a/V2/tezex/src/components/ui/views/header/index.test.tsx
+++ b/V2/tezex/src/components/ui/views/header/index.test.tsx
@@ -16,7 +16,7 @@ jest.mock("../../../../functions/beacon", () => ({
 }));
 
 jest.mock("../../../../pages/Stez/network", () => ({
-  resolveCurrentWeeklynet: jest.fn(),
+  resolveSnet: jest.fn(),
 }));
 
 jest.mock("../../../nav", () => ({

--- a/V2/tezex/src/components/ui/views/header/index.tsx
+++ b/V2/tezex/src/components/ui/views/header/index.tsx
@@ -20,7 +20,7 @@ import { useColorMode } from "../../../../contexts/color-mode";
 import { homePathForHost } from "../../../../routing";
 import { useWallet } from "../../../../hooks/wallet";
 import { connectWalletToCustomNetwork } from "../../../../functions/beacon";
-import { resolveCurrentWeeklynet } from "../../../../pages/Stez/network";
+import { resolveSnet } from "../../../../pages/Stez/network";
 
 export interface IHeader {
   openMenu: boolean;
@@ -35,11 +35,11 @@ export const Header: FC<IHeader> = (props) => {
   const location = useLocation();
   const wallet = useWallet();
   const isStezRoute = location.pathname.startsWith("/stez");
-  const connectToWeeklynet = useCallback(async () => {
-    const weeklynet = await resolveCurrentWeeklynet();
+  const connectToSnet = useCallback(async () => {
+    const snet = await resolveSnet();
     await connectWalletToCustomNetwork(wallet, {
-      name: weeklynet.name,
-      rpcUrl: weeklynet.rpcUrl,
+      name: snet.name,
+      rpcUrl: snet.rpcUrl,
     });
   }, [wallet]);
 
@@ -98,7 +98,7 @@ export const Header: FC<IHeader> = (props) => {
                   variant={"header"}
                   scalingKey={scalingKey}
                   visualVariant="dark"
-                  connectOverride={isStezRoute ? connectToWeeklynet : undefined}
+                  connectOverride={isStezRoute ? connectToSnet : undefined}
                 />
               </Box>
             </Box>

--- a/V2/tezex/src/components/ui/views/layout/index.tsx
+++ b/V2/tezex/src/components/ui/views/layout/index.tsx
@@ -77,7 +77,7 @@ export const Layout: FC<ILayout> = (props) => {
             <Box sx={styles.bottomSpace}>
               <Typography sx={styles.bottomSpaceText}>
                 {isStezRoute ? (
-                  "sTEZ data read from the current Weeklynet RPC"
+                  "sTEZ data read from the Snet RPC"
                 ) : (
                   <>
                     Data provided by

--- a/V2/tezex/src/pages/Stez/index.test.tsx
+++ b/V2/tezex/src/pages/Stez/index.test.tsx
@@ -3,24 +3,24 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import { Stez } from ".";
 import { connectWalletToCustomNetwork } from "../../functions/beacon";
-import { resolveCurrentWeeklynet } from "./network";
+import { resolveSnet } from "./network";
 import { loadStezSnapshot, StezSnapshot } from "./rpc";
 
 jest.mock("../../functions/beacon", () => ({
   connectWalletToCustomNetwork: jest.fn(),
 }));
 
-const weeklynet = {
-  key: "weeklynet-2026-08-05",
-  name: "Weeklynet" as const,
-  rpcUrl: "https://rpc.weeklynet-2026-08-05.teztnets.com",
-  faucetUrl: "https://faucet.weeklynet-2026-08-05.teztnets.com",
-  chainId: "NetXmT6tP86uFqw",
-  activatedOn: "2026-08-05",
+const snet = {
+  key: "snet" as const,
+  name: "Snet" as const,
+  rpcUrl: "https://rpc.snet.teztnets.com",
+  faucetUrl: "https://faucet.snet.teztnets.com",
+  chainId: "NetXVasgoZmPMLe",
+  activatedOn: "2026-08-14",
   info: {
-    tezosServer: "https://rpc.weeklynet-2026-08-05.teztnets.com",
+    tezosServer: "https://rpc.snet.teztnets.com",
     rpcFallbacks: [],
-    chainId: "NetXmT6tP86uFqw",
+    chainId: "NetXVasgoZmPMLe",
     pools: [],
     assets: [],
   },
@@ -46,7 +46,7 @@ jest.mock("../../hooks/wallet", () => ({
 }));
 jest.mock("./network", () => {
   const actual = jest.requireActual("./network");
-  return { ...actual, resolveCurrentWeeklynet: jest.fn() };
+  return { ...actual, resolveSnet: jest.fn() };
 });
 jest.mock("./rpc", () => {
   const actual = jest.requireActual("./rpc");
@@ -55,8 +55,8 @@ jest.mock("./rpc", () => {
 
 const baseSnapshot: StezSnapshot = {
   availability: "available",
-  endpoint: weeklynet.rpcUrl,
-  chainId: weeklynet.chainId,
+  endpoint: snet.rpcUrl,
+  chainId: snet.chainId,
   protocolHash: "ProtoALphaALphaALphaALphaALphaALphaALphaALphaDdp3zK",
   blockHash: "BLockHash",
   blockLevel: BigInt(2_640),
@@ -79,27 +79,27 @@ beforeEach(() => {
   mockWallet.isWalletConnected = false;
   mockWallet.address = null;
   mockWallet.client = null;
-  (resolveCurrentWeeklynet as jest.Mock).mockResolvedValue(weeklynet);
+  (resolveSnet as jest.Mock).mockResolvedValue(snet);
   (loadStezSnapshot as jest.Mock).mockResolvedValue(baseSnapshot);
 });
 
-test("loads live Weeklynet data and its matching faucet", async () => {
+test("loads live Snet data and its matching faucet", async () => {
   render(<Stez />);
 
   expect(screen.getByText("Loading sTEZ data")).toBeInTheDocument();
-  await screen.findByText("sTEZ is live on Weeklynet");
+  await screen.findByText("sTEZ is live on Snet");
 
   expect(
-    screen.getByText(/Weeklynet resets every Wednesday/)
+    screen.getByText(/without Weeklynet’s scheduled resets/)
   ).toBeInTheDocument();
   expect(screen.getByText("Stake tez, stay liquid.")).toBeInTheDocument();
   expect(screen.getByText("sTEZ Balance")).toBeInTheDocument();
   expect(screen.getByText("Total sTEZ supply")).toBeInTheDocument();
 
   const faucet = screen.getByRole("link", {
-    name: "Get Weeklynet test XTZ from the official Teztnets faucet",
+    name: "Get Snet test XTZ from the official Teztnets faucet",
   });
-  expect(faucet).toHaveAttribute("href", weeklynet.faucetUrl);
+  expect(faucet).toHaveAttribute("href", snet.faucetUrl);
   expect(faucet.querySelector("svg")).toBeInTheDocument();
 
   fireEvent.click(screen.getByRole("tab", { name: "Redeem" }));
@@ -119,7 +119,7 @@ test("shows an exact inactive-network state without enabling controls", async ()
 
   render(<Stez />);
 
-  await screen.findByText("sTEZ is not active on Weeklynet");
+  await screen.findByText("sTEZ is not active on Snet");
   expect(
     screen.getByText(
       "The selected network includes the sTEZ protocol code, but native sTEZ contracts are not enabled. No balances, rates, or transaction controls are shown."
@@ -127,13 +127,13 @@ test("shows an exact inactive-network state without enabling controls", async ()
   ).toBeInTheDocument();
 });
 
-test("enables a stake request only for a wallet connected to current Weeklynet", async () => {
+test("enables a stake request only for a wallet connected to Snet", async () => {
   mockWallet.isWalletConnected = true;
   mockWallet.address = "tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb";
   mockWallet.client = mockClient;
   mockClient.getActiveAccount.mockResolvedValue({
     address: mockWallet.address,
-    network: { type: "custom", rpcUrl: weeklynet.rpcUrl },
+    network: { type: "custom", rpcUrl: snet.rpcUrl },
   });
   (loadStezSnapshot as jest.Mock).mockResolvedValue({
     ...baseSnapshot,
@@ -145,7 +145,7 @@ test("enables a stake request only for a wallet connected to current Weeklynet",
 
   render(<Stez />);
 
-  await screen.findByText("sTEZ is live on Weeklynet");
+  await screen.findByText("sTEZ is live on Snet");
   await waitFor(() =>
     expect(
       screen.getByRole("button", { name: "ENTER AN AMOUNT" })
@@ -158,18 +158,18 @@ test("enables a stake request only for a wallet connected to current Weeklynet",
   expect(screen.getByRole("button", { name: "STAKE XTZ" })).toBeEnabled();
 });
 
-test("connects a disconnected wallet to the resolved Weeklynet RPC", async () => {
+test("connects a disconnected wallet to the Snet RPC", async () => {
   render(<Stez />);
-  await screen.findByText("sTEZ is live on Weeklynet");
+  await screen.findByText("sTEZ is live on Snet");
 
   fireEvent.click(
-    screen.getByRole("button", { name: "CONNECT WALLET TO WEEKLYNET" })
+    screen.getByRole("button", { name: "CONNECT WALLET TO SNET" })
   );
 
   await waitFor(() =>
     expect(connectWalletToCustomNetwork).toHaveBeenCalledWith(mockWallet, {
-      name: "Weeklynet",
-      rpcUrl: weeklynet.rpcUrl,
+      name: "Snet",
+      rpcUrl: snet.rpcUrl,
     })
   );
 });

--- a/V2/tezex/src/pages/Stez/index.tsx
+++ b/V2/tezex/src/pages/Stez/index.tsx
@@ -16,11 +16,7 @@ import {
   stezUnderlyingValue,
   waitForStezOperation,
 } from "./rpc";
-import {
-  isWeeklynetAccount,
-  resolveCurrentWeeklynet,
-  WeeklynetNetwork,
-} from "./network";
+import { isSnetAccount, resolveSnet, SnetNetwork } from "./network";
 import { readableStezError, submitStezOperation } from "./transactions";
 import "./style.css";
 
@@ -84,15 +80,15 @@ const statusCopy = (
     return {
       title: "Loading sTEZ data",
       description:
-        "TEZEX is resolving the current Weeklynet and checking its native sTEZ contract.",
+        "TEZEX is connecting to Snet and checking its native sTEZ contract.",
     };
   }
   if (!snapshot) {
     return {
-      title: "Unable to resolve Weeklynet",
+      title: "Unable to reach Snet",
       description:
         networkError ??
-        "The current Weeklynet could not be read from the official Teztnets directory.",
+        "The Snet public RPC could not be reached. No cached or estimated values have been substituted.",
     };
   }
   if (snapshot.availability === "available") {
@@ -100,7 +96,7 @@ const statusCopy = (
       title: `sTEZ is live on ${selectedNetwork}`,
       description: `Use test XTZ to stake, redeem, and finalize against the current experimental protocol. Live data was read from block ${snapshot.blockLevel.toLocaleString(
         "en-US"
-      )}. Weeklynet resets every Wednesday, so balances and addresses are temporary.`,
+      )}. Snet is intended for longer-term sTEZ testing without Weeklynet’s scheduled resets.`,
     };
   }
   if (snapshot.availability === "disabled") {
@@ -151,8 +147,8 @@ const PositionCell: FC<PositionCellProps> = ({
 
 export const Stez: FC = () => {
   const wallet = useWallet();
-  const selectedNetwork = "Weeklynet";
-  const [weeklynet, setWeeklynet] = useState<WeeklynetNetwork | null>(null);
+  const selectedNetwork = "Snet";
+  const [snet, setSnet] = useState<SnetNetwork | null>(null);
   const [snapshot, setSnapshot] = useState<StezSnapshot | null>(null);
   const [loading, setLoading] = useState(true);
   const [networkError, setNetworkError] = useState<string | null>(null);
@@ -171,11 +167,11 @@ export const Stez: FC = () => {
     setNetworkError(null);
     setAmount("");
 
-    resolveCurrentWeeklynet(controller.signal)
-      .then(async (nextWeeklynet) => {
-        if (!controller.signal.aborted) setWeeklynet(nextWeeklynet);
+    resolveSnet()
+      .then(async (nextSnet) => {
+        if (!controller.signal.aborted) setSnet(nextSnet);
         return loadStezSnapshot(
-          nextWeeklynet.info,
+          nextSnet.info,
           wallet.address,
           controller.signal
         );
@@ -199,7 +195,7 @@ export const Stez: FC = () => {
   useEffect(() => {
     let mounted = true;
 
-    if (!wallet.client || !weeklynet) {
+    if (!wallet.client || !snet) {
       setWalletReady(false);
       return () => {
         mounted = false;
@@ -209,7 +205,7 @@ export const Stez: FC = () => {
     wallet.client
       .getActiveAccount()
       .then((account) => {
-        if (mounted) setWalletReady(isWeeklynetAccount(account, weeklynet));
+        if (mounted) setWalletReady(isSnetAccount(account, snet));
       })
       .catch(() => {
         if (mounted) setWalletReady(false);
@@ -218,7 +214,7 @@ export const Stez: FC = () => {
     return () => {
       mounted = false;
     };
-  }, [wallet.client, weeklynet]);
+  }, [wallet.client, snet]);
 
   const available = snapshot?.availability === "available";
   const walletConnected =
@@ -264,13 +260,13 @@ export const Stez: FC = () => {
   const copy = statusCopy(snapshot, loading, selectedNetwork, networkError);
 
   const connect = useCallback(async () => {
-    const activeWeeklynet = weeklynet ?? (await resolveCurrentWeeklynet());
-    setWeeklynet(activeWeeklynet);
+    const activeSnet = snet ?? (await resolveSnet());
+    setSnet(activeSnet);
     await connectWalletToCustomNetwork(wallet, {
-      name: activeWeeklynet.name,
-      rpcUrl: activeWeeklynet.rpcUrl,
+      name: activeSnet.name,
+      rpcUrl: activeSnet.rpcUrl,
     });
-  }, [wallet, weeklynet]);
+  }, [wallet, snet]);
 
   const setMaximum = () => {
     const maximum =
@@ -283,9 +279,9 @@ export const Stez: FC = () => {
   };
 
   const actionButtonCopy = () => {
-    if (!walletConnected) return "CONNECT WALLET TO WEEKLYNET";
+    if (!walletConnected) return "CONNECT WALLET TO SNET";
     if (transactionStage === "requesting") return "CONFIRM IN WALLET";
-    if (transactionStage === "submitted") return "CONFIRMING ON WEEKLYNET";
+    if (transactionStage === "submitted") return "CONFIRMING ON SNET";
     if (transactionStage === "confirmed") return "CONFIRMED";
     if (
       activeAction === "Finalize" &&
@@ -307,12 +303,7 @@ export const Stez: FC = () => {
       await connect();
       return;
     }
-    if (
-      !wallet.client ||
-      !wallet.address ||
-      !weeklynet ||
-      !snapshot?.contractHash
-    ) {
+    if (!wallet.client || !wallet.address || !snet || !snapshot?.contractHash) {
       return;
     }
 
@@ -330,14 +321,14 @@ export const Stez: FC = () => {
       setOperationHash(hash);
       setTransactionStage("submitted");
       setTransactionMessage(
-        "Operation submitted. Waiting for Weeklynet confirmation."
+        "Operation submitted. Waiting for Snet confirmation."
       );
       await waitForStezOperation(snapshot.endpoint, hash);
-      const refreshed = await loadStezSnapshot(weeklynet.info, wallet.address);
+      const refreshed = await loadStezSnapshot(snet.info, wallet.address);
       setSnapshot(refreshed);
       setAmount("");
       setTransactionStage("confirmed");
-      setTransactionMessage("Operation confirmed on Weeklynet.");
+      setTransactionMessage("Operation confirmed on Snet.");
     } catch (error) {
       setTransactionStage("failed");
       setTransactionMessage(readableStezError(error));
@@ -350,7 +341,7 @@ export const Stez: FC = () => {
     wallet.address,
     wallet.client,
     walletConnected,
-    weeklynet,
+    snet,
   ]);
 
   const actionDisabled =
@@ -395,15 +386,15 @@ export const Stez: FC = () => {
           <strong>{copy.title}</strong>
           <p>{copy.description}</p>
         </div>
-        {weeklynet && (
+        {snet && (
           <a
             className="stez-availability__faucet-link"
-            href={weeklynet.faucetUrl}
+            href={snet.faucetUrl}
             target="_blank"
             rel="noreferrer"
-            aria-label="Get Weeklynet test XTZ from the official Teztnets faucet"
+            aria-label="Get Snet test XTZ from the official Teztnets faucet"
           >
-            GET WEEKLYNET TEST XTZ
+            GET SNET TEST XTZ
             <ArrowOutwardRoundedIcon aria-hidden="true" />
           </a>
         )}
@@ -719,7 +710,7 @@ export const Stez: FC = () => {
               <dt>Network / chain ID</dt>
               <dd>
                 {selectedNetwork} ·{" "}
-                {shortAddress(snapshot?.chainId || weeklynet?.chainId, 10, 6)}
+                {shortAddress(snapshot?.chainId || snet?.chainId, 10, 6)}
               </dd>
               <dt>Protocol</dt>
               <dd>

--- a/V2/tezex/src/pages/Stez/network.test.ts
+++ b/V2/tezex/src/pages/Stez/network.test.ts
@@ -1,79 +1,45 @@
 import {
-  isWeeklynetAccount,
-  resolveCurrentWeeklynet,
-  TEZTNETS_DIRECTORY_URL,
+  isSnetAccount,
+  resolveSnet,
+  SNET_CHAIN_ID,
+  SNET_FAUCET_URL,
+  SNET_RPC_URL,
 } from "./network";
 
-const response = (body: unknown, status = 200) =>
-  Promise.resolve(
-    new Response(JSON.stringify(body), {
-      status,
-      headers: { "Content-Type": "application/json" },
-    })
-  );
+test("resolves the stable Snet configuration", async () => {
+  const network = await resolveSnet();
 
-beforeEach(() => window.localStorage.clear());
-afterEach(() => jest.restoreAllMocks());
-
-test("resolves the newest rotating Weeklynet and its matching faucet", async () => {
-  jest.spyOn(global, "fetch").mockImplementation((input) => {
-    const url = String(input);
-    if (url === TEZTNETS_DIRECTORY_URL) {
-      return response({
-        "weeklynet-2026-07-29": {
-          human_name: "Weeklynet",
-          activated_on: "2026-07-29",
-          rpc_url: "https://rpc.old.example",
-          faucet_url: "https://faucet.old.example",
-        },
-        "weeklynet-2026-08-05": {
-          human_name: "Weeklynet",
-          activated_on: "2026-08-05",
-          rpc_url: "https://rpc.current.example/",
-          faucet_url: "https://faucet.current.example/",
-        },
-      });
-    }
-    if (url === "https://rpc.current.example/chains/main/chain_id") {
-      return response("NetXmT6tP86uFqw");
-    }
-    throw new Error(`Unexpected URL: ${url}`);
-  });
-
-  const network = await resolveCurrentWeeklynet();
-
-  expect(network.key).toBe("weeklynet-2026-08-05");
-  expect(network.rpcUrl).toBe("https://rpc.current.example");
-  expect(network.faucetUrl).toBe("https://faucet.current.example");
-  expect(network.chainId).toBe("NetXmT6tP86uFqw");
+  expect(network.key).toBe("snet");
+  expect(network.name).toBe("Snet");
+  expect(network.rpcUrl).toBe(SNET_RPC_URL);
+  expect(network.faucetUrl).toBe(SNET_FAUCET_URL);
+  expect(network.chainId).toBe(SNET_CHAIN_ID);
+  expect(network.info.tezosServer).toBe(SNET_RPC_URL);
 });
 
-test("recognizes only a wallet permission for the resolved Weeklynet RPC", () => {
-  const network = {
-    key: "weeklynet-2026-08-05",
-    name: "Weeklynet" as const,
-    rpcUrl: "https://rpc.current.example",
-    faucetUrl: "https://faucet.current.example",
-    chainId: "NetXTest",
-    activatedOn: "2026-08-05",
-    info: {
-      tezosServer: "https://rpc.current.example",
-      rpcFallbacks: [],
-      chainId: "NetXTest",
-      pools: [],
-      assets: [],
-    },
-  };
+test("recognizes only a wallet permission for the Snet RPC", async () => {
+  const network = await resolveSnet();
 
   expect(
-    isWeeklynetAccount(
-      { network: { type: "custom", rpcUrl: "https://rpc.current.example/" } },
+    isSnetAccount(
+      { network: { type: "custom", rpcUrl: `${SNET_RPC_URL}/` } },
       network
     )
   ).toBe(true);
   expect(
-    isWeeklynetAccount(
-      { network: { type: "custom", rpcUrl: "https://rpc.old.example" } },
+    isSnetAccount(
+      {
+        network: {
+          type: "custom",
+          rpcUrl: "https://rpc.weeklynet.example",
+        },
+      },
+      network
+    )
+  ).toBe(false);
+  expect(
+    isSnetAccount(
+      { network: { type: "mainnet", rpcUrl: SNET_RPC_URL } },
       network
     )
   ).toBe(false);

--- a/V2/tezex/src/pages/Stez/network.ts
+++ b/V2/tezex/src/pages/Stez/network.ts
@@ -1,30 +1,12 @@
 import { NetworkInfo } from "../../contexts/network";
 
-export const TEZTNETS_DIRECTORY_URL = "https://teztnets.com/teztnets.json";
+export const SNET_RPC_URL = "https://rpc.snet.teztnets.com";
+export const SNET_FAUCET_URL = "https://faucet.snet.teztnets.com";
+export const SNET_CHAIN_ID = "NetXVasgoZmPMLe";
 
-const WEEKLYNET_CACHE_KEY = "tezex:weeklynet";
-
-interface TeztnetDirectoryEntry {
-  activated_on?: string;
-  faucet_url?: string;
-  human_name?: string;
-  rpc_url?: string;
-}
-
-type TeztnetDirectory = Record<string, TeztnetDirectoryEntry>;
-
-interface CachedWeeklynet {
-  key: string;
-  rpcUrl: string;
-  faucetUrl: string;
-  chainId: string;
-  activatedOn: string;
-  resolvedAt: number;
-}
-
-export interface WeeklynetNetwork {
-  key: string;
-  name: "Weeklynet";
+export interface SnetNetwork {
+  key: "snet";
+  name: "Snet";
   rpcUrl: string;
   faucetUrl: string;
   chainId: string;
@@ -34,102 +16,27 @@ export interface WeeklynetNetwork {
 
 const normalizeEndpoint = (endpoint: string) => endpoint.replace(/\/+$/, "");
 
-const readJson = async <T>(url: string, signal?: AbortSignal): Promise<T> => {
-  const response = await fetch(url, {
-    signal,
-    headers: { Accept: "application/json" },
-  });
-  if (!response.ok) {
-    throw new Error(`Request failed (${response.status})`);
-  }
-  return (await response.json()) as T;
-};
-
-const mostRecentWeeklynet = (directory: TeztnetDirectory) => {
-  const candidates = Object.entries(directory)
-    .filter(([, entry]) => entry.human_name === "Weeklynet")
-    .filter(([, entry]) => Boolean(entry.rpc_url && entry.faucet_url))
-    .sort(([, a], [, b]) =>
-      String(b.activated_on ?? "").localeCompare(String(a.activated_on ?? ""))
-    );
-
-  if (!candidates.length) {
-    throw new Error("The Teztnets directory does not list an active Weeklynet");
-  }
-
-  return candidates[0];
-};
-
-const toWeeklynet = (cached: CachedWeeklynet): WeeklynetNetwork => ({
-  key: cached.key,
-  name: "Weeklynet",
-  rpcUrl: cached.rpcUrl,
-  faucetUrl: cached.faucetUrl,
-  chainId: cached.chainId,
-  activatedOn: cached.activatedOn,
+export const SNET_NETWORK: SnetNetwork = {
+  key: "snet",
+  name: "Snet",
+  rpcUrl: SNET_RPC_URL,
+  faucetUrl: SNET_FAUCET_URL,
+  chainId: SNET_CHAIN_ID,
+  activatedOn: "2026-08-14",
   info: {
-    tezosServer: cached.rpcUrl,
+    tezosServer: SNET_RPC_URL,
     rpcFallbacks: [],
-    chainId: cached.chainId,
+    chainId: SNET_CHAIN_ID,
     pools: [],
     assets: [],
   },
-});
-
-const readCachedWeeklynet = (): CachedWeeklynet | null => {
-  try {
-    const value = window.localStorage.getItem(WEEKLYNET_CACHE_KEY);
-    if (!value) return null;
-    const parsed = JSON.parse(value) as CachedWeeklynet;
-    return parsed.rpcUrl && parsed.faucetUrl && parsed.chainId ? parsed : null;
-  } catch {
-    return null;
-  }
 };
 
-const writeCachedWeeklynet = (network: CachedWeeklynet) => {
-  try {
-    window.localStorage.setItem(WEEKLYNET_CACHE_KEY, JSON.stringify(network));
-  } catch {
-    // Weeklynet discovery still works when storage is blocked.
-  }
-};
+export const resolveSnet = async (): Promise<SnetNetwork> => SNET_NETWORK;
 
-export const resolveCurrentWeeklynet = async (
-  signal?: AbortSignal
-): Promise<WeeklynetNetwork> => {
-  try {
-    const directory = await readJson<TeztnetDirectory>(
-      TEZTNETS_DIRECTORY_URL,
-      signal
-    );
-    const [key, entry] = mostRecentWeeklynet(directory);
-    const rpcUrl = normalizeEndpoint(entry.rpc_url as string);
-    const chainId = await readJson<string>(
-      `${rpcUrl}/chains/main/chain_id`,
-      signal
-    );
-    const resolved: CachedWeeklynet = {
-      key,
-      rpcUrl,
-      faucetUrl: normalizeEndpoint(entry.faucet_url as string),
-      chainId,
-      activatedOn: entry.activated_on ?? key.replace("weeklynet-", ""),
-      resolvedAt: Date.now(),
-    };
-    writeCachedWeeklynet(resolved);
-    return toWeeklynet(resolved);
-  } catch (error) {
-    if (signal?.aborted) throw error;
-    const cached = readCachedWeeklynet();
-    if (cached) return toWeeklynet(cached);
-    throw error;
-  }
-};
-
-export const isWeeklynetAccount = (
+export const isSnetAccount = (
   account: { network?: { type?: string; rpcUrl?: string } } | null | undefined,
-  network: WeeklynetNetwork
+  network: SnetNetwork
 ) =>
   account?.network?.type === "custom" &&
   normalizeEndpoint(account.network.rpcUrl ?? "") ===

--- a/V2/tezex/src/pages/Stez/rpc.ts
+++ b/V2/tezex/src/pages/Stez/rpc.ts
@@ -387,6 +387,6 @@ export async function waitForStezOperation(
   }
 
   throw new Error(
-    "The operation was submitted, but confirmation has not appeared on Weeklynet yet."
+    "The operation was submitted, but confirmation has not appeared on Snet yet."
   );
 }


### PR DESCRIPTION
Switches the sTEZ experience from rotating Weeklynet instances to the persistent Snet network created for longer-term sTEZ testing. Updates wallet connection, network identity, faucet routing, status copy, confirmation messaging, and regression tests. No swap, liquidity, styling, or transaction-encoding logic is changed.\n\nVerified with the live Snet RPC, full test suite, TypeScript, production build, desktop and mobile rendering, and browser console/network inspection.