### PR TITLE
Place sTEZ rate history last

### DIFF
--- a/V2/tezex/src/pages/Stez/index.test.tsx
+++ b/V2/tezex/src/pages/Stez/index.test.tsx
@@ -95,6 +95,12 @@ test("loads live Snet data and its matching faucet", async () => {
   expect(screen.getByText("Stake tez, stay liquid.")).toBeInTheDocument();
   expect(screen.getByText("sTEZ Balance")).toBeInTheDocument();
   expect(screen.getByText("Total sTEZ supply")).toBeInTheDocument();
+  expect(
+    screen
+      .getByText("PROTOCOL DETAILS")
+      .compareDocumentPosition(screen.getByText("RATE HISTORY")) &
+      Node.DOCUMENT_POSITION_FOLLOWING
+  ).toBeTruthy();
 
   const faucet = screen.getByRole("link", {
     name: "Get Snet test XTZ from the official Teztnets faucet",

--- a/V2/tezex/src/pages/Stez/index.tsx
+++ b/V2/tezex/src/pages/Stez/index.tsx
@@ -694,39 +694,6 @@ export const Stez: FC = () => {
           </div>
         </section>
 
-        <section
-          className="stez-panel stez-workspace__rate"
-          aria-labelledby="stez-rate-history-title"
-        >
-          <header className="stez-panel__head">
-            <h2 id="stez-rate-history-title">RATE HISTORY</h2>
-            <span>
-              Block {snapshot?.blockLevel.toLocaleString("en-US") ?? "—"}
-            </span>
-          </header>
-          <div className="stez-rate-panel">
-            <div className="stez-rate-panel__current">
-              <span className="stez-field-label">CURRENT RATE</span>
-              <strong>
-                1 sTEZ <span>=</span> {rate} XTZ
-              </strong>
-              <small>
-                Rewards and slashing change the XTZ value represented by each
-                sTEZ; they do not change the number of sTEZ in your wallet.
-              </small>
-            </div>
-            <div className="stez-rate-panel__empty">
-              <div>
-                <strong>NO HISTORY YET</strong>
-                <p>
-                  Historical rates will appear after TEZEX has indexed enough
-                  Snet observations. No projected returns are substituted.
-                </p>
-              </div>
-            </div>
-          </div>
-        </section>
-
         <details className="stez-protocol-details stez-workspace__details">
           <summary>PROTOCOL DETAILS</summary>
           <div>
@@ -764,6 +731,39 @@ export const Stez: FC = () => {
             </p>
           </div>
         </details>
+
+        <section
+          className="stez-panel stez-workspace__rate"
+          aria-labelledby="stez-rate-history-title"
+        >
+          <header className="stez-panel__head">
+            <h2 id="stez-rate-history-title">RATE HISTORY</h2>
+            <span>
+              Block {snapshot?.blockLevel.toLocaleString("en-US") ?? "—"}
+            </span>
+          </header>
+          <div className="stez-rate-panel">
+            <div className="stez-rate-panel__current">
+              <span className="stez-field-label">CURRENT RATE</span>
+              <strong>
+                1 sTEZ <span>=</span> {rate} XTZ
+              </strong>
+              <small>
+                Rewards and slashing change the XTZ value represented by each
+                sTEZ; they do not change the number of sTEZ in your wallet.
+              </small>
+            </div>
+            <div className="stez-rate-panel__empty">
+              <div>
+                <strong>NO HISTORY YET</strong>
+                <p>
+                  Historical rates will appear after TEZEX has indexed enough
+                  Snet observations. No projected returns are substituted.
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
       </div>
     </main>
   );

--- a/V2/tezex/src/pages/Stez/style.css
+++ b/V2/tezex/src/pages/Stez/style.css
@@ -179,8 +179,8 @@
   grid-template-columns: 470px minmax(0, 1fr);
   grid-template-areas:
     "action position"
-    "rate rate"
-    "details details";
+    "details details"
+    "rate rate";
   align-items: stretch;
   gap: 18px 20px;
 }
@@ -381,11 +381,6 @@
   background: var(--tezex-field);
   border: 1px solid var(--tezex-line);
   border-radius: 15px;
-  transition: border-color 160ms ease;
-}
-
-.stez-amount-field:focus-within {
-  border-color: var(--tezex-line-strong);
 }
 
 .stez-amount-field__topline {
@@ -713,10 +708,13 @@
 }
 
 .stez-page button:focus-visible,
-.stez-page input:focus-visible,
 .stez-page summary:focus-visible {
   outline: 2px solid var(--tezex-text-secondary);
   outline-offset: 3px;
+}
+
+.stez-amount-field__input input:focus-visible {
+  outline: 0;
 }
 
 @media (max-width: 959px) {
@@ -759,11 +757,11 @@
     order: 2;
   }
 
-  .stez-workspace__rate {
+  .stez-workspace__details {
     order: 3;
   }
 
-  .stez-workspace__details {
+  .stez-workspace__rate {
     order: 4;
   }
 


### PR DESCRIPTION
## What changed

- places Protocol Details before Rate History on desktop and mobile
- keeps Rate History as the final content card so future observations can grow without burying controls
- removes the nested focus outline and focus-border change from the amount entry field
- adds coverage for the intended content order

## Verification

- production dependency audit (no high-severity finding)
- TypeScript check
- 214 tests passed, 2 skipped
- production build
- desktop and mobile browser verification