### PR TITLE
Restore consistent swap action typography

### DIFF
--- a/V2/tezex/src/components/wallet/Wallet.test.tsx
+++ b/V2/tezex/src/components/wallet/Wallet.test.tsx
@@ -104,6 +104,14 @@ test("keeps the normal action available and delegates zero-amount validation", (
 
   const action = screen.getByRole("button", { name: "Swap" });
   expect(action).toBeEnabled();
+  expect(screen.getByText("Swap")).toHaveStyle({
+    fontFamily: "inherit",
+    fontWeight: "inherit",
+    fontSize: "inherit",
+    lineHeight: "1",
+    letterSpacing: "inherit",
+    textTransform: "inherit",
+  });
 
   fireEvent.click(action);
 

--- a/V2/tezex/src/components/wallet/Wallet.tsx
+++ b/V2/tezex/src/components/wallet/Wallet.tsx
@@ -335,7 +335,16 @@ export const Wallet: FC<IWallet> = (props) => {
             >
               <CircularProgress sx={styles.spinner} />
             </Box>
-            <Typography sx={styles.transactionStatus}>{walletText}</Typography>
+            <Typography
+              component="span"
+              sx={
+                props.visualVariant === "dark"
+                  ? styles.transactionStatusDark
+                  : styles.transactionStatus
+              }
+            >
+              {walletText}
+            </Typography>
           </Box>
         </Button>
       );

--- a/V2/tezex/src/components/wallet/style.js
+++ b/V2/tezex/src/components/wallet/style.js
@@ -6,6 +6,14 @@ const style = (theme, scale = 1) => {
       fontSize: `calc(1.66vw * ${scale})`,
       lineHeight: `calc(2.01vw * ${scale})`,
     },
+    transactionStatusDark: {
+      fontFamily: "inherit",
+      fontWeight: "inherit",
+      fontSize: "inherit",
+      lineHeight: 1,
+      letterSpacing: "inherit",
+      textTransform: "inherit",
+    },
 
     spinnerBox: {
       position: "absolute",


### PR DESCRIPTION
## What changed
- keep the established all-caps TEZEX action-button treatment in every wallet state
- prevent the connected swap label from inheriting the legacy viewport-scaled transaction text style
- add regression coverage for the connected action label typography

## Verification
- production dependency audit completed at the configured threshold
- typecheck passed
- 216 tests passed, 2 skipped
- production build passed