### PR TITLE
Refine sTEZ position summary

### DIFF
--- a/V2/tezex/src/pages/Stez/index.test.tsx
+++ b/V2/tezex/src/pages/Stez/index.test.tsx
@@ -67,7 +67,6 @@ const baseSnapshot: StezSnapshot = {
   rateNumeratorMutez: BigInt(1_100_000),
   rateDenominatorTokenUnits: BigInt(1_000_000),
   walletXtzMutez: null,
-  walletStakedMutez: null,
   walletStezUnits: null,
   redeemedFrozenMutez: null,
   redeemedFinalizableMutez: null,
@@ -139,7 +138,6 @@ test("enables a stake request only for a wallet connected to Snet", async () => 
   (loadStezSnapshot as jest.Mock).mockResolvedValue({
     ...baseSnapshot,
     walletXtzMutez: BigInt(5_000_000),
-    walletStakedMutez: BigInt(1_500_000),
     walletStezUnits: BigInt(2_000_000),
     redeemedFrozenMutez: BigInt(250_000),
     redeemedFinalizableMutez: BigInt(100_000),
@@ -154,10 +152,10 @@ test("enables a stake request only for a wallet connected to Snet", async () => 
     ).toBeDisabled()
   );
   expect(screen.getByText("5.0")).toBeInTheDocument();
-  expect(screen.getByText("1.5")).toBeInTheDocument();
   expect(screen.getByText("2.0")).toBeInTheDocument();
-  expect(screen.getByText("Direct stake")).toBeInTheDocument();
-  expect(screen.getByText("XTZ value of sTEZ")).toBeInTheDocument();
+  expect(screen.getByText("2.2")).toBeInTheDocument();
+  expect(screen.queryByText("Direct stake")).not.toBeInTheDocument();
+  expect(screen.getByText("Current redemption value")).toBeInTheDocument();
   expect(
     screen.getByText(/Test XTZ detected in your connected wallet/)
   ).toBeInTheDocument();

--- a/V2/tezex/src/pages/Stez/index.tsx
+++ b/V2/tezex/src/pages/Stez/index.tsx
@@ -5,7 +5,6 @@ import CheckCircleOutlineRoundedIcon from "@mui/icons-material/CheckCircleOutlin
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import LockClockOutlinedIcon from "@mui/icons-material/LockClockOutlined";
 import ArrowOutwardRoundedIcon from "@mui/icons-material/ArrowOutwardRounded";
-import SavingsOutlinedIcon from "@mui/icons-material/SavingsOutlined";
 import SwapHorizRoundedIcon from "@mui/icons-material/SwapHorizRounded";
 
 import { connectWalletToCustomNetwork } from "../../functions/beacon";
@@ -447,20 +446,6 @@ export const Stez: FC = () => {
               icon={<AccountBalanceWalletOutlinedIcon />}
             />
             <PositionCell
-              label="Direct stake"
-              value={
-                walletConnected
-                  ? formatUnits(snapshot?.walletStakedMutez ?? null)
-                  : "—"
-              }
-              note={
-                walletConnected
-                  ? "Staked separately from sTEZ"
-                  : "Connect to view"
-              }
-              icon={<SavingsOutlinedIcon />}
-            />
-            <PositionCell
               label="sTEZ Balance"
               value={
                 walletConnected
@@ -473,11 +458,11 @@ export const Stez: FC = () => {
               icon={<AccountBalanceWalletOutlinedIcon />}
             />
             <PositionCell
-              label="XTZ value of sTEZ"
+              label="Current redemption value"
               value={walletConnected ? formatUnits(walletUnderlying) : "—"}
               note={
                 walletConnected
-                  ? "Same sTEZ position, shown in XTZ"
+                  ? "XTZ represented by your sTEZ at the current protocol rate"
                   : "Connect to view"
               }
               icon={<SwapHorizRoundedIcon />}

--- a/V2/tezex/src/pages/Stez/rpc.test.ts
+++ b/V2/tezex/src/pages/Stez/rpc.test.ts
@@ -90,7 +90,6 @@ describe("sTEZ RPC adapter", () => {
         return response({ numerator: "1040000000", denominator: "1000000000" });
       }
       if (url.endsWith("/balance")) return response("9000000");
-      if (url.endsWith("/staked_balance")) return response("1500000");
       if (url.endsWith("/stez_balance")) return response("2000000");
       if (url.endsWith("/stez_redeemed_frozen_balance")) {
         return response("300000");
@@ -105,7 +104,6 @@ describe("sTEZ RPC adapter", () => {
 
     expect(snapshot.availability).toBe("available");
     expect(snapshot.contractHash).toBe("KT1Native");
-    expect(snapshot.walletStakedMutez).toBe(BigInt(1_500_000));
     expect(snapshot.walletStezUnits).toBe(BigInt(2_000_000));
     expect(snapshot.redeemedFinalizableMutez).toBe(BigInt(100_000));
     expect(

--- a/V2/tezex/src/pages/Stez/rpc.ts
+++ b/V2/tezex/src/pages/Stez/rpc.ts
@@ -23,7 +23,6 @@ export interface StezSnapshot {
   rateNumeratorMutez: bigint | null;
   rateDenominatorTokenUnits: bigint | null;
   walletXtzMutez: bigint | null;
-  walletStakedMutez: bigint | null;
   walletStezUnits: bigint | null;
   redeemedFrozenMutez: bigint | null;
   redeemedFinalizableMutez: bigint | null;
@@ -148,7 +147,6 @@ const unavailableSnapshot = (
   rateNumeratorMutez: null,
   rateDenominatorTokenUnits: null,
   walletXtzMutez: null,
-  walletStakedMutez: null,
   walletStezUnits: null,
   redeemedFrozenMutez: null,
   redeemedFinalizableMutez: null,
@@ -296,11 +294,6 @@ export async function loadStezSnapshot(
           ),
           fetchRpc<string | number>(
             metadata.endpoint,
-            `${accountPath}/staked_balance`,
-            signal
-          ),
-          fetchRpc<string | number>(
-            metadata.endpoint,
             `${accountPath}/stez_balance`,
             signal
           ),
@@ -331,10 +324,9 @@ export async function loadStezSnapshot(
       rateNumeratorMutez: toBigInt(rate.numerator),
       rateDenominatorTokenUnits: toBigInt(rate.denominator),
       walletXtzMutez: account ? toBigInt(account[0]) : null,
-      walletStakedMutez: account ? toBigInt(account[1]) : null,
-      walletStezUnits: account ? toBigInt(account[2]) : null,
-      redeemedFrozenMutez: account ? toBigInt(account[3]) : null,
-      redeemedFinalizableMutez: account ? toBigInt(account[4]) : null,
+      walletStezUnits: account ? toBigInt(account[1]) : null,
+      redeemedFrozenMutez: account ? toBigInt(account[2]) : null,
+      redeemedFinalizableMutez: account ? toBigInt(account[3]) : null,
       checkedAt: Date.now(),
       detail:
         "sTEZ is active and the current position was read from one fixed Tezos block.",

--- a/V2/tezex/src/pages/Stez/style.css
+++ b/V2/tezex/src/pages/Stez/style.css
@@ -265,12 +265,17 @@
   border-right: 0;
 }
 
-.stez-position-cell:nth-child(odd) {
+.stez-position-cell:nth-child(1),
+.stez-position-cell:nth-child(4) {
   border-right: 1px solid var(--tezex-line);
 }
 
-.stez-position-cell:nth-child(-n + 4) {
+.stez-position-cell:nth-child(-n + 3) {
   border-bottom: 1px solid var(--tezex-line);
+}
+
+.stez-position-cell:nth-child(3) {
+  grid-column: 1 / -1;
 }
 
 .stez-position-cell__label {


### PR DESCRIPTION
## What changed
- Remove the unrelated direct-staking balance from the sTEZ position summary
- Rename the sTEZ-backed XTZ amount to Current redemption value
- Reorder the five position metrics into a balanced balance, value, and redemption sequence
- Remove the unused direct-staking RPC request

## Verification
- Production audit has no high-severity findings
- Typecheck passed
- 214 tests passed
- Production build passed
- Desktop and mobile browser verification passed with no runtime warnings or errors