### PR TITLE
Promote mobile swap transaction status

### DIFF
--- a/V2/tezex/src/components/swap/index.tsx
+++ b/V2/tezex/src/components/swap/index.tsx
@@ -488,6 +488,21 @@ export const Swap: FC<ISwapToken> = ({ routeSelection, onRouteChange }) => {
         </Card>
 
         <Box sx={styles.contextColumn}>
+          <Box sx={styles.statusPanel} aria-live="polite">
+            <Box sx={styles.statusHeader}>
+              <Typography sx={styles.eyebrow}>TRANSACTION STATUS</Typography>
+              <Typography sx={styles.statusText}>{statusLabel}</Typography>
+            </Box>
+
+            <TransactionProgress statusStep={statusStep} styles={styles} />
+
+            <Typography sx={styles.statusFootnote}>
+              Request gets a live pool price. Swap covers wallet approval and
+              on-chain execution. Complete means the operation is confirmed on
+              Tezos.
+            </Typography>
+          </Box>
+
           <Box sx={styles.detailsPanel}>
             <Box sx={styles.panelHeader}>
               <Box sx={styles.headerTitleGroup}>
@@ -552,21 +567,6 @@ export const Swap: FC<ISwapToken> = ({ routeSelection, onRouteChange }) => {
               Review every amount and destination in your wallet before
               approving.
             </Box>
-          </Box>
-
-          <Box sx={styles.statusPanel} aria-live="polite">
-            <Box sx={styles.statusHeader}>
-              <Typography sx={styles.eyebrow}>TRANSACTION STATUS</Typography>
-              <Typography sx={styles.statusText}>{statusLabel}</Typography>
-            </Box>
-
-            <TransactionProgress statusStep={statusStep} styles={styles} />
-
-            <Typography sx={styles.statusFootnote}>
-              Request gets a live pool price. Swap covers wallet approval and
-              on-chain execution. Complete means the operation is confirmed on
-              Tezos.
-            </Typography>
           </Box>
         </Box>
       </Box>

--- a/V2/tezex/src/components/swap/style.js
+++ b/V2/tezex/src/components/swap/style.js
@@ -160,6 +160,7 @@ const style = (theme, scale = 1) => {
       borderRadius: { xs: "20px", sm: "24px" },
       background: "var(--tezex-panel)",
       border: "1px solid var(--tezex-line)",
+      "@media (min-width: 960px)": { order: 1 },
     },
     panelHeader: {
       minHeight: "82px",
@@ -245,7 +246,7 @@ const style = (theme, scale = 1) => {
       borderRadius: { xs: "20px", sm: "24px" },
       background: "var(--tezex-panel)",
       border: "1px solid var(--tezex-line)",
-      "@media (min-width: 960px)": { marginTop: "auto" },
+      "@media (min-width: 960px)": { order: 2, marginTop: "auto" },
     },
     statusHeader: {
       display: "flex",


### PR DESCRIPTION
## What changed

- Places Transaction Status above Swap Details in the stacked mobile layout.
- Preserves the existing details-first order in the desktop context column.

## Why

Transaction Status is the live, changing part of the swap flow and should remain visible before passive transaction details on narrow screens.

## Validation

- TypeScript typecheck
- Transaction progress tests
- Production build
- Responsive browser verification at 390px and 1440px
- Browser console check
