### PR TITLE
Refine empty swap amount feedback

### DIFF
--- a/V2/tezex/src/components/swap/index.tsx
+++ b/V2/tezex/src/components/swap/index.tsx
@@ -3,6 +3,7 @@ import React, {
   useState,
   useEffect,
   useCallback,
+  useRef,
   useSyncExternalStore,
 } from "react";
 import BigNumber from "bignumber.js";
@@ -144,6 +145,9 @@ export const Swap: FC<ISwapToken> = ({ routeSelection, onRouteChange }) => {
 
   const [swappingFileds, setSwappingFileds] = useState<boolean>(false);
   const [sendInputValue, setSendInputValue] = useState("0.00");
+  const [showAmountValidation, setShowAmountValidation] = useState(false);
+  const [shakeAmountField, setShakeAmountField] = useState(false);
+  const sendAmountInputRef = useRef<HTMLInputElement>(null);
   const session = useSession();
   const [canUpdate, setCanUpdate] = useState<boolean>(false);
   const previewLoading =
@@ -180,6 +184,8 @@ export const Swap: FC<ISwapToken> = ({ routeSelection, onRouteChange }) => {
     network.setSelectedPool(routeSelection.pool);
     setAssets(nextAssets);
     setSendInputValue("0.00");
+    setShowAmountValidation(false);
+    setShakeAmountField(false);
     wallet.clearTransaction(TransactingComponent.SWAP);
     setLoading(true);
     setReloading(true);
@@ -205,6 +211,8 @@ export const Swap: FC<ISwapToken> = ({ routeSelection, onRouteChange }) => {
       network.setSelectedPool(pool);
       setAssets(nextAssets);
       setSendInputValue("0.00");
+      setShowAmountValidation(false);
+      setShakeAmountField(false);
       onRouteChange?.(nextAssets[send].name, nextAssets[receive].name);
 
       wallet.clearTransaction(TransactingComponent.ADD_LIQUIDITY);
@@ -222,7 +230,27 @@ export const Swap: FC<ISwapToken> = ({ routeSelection, onRouteChange }) => {
     await walletOps.sendTransaction();
   }, [walletOps]);
 
+  const handleSendAmountChange = useCallback((value: string) => {
+    setSendInputValue(value);
+    if (new BigNumber(value || 0).isGreaterThan(0)) {
+      setShowAmountValidation(false);
+      setShakeAmountField(false);
+    }
+  }, []);
+
+  const handleZeroAmount = useCallback(() => {
+    setShowAmountValidation(true);
+    setShakeAmountField(false);
+    sendAmountInputRef.current?.focus();
+
+    window.requestAnimationFrame(() => {
+      window.requestAnimationFrame(() => setShakeAmountField(true));
+    });
+  }, []);
+
   const swapFields = useCallback(async () => {
+    setShowAmountValidation(false);
+    setShakeAmountField(false);
     setAssets([assets[1], assets[0]]);
     onRouteChange?.(assets[receive].name, assets[send].name);
     await transactionOps.swapFields();
@@ -363,7 +391,7 @@ export const Swap: FC<ISwapToken> = ({ routeSelection, onRouteChange }) => {
       )
     : undefined;
   const status = transaction?.transactionStatus;
-  const statusLabel = hasQuote ? getStatusLabel(status) : "Enter an amount";
+  const statusLabel = hasQuote ? getStatusLabel(status) : "Ready";
   const statusStep =
     status === TransactionStatus.COMPLETED
       ? 3
@@ -406,12 +434,18 @@ export const Swap: FC<ISwapToken> = ({ routeSelection, onRouteChange }) => {
           </Box>
 
           <CardContent sx={styles.cardContent}>
-            <Box sx={styles.amountField}>
+            <Box
+              sx={{
+                ...styles.amountField,
+                ...(shakeAmountField ? styles.amountFieldShake : {}),
+              }}
+              onAnimationEnd={() => setShakeAmountField(false)}
+            >
               <UserAmountField
                 component={TransactingComponent.SWAP}
                 transferType={TransferType.SEND}
                 asset={assets[send]}
-                onChange={setSendInputValue}
+                onChange={handleSendAmountChange}
                 readOnly={!canUpdate}
                 scalingKey={scalingKey}
                 loading={!isLoaded()}
@@ -420,6 +454,10 @@ export const Swap: FC<ISwapToken> = ({ routeSelection, onRouteChange }) => {
                 selectableAssets={sendAssetOptions}
                 onAssetChange={(asset) => handleAssetChange(send, asset)}
                 assetSelectionDisabled={!canUpdate}
+                validationMessage={
+                  showAmountValidation ? "Enter an amount" : undefined
+                }
+                inputRef={sendAmountInputRef}
               />
             </Box>
 
@@ -453,7 +491,9 @@ export const Swap: FC<ISwapToken> = ({ routeSelection, onRouteChange }) => {
                     )} ${assets[receive].label}`
                   : "Enter an amount to load a live pool quote"}
               </Typography>
-              <Typography sx={styles.quoteStatus}>{statusLabel}</Typography>
+              <Typography sx={styles.quoteStatus}>
+                {hasQuote ? statusLabel : ""}
+              </Typography>
             </Box>
           </CardContent>
 
@@ -464,6 +504,7 @@ export const Swap: FC<ISwapToken> = ({ routeSelection, onRouteChange }) => {
               callback={transact}
               scalingKey={scalingKey}
               visualVariant="dark"
+              onZeroAmount={handleZeroAmount}
             >
               Swap
             </Wallet>

--- a/V2/tezex/src/components/swap/style.js
+++ b/V2/tezex/src/components/swap/style.js
@@ -84,6 +84,19 @@ const style = (theme, scale = 1) => {
       width: "100%",
       minHeight: { xs: "108px", sm: "116px" },
     },
+    amountFieldShake: {
+      animation: "tezexAmountFieldShake 320ms ease-out",
+      "@keyframes tezexAmountFieldShake": {
+        "0%, 100%": { transform: "translateX(0)" },
+        "20%": { transform: "translateX(-4px)" },
+        "40%": { transform: "translateX(4px)" },
+        "60%": { transform: "translateX(-3px)" },
+        "80%": { transform: "translateX(3px)" },
+      },
+      "@media (prefers-reduced-motion: reduce)": {
+        animation: "none",
+      },
+    },
     swapToggle: {
       position: "relative",
       zIndex: 3,

--- a/V2/tezex/src/components/ui/elements/inputs/UserAmount/index.tsx
+++ b/V2/tezex/src/components/ui/elements/inputs/UserAmount/index.tsx
@@ -25,6 +25,8 @@ export interface IAmountField {
   selectableAssets?: Asset[];
   onAssetChange?: (asset: Asset) => void;
   assetSelectionDisabled?: boolean;
+  validationMessage?: string;
+  inputRef?: React.Ref<HTMLInputElement>;
 }
 
 const AmountField: FC<IAmountField> = (props) => {
@@ -46,6 +48,8 @@ const AmountField: FC<IAmountField> = (props) => {
       selectableAssets={props.selectableAssets}
       onAssetChange={props.onAssetChange}
       assetSelectionDisabled={props.assetSelectionDisabled}
+      validationMessage={props.validationMessage}
+      inputRef={props.inputRef}
     />
   );
 };

--- a/V2/tezex/src/components/ui/elements/inputs/UserAmount/token-input/index.tsx
+++ b/V2/tezex/src/components/ui/elements/inputs/UserAmount/token-input/index.tsx
@@ -46,6 +46,8 @@ export interface IRigthInput {
   selectableAssets?: Asset[];
   onAssetChange?: (asset: Asset) => void;
   assetSelectionDisabled?: boolean;
+  validationMessage?: string;
+  inputRef?: React.Ref<HTMLInputElement>;
 }
 
 const TokenInput: FC<IRigthInput> = (props) => {
@@ -270,16 +272,30 @@ const TokenInput: FC<IRigthInput> = (props) => {
           <Box component="label" htmlFor={inputId} sx={styles.tezex.label}>
             {props.label}
           </Box>
-          <WalletConnected>
-            <Typography hidden={!transactionBalance} sx={styles.tezex.balance}>
-              Balance {transactionBalance ? String(transactionBalance) : "—"}
+          {props.validationMessage ? (
+            <Typography
+              id={`${inputId}-validation`}
+              role="alert"
+              sx={styles.tezex.validationMessage}
+            >
+              {props.validationMessage}
             </Typography>
-          </WalletConnected>
+          ) : (
+            <WalletConnected>
+              <Typography
+                hidden={!transactionBalance}
+                sx={styles.tezex.balance}
+              >
+                Balance {transactionBalance ? String(transactionBalance) : "—"}
+              </Typography>
+            </WalletConnected>
+          )}
         </Box>
 
         <Box sx={styles.tezex.amountRow}>
           <TextField
             id={inputId}
+            inputRef={props.inputRef}
             autoComplete="off"
             onFocus={handleFocus}
             onBlur={handleBlur}
@@ -290,6 +306,10 @@ const TokenInput: FC<IRigthInput> = (props) => {
               inputMode: "decimal",
               readOnly: props.readOnly,
               "aria-label": `${props.label || props.transferType} amount`,
+              "aria-invalid": Boolean(props.validationMessage),
+              "aria-describedby": props.validationMessage
+                ? `${inputId}-validation`
+                : undefined,
             }}
             variant="standard"
             InputProps={{ disableUnderline: true }}

--- a/V2/tezex/src/components/ui/elements/inputs/UserAmount/token-input/style.js
+++ b/V2/tezex/src/components/ui/elements/inputs/UserAmount/token-input/style.js
@@ -35,6 +35,13 @@ export const style = (theme, scale = 1) => {
         fontSize: "11px",
         fontWeight: 400,
       },
+      validationMessage: {
+        color: "#c94c4c",
+        fontSize: "10px",
+        fontWeight: 700,
+        letterSpacing: "0.04em",
+        lineHeight: 1.2,
+      },
       amountRow: {
         display: "flex",
         alignItems: "center",

--- a/V2/tezex/src/components/wallet/Wallet.test.tsx
+++ b/V2/tezex/src/components/wallet/Wallet.test.tsx
@@ -5,6 +5,7 @@ import { Wallet } from "./Wallet";
 
 const mockDisconnect = jest.fn().mockResolvedValue(undefined);
 const mockConnectOverride = jest.fn().mockResolvedValue(undefined);
+const mockZeroAmount = jest.fn();
 const mockWallet = {
   address: "tz1d4ExampleAccountAddressMuU7n",
   isWalletConnected: true,
@@ -32,6 +33,7 @@ jest.mock("../../functions/beacon", () => ({
 beforeEach(() => {
   mockDisconnect.mockClear();
   mockConnectOverride.mockClear();
+  mockZeroAmount.mockClear();
 });
 
 const renderWallet = () =>
@@ -89,4 +91,21 @@ test("disconnect is only called from the explicit action", async () => {
 
   await waitFor(() => expect(mockDisconnect).toHaveBeenCalledTimes(1));
   expect(mockConnectOverride).not.toHaveBeenCalled();
+});
+
+test("keeps the normal action available and delegates zero-amount validation", () => {
+  render(
+    <MemoryRouter>
+      <Wallet visualVariant="dark" onZeroAmount={mockZeroAmount}>
+        Swap
+      </Wallet>
+    </MemoryRouter>
+  );
+
+  const action = screen.getByRole("button", { name: "Swap" });
+  expect(action).toBeEnabled();
+
+  fireEvent.click(action);
+
+  expect(mockZeroAmount).toHaveBeenCalledTimes(1);
 });

--- a/V2/tezex/src/components/wallet/Wallet.tsx
+++ b/V2/tezex/src/components/wallet/Wallet.tsx
@@ -32,6 +32,7 @@ interface IWallet {
   visualVariant?: "default" | "dark";
   connectOverride?: () => Promise<void>;
   accountPresentation?: "header" | "drawer";
+  onZeroAmount?: () => void;
 }
 
 export const Wallet: FC<IWallet> = (props) => {
@@ -69,9 +70,9 @@ export const Wallet: FC<IWallet> = (props) => {
   useEffect(() => {
     switch (transactionStatus) {
       case TransactionStatus.ZERO_AMOUNT:
-        setDisabled(true);
+        setDisabled(!props.onZeroAmount);
         setSpinner(false);
-        setWalletText(transactionStatus);
+        setWalletText(props.onZeroAmount ? props.children : transactionStatus);
         break;
       case TransactionStatus.INSUFFICIENT_BALANCE:
         setDisabled(true);
@@ -127,9 +128,17 @@ export const Wallet: FC<IWallet> = (props) => {
         setSpinner(true);
         setWalletText(transactionStatus);
     }
-  }, [transactionStatus, props.children]);
+  }, [transactionStatus, props.children, props.onZeroAmount]);
 
   const transact = async () => {
+    if (
+      transactionStatus === TransactionStatus.ZERO_AMOUNT &&
+      props.onZeroAmount
+    ) {
+      props.onZeroAmount();
+      return;
+    }
+
     if (transactionStatus === TransactionStatus.CONFIRMATION_UNKNOWN) {
       const operationHash = walletOps?.getActiveTransaction()?.operationHash;
       if (operationHash) {


### PR DESCRIPTION
## What changed
- keep the connected swap action labeled `SWAP` when the amount is empty
- validate only after an empty swap attempt
- focus and briefly shake the source amount field with compact inline feedback
- clear the feedback as soon as a valid amount is entered
- replace the passive empty transaction status with `Ready`

## Verification
- production dependency audit
- TypeScript typecheck
- 41 test suites: 216 passed, 2 skipped
- optimized production build
- mobile production-build visual check