### PR TITLE
Refine sTEZ position and rate layout

### DIFF
--- a/V2/tezex/src/pages/Stez/index.test.tsx
+++ b/V2/tezex/src/pages/Stez/index.test.tsx
@@ -67,6 +67,7 @@ const baseSnapshot: StezSnapshot = {
   rateNumeratorMutez: BigInt(1_100_000),
   rateDenominatorTokenUnits: BigInt(1_000_000),
   walletXtzMutez: null,
+  walletStakedMutez: null,
   walletStezUnits: null,
   redeemedFrozenMutez: null,
   redeemedFinalizableMutez: null,
@@ -138,6 +139,7 @@ test("enables a stake request only for a wallet connected to Snet", async () => 
   (loadStezSnapshot as jest.Mock).mockResolvedValue({
     ...baseSnapshot,
     walletXtzMutez: BigInt(5_000_000),
+    walletStakedMutez: BigInt(1_500_000),
     walletStezUnits: BigInt(2_000_000),
     redeemedFrozenMutez: BigInt(250_000),
     redeemedFinalizableMutez: BigInt(100_000),
@@ -152,7 +154,10 @@ test("enables a stake request only for a wallet connected to Snet", async () => 
     ).toBeDisabled()
   );
   expect(screen.getByText("5.0")).toBeInTheDocument();
+  expect(screen.getByText("1.5")).toBeInTheDocument();
   expect(screen.getByText("2.0")).toBeInTheDocument();
+  expect(screen.getByText("Direct stake")).toBeInTheDocument();
+  expect(screen.getByText("XTZ value of sTEZ")).toBeInTheDocument();
   expect(
     screen.getByText(/Test XTZ detected in your connected wallet/)
   ).toBeInTheDocument();

--- a/V2/tezex/src/pages/Stez/index.tsx
+++ b/V2/tezex/src/pages/Stez/index.tsx
@@ -5,6 +5,8 @@ import CheckCircleOutlineRoundedIcon from "@mui/icons-material/CheckCircleOutlin
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import LockClockOutlinedIcon from "@mui/icons-material/LockClockOutlined";
 import ArrowOutwardRoundedIcon from "@mui/icons-material/ArrowOutwardRounded";
+import SavingsOutlinedIcon from "@mui/icons-material/SavingsOutlined";
+import SwapHorizRoundedIcon from "@mui/icons-material/SwapHorizRounded";
 
 import { connectWalletToCustomNetwork } from "../../functions/beacon";
 import { useWallet } from "../../hooks/wallet";
@@ -435,6 +437,30 @@ export const Stez: FC = () => {
           </header>
           <div className="stez-position-grid">
             <PositionCell
+              label="Wallet XTZ"
+              value={
+                walletConnected
+                  ? formatUnits(snapshot?.walletXtzMutez ?? null)
+                  : "—"
+              }
+              note={walletConnected ? "Spendable now" : "Connect to view"}
+              icon={<AccountBalanceWalletOutlinedIcon />}
+            />
+            <PositionCell
+              label="Direct stake"
+              value={
+                walletConnected
+                  ? formatUnits(snapshot?.walletStakedMutez ?? null)
+                  : "—"
+              }
+              note={
+                walletConnected
+                  ? "Staked separately from sTEZ"
+                  : "Connect to view"
+              }
+              icon={<SavingsOutlinedIcon />}
+            />
+            <PositionCell
               label="sTEZ Balance"
               value={
                 walletConnected
@@ -442,25 +468,19 @@ export const Stez: FC = () => {
                   : "—"
               }
               note={
-                walletConnected
-                  ? `≈ ${formatUnits(
-                      walletUnderlying
-                    )} XTZ at the current protocol rate`
-                  : "Connect to view"
+                walletConnected ? "Liquid and transferable" : "Connect to view"
               }
               icon={<AccountBalanceWalletOutlinedIcon />}
             />
             <PositionCell
-              label="Wallet XTZ"
-              value={
-                walletConnected
-                  ? formatUnits(snapshot?.walletXtzMutez ?? null)
-                  : "—"
-              }
+              label="XTZ value of sTEZ"
+              value={walletConnected ? formatUnits(walletUnderlying) : "—"}
               note={
-                walletConnected ? "Available in your wallet" : "Connect to view"
+                walletConnected
+                  ? "Same sTEZ position, shown in XTZ"
+                  : "Connect to view"
               }
-              icon={<AccountBalanceWalletOutlinedIcon />}
+              icon={<SwapHorizRoundedIcon />}
             />
             <PositionCell
               label="Pending Redemption"
@@ -471,7 +491,7 @@ export const Stez: FC = () => {
               }
               note={
                 walletConnected
-                  ? "Frozen XTZ awaiting maturity"
+                  ? "Redeemed XTZ still frozen"
                   : "Connect to view"
               }
               icon={<LockClockOutlinedIcon />}
@@ -694,31 +714,30 @@ export const Stez: FC = () => {
           aria-labelledby="stez-rate-history-title"
         >
           <header className="stez-panel__head">
-            <h2 id="stez-rate-history-title">PROTOCOL RATE</h2>
+            <h2 id="stez-rate-history-title">RATE HISTORY</h2>
             <span>
               Block {snapshot?.blockLevel.toLocaleString("en-US") ?? "—"}
             </span>
           </header>
           <div className="stez-rate-panel">
-            <div>
-              <span className="stez-field-label">CURRENT REDEMPTION RATE</span>
+            <div className="stez-rate-panel__current">
+              <span className="stez-field-label">CURRENT RATE</span>
               <strong>
-                <span>1 sTEZ =</span>
-                <span>{rate} XTZ</span>
+                1 sTEZ <span>=</span> {rate} XTZ
               </strong>
               <small>
-                Rewards do not increase your sTEZ balance. Instead, they
-                increase the amount of XTZ each sTEZ can redeem for. Baker fees
-                reduce the rewards passed through, and slashing can lower the
-                redemption rate.
+                Rewards and slashing change the XTZ value represented by each
+                sTEZ; they do not change the number of sTEZ in your wallet.
               </small>
             </div>
             <div className="stez-rate-panel__empty">
-              <p>
-                Rate history will appear once TEZEX is indexing a live
-                sTEZ-enabled network. No simulated returns or projected APY are
-                shown.
-              </p>
+              <div>
+                <strong>NO HISTORY YET</strong>
+                <p>
+                  Historical rates will appear after TEZEX has indexed enough
+                  Snet observations. No projected returns are substituted.
+                </p>
+              </div>
             </div>
           </div>
         </section>

--- a/V2/tezex/src/pages/Stez/rpc.test.ts
+++ b/V2/tezex/src/pages/Stez/rpc.test.ts
@@ -90,6 +90,7 @@ describe("sTEZ RPC adapter", () => {
         return response({ numerator: "1040000000", denominator: "1000000000" });
       }
       if (url.endsWith("/balance")) return response("9000000");
+      if (url.endsWith("/staked_balance")) return response("1500000");
       if (url.endsWith("/stez_balance")) return response("2000000");
       if (url.endsWith("/stez_redeemed_frozen_balance")) {
         return response("300000");
@@ -104,6 +105,7 @@ describe("sTEZ RPC adapter", () => {
 
     expect(snapshot.availability).toBe("available");
     expect(snapshot.contractHash).toBe("KT1Native");
+    expect(snapshot.walletStakedMutez).toBe(BigInt(1_500_000));
     expect(snapshot.walletStezUnits).toBe(BigInt(2_000_000));
     expect(snapshot.redeemedFinalizableMutez).toBe(BigInt(100_000));
     expect(

--- a/V2/tezex/src/pages/Stez/rpc.ts
+++ b/V2/tezex/src/pages/Stez/rpc.ts
@@ -23,6 +23,7 @@ export interface StezSnapshot {
   rateNumeratorMutez: bigint | null;
   rateDenominatorTokenUnits: bigint | null;
   walletXtzMutez: bigint | null;
+  walletStakedMutez: bigint | null;
   walletStezUnits: bigint | null;
   redeemedFrozenMutez: bigint | null;
   redeemedFinalizableMutez: bigint | null;
@@ -147,6 +148,7 @@ const unavailableSnapshot = (
   rateNumeratorMutez: null,
   rateDenominatorTokenUnits: null,
   walletXtzMutez: null,
+  walletStakedMutez: null,
   walletStezUnits: null,
   redeemedFrozenMutez: null,
   redeemedFinalizableMutez: null,
@@ -294,6 +296,11 @@ export async function loadStezSnapshot(
           ),
           fetchRpc<string | number>(
             metadata.endpoint,
+            `${accountPath}/staked_balance`,
+            signal
+          ),
+          fetchRpc<string | number>(
+            metadata.endpoint,
             `${accountPath}/stez_balance`,
             signal
           ),
@@ -324,9 +331,10 @@ export async function loadStezSnapshot(
       rateNumeratorMutez: toBigInt(rate.numerator),
       rateDenominatorTokenUnits: toBigInt(rate.denominator),
       walletXtzMutez: account ? toBigInt(account[0]) : null,
-      walletStezUnits: account ? toBigInt(account[1]) : null,
-      redeemedFrozenMutez: account ? toBigInt(account[2]) : null,
-      redeemedFinalizableMutez: account ? toBigInt(account[3]) : null,
+      walletStakedMutez: account ? toBigInt(account[1]) : null,
+      walletStezUnits: account ? toBigInt(account[2]) : null,
+      redeemedFrozenMutez: account ? toBigInt(account[3]) : null,
+      redeemedFinalizableMutez: account ? toBigInt(account[4]) : null,
       checkedAt: Date.now(),
       detail:
         "sTEZ is active and the current position was read from one fixed Tezos block.",

--- a/V2/tezex/src/pages/Stez/style.css
+++ b/V2/tezex/src/pages/Stez/style.css
@@ -179,9 +179,9 @@
   grid-template-columns: 470px minmax(0, 1fr);
   grid-template-areas:
     "action position"
-    "action rate"
-    "action details";
-  align-items: start;
+    "rate rate"
+    "details details";
+  align-items: stretch;
   gap: 18px 20px;
 }
 
@@ -196,6 +196,8 @@
 
 .stez-workspace__position {
   grid-area: position;
+  display: flex;
+  flex-direction: column;
 }
 
 .stez-workspace__rate {
@@ -207,25 +209,21 @@
 }
 
 .stez-workspace__position .stez-position-cell {
-  min-height: 100px;
+  min-height: 108px;
   padding: 15px 18px;
 }
 
 .stez-workspace__rate .stez-rate-panel {
-  min-height: 190px;
-  grid-template-columns: 130px minmax(0, 1fr);
-}
-
-.stez-workspace__rate .stez-rate-panel > div:first-child {
-  padding: 20px 18px;
+  min-height: 128px;
+  grid-template-columns: minmax(0, 0.58fr) minmax(0, 0.42fr);
 }
 
 .stez-workspace__rate .stez-rate-panel__empty {
-  padding: 18px;
+  padding: 20px 24px;
 }
 
-.stez-workspace__rate .stez-rate-panel__empty p {
-  padding: 10px 12px;
+.stez-workspace__rate .stez-rate-panel__empty > div {
+  max-width: 360px;
 }
 
 .stez-panel__head {
@@ -251,8 +249,10 @@
 }
 
 .stez-position-grid {
+  flex: 1;
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-auto-rows: 1fr;
 }
 
 .stez-position-cell {
@@ -262,18 +262,14 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
+  border-right: 0;
+}
+
+.stez-position-cell:nth-child(odd) {
   border-right: 1px solid var(--tezex-line);
 }
 
-.stez-position-cell:last-child {
-  border-right: 0;
-}
-
-.stez-position-cell:nth-child(2) {
-  border-right: 0;
-}
-
-.stez-position-cell:nth-child(-n + 2) {
+.stez-position-cell:nth-child(-n + 4) {
   border-bottom: 1px solid var(--tezex-line);
 }
 
@@ -557,36 +553,41 @@
 }
 
 .stez-rate-panel {
-  min-height: 210px;
+  min-height: 128px;
   display: grid;
-  grid-template-columns: minmax(180px, 0.32fr) minmax(0, 0.68fr);
+  grid-template-columns: minmax(0, 0.58fr) minmax(0, 0.42fr);
 }
 
-.stez-rate-panel > div:first-child {
-  padding: 26px 22px;
+.stez-rate-panel__current {
+  min-width: 0;
+  padding: 22px 24px;
   display: flex;
   flex-direction: column;
   justify-content: center;
   border-right: 1px solid var(--tezex-line);
 }
 
-.stez-rate-panel > div:first-child strong {
-  margin-top: 13px;
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
+.stez-rate-panel__current strong {
+  margin-top: 10px;
+  display: block;
   font-family: "Red Hat Mono", monospace;
-  font-size: clamp(18px, 2.8vw, 24px);
+  font-size: clamp(18px, 2.4vw, 23px);
   font-weight: 500;
-  line-height: 1.15;
+  line-height: 1.2;
   letter-spacing: -0.04em;
+  white-space: nowrap;
 }
 
-.stez-rate-panel > div:first-child small {
-  margin-top: 7px;
+.stez-rate-panel__current strong span {
+  color: var(--tezex-muted);
+}
+
+.stez-rate-panel__current small {
+  max-width: 520px;
+  margin-top: 8px;
   color: var(--tezex-faint);
-  font-family: "Red Hat Mono", monospace;
-  font-size: 9px;
+  font-size: 10px;
+  line-height: 1.5;
 }
 
 .stez-rate-panel__empty {
@@ -597,17 +598,25 @@
   justify-content: center;
 }
 
-.stez-rate-panel__empty p {
+.stez-rate-panel__empty > div {
   max-width: 390px;
   margin: 0;
-  padding: 12px 16px;
+}
+
+.stez-rate-panel__empty strong {
+  display: block;
+  color: var(--tezex-faint);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+}
+
+.stez-rate-panel__empty p {
+  margin: 7px 0 0;
   color: var(--tezex-muted);
-  background: var(--tezex-panel);
-  border: 1px solid var(--tezex-line);
-  border-radius: 12px;
   font-size: 11px;
   line-height: 1.6;
-  text-align: center;
+  text-align: left;
 }
 
 .stez-protocol-details summary {
@@ -764,20 +773,17 @@
   }
 
   .stez-workspace__rate .stez-rate-panel {
-    min-height: 210px;
-    grid-template-columns: minmax(180px, 0.32fr) minmax(0, 0.68fr);
+    min-height: 0;
+    grid-template-columns: minmax(0, 1fr);
   }
 
-  .stez-workspace__rate .stez-rate-panel > div:first-child {
-    padding: 26px 22px;
+  .stez-workspace__rate .stez-rate-panel__current {
+    border-right: 0;
+    border-bottom: 1px solid var(--tezex-line);
   }
 
   .stez-workspace__rate .stez-rate-panel__empty {
-    padding: 30px;
-  }
-
-  .stez-workspace__rate .stez-rate-panel__empty p {
-    padding: 12px 16px;
+    padding: 20px 22px;
   }
 }
 
@@ -900,15 +906,15 @@
     display: block;
   }
 
-  .stez-rate-panel > div:first-child {
+  .stez-rate-panel__current {
     min-height: 128px;
     border-right: 0;
     border-bottom: 1px solid var(--tezex-line);
   }
 
   .stez-rate-panel__empty {
-    min-height: 180px;
-    padding: 22px;
+    min-height: 0;
+    padding: 20px 22px;
   }
 }
 


### PR DESCRIPTION
## What changed
- expands the position ledger around the user asset lifecycle
- reads direct Tezos stake separately from the sTEZ position
- labels the XTZ value of sTEZ without double-counting it
- moves rate history below the action workspace and simplifies its hierarchy
- aligns the desktop action and position columns while preserving the mobile layout

## Verification
- production audit threshold passed
- typecheck passed
- 214 active tests passed
- production build passed
- desktop and mobile browser checks passed with no console errors