### PR TITLE
Refine sTEZ position and amount labels

### DIFF
--- a/V2/tezex/src/pages/Stez/index.test.tsx
+++ b/V2/tezex/src/pages/Stez/index.test.tsx
@@ -109,11 +109,11 @@ test("loads live Snet data and its matching faucet", async () => {
   expect(faucet.querySelector("svg")).toBeInTheDocument();
 
   fireEvent.click(screen.getByRole("tab", { name: "Redeem" }));
-  expect(screen.getByText("YOU REDEEM")).toBeInTheDocument();
-  expect(screen.getByText("XTZ ENTERING REDEMPTION")).toBeInTheDocument();
+  expect(screen.getByText("AMOUNT TO REDEEM")).toBeInTheDocument();
+  expect(screen.getByText("ESTIMATED XTZ")).toBeInTheDocument();
 
   fireEvent.click(screen.getByRole("tab", { name: "Finalize" }));
-  expect(screen.getByText("READY TO FINALIZE")).toBeInTheDocument();
+  expect(screen.getByText("CLAIMABLE XTZ")).toBeInTheDocument();
 });
 
 test("shows an exact inactive-network state without enabling controls", async () => {
@@ -162,6 +162,8 @@ test("enables a stake request only for a wallet connected to Snet", async () => 
   expect(screen.getByText("2.2")).toBeInTheDocument();
   expect(screen.queryByText("Direct stake")).not.toBeInTheDocument();
   expect(screen.getByText("Current redemption value")).toBeInTheDocument();
+  expect(screen.getByText("Redemption in progress")).toBeInTheDocument();
+  expect(screen.getByText("Claimable XTZ")).toBeInTheDocument();
   expect(
     screen.getByText(/Test XTZ detected in your connected wallet/)
   ).toBeInTheDocument();
@@ -171,7 +173,7 @@ test("enables a stake request only for a wallet connected to Snet", async () => 
     })
   ).toHaveTextContent("GET MORE SNET TEST XTZ");
 
-  fireEvent.change(screen.getByLabelText("YOU STAKE"), {
+  fireEvent.change(screen.getByLabelText("AMOUNT TO STAKE"), {
     target: { value: "1" },
   });
   expect(screen.getByRole("button", { name: "STAKE XTZ" })).toBeEnabled();

--- a/V2/tezex/src/pages/Stez/index.tsx
+++ b/V2/tezex/src/pages/Stez/index.tsx
@@ -240,6 +240,10 @@ export const Stez: FC = () => {
           snapshot.rateDenominatorTokenUnits
         )
       : null;
+  const hasRedemptionStatus =
+    walletConnected &&
+    ((snapshot?.redeemedFrozenMutez ?? ZERO) > ZERO ||
+      (snapshot?.redeemedFinalizableMutez ?? ZERO) > ZERO);
   const inputUnits = parseUnits(amount);
   const quotedOutput = useMemo(() => {
     if (
@@ -434,7 +438,11 @@ export const Stez: FC = () => {
                 : "Wallet not connected"}
             </span>
           </header>
-          <div className="stez-position-grid">
+          <div
+            className={`stez-position-grid${
+              hasRedemptionStatus ? " has-redemption-status" : ""
+            }`}
+          >
             <PositionCell
               label="Wallet XTZ"
               value={
@@ -467,35 +475,25 @@ export const Stez: FC = () => {
               }
               icon={<SwapHorizRoundedIcon />}
             />
-            <PositionCell
-              label="Pending Redemption"
-              value={
-                walletConnected
-                  ? formatUnits(snapshot?.redeemedFrozenMutez ?? null)
-                  : "—"
-              }
-              note={
-                walletConnected
-                  ? "Redeemed XTZ still frozen"
-                  : "Connect to view"
-              }
-              icon={<LockClockOutlinedIcon />}
-            />
-            <PositionCell
-              label="Ready to Finalize"
-              value={
-                walletConnected
-                  ? formatUnits(snapshot?.redeemedFinalizableMutez ?? null)
-                  : "—"
-              }
-              note={
-                walletConnected
-                  ? "Matured XTZ ready to claim"
-                  : "Connect to view"
-              }
-              positive={Boolean(snapshot?.redeemedFinalizableMutez)}
-              icon={<CheckCircleOutlineRoundedIcon />}
-            />
+            {hasRedemptionStatus && (
+              <>
+                <PositionCell
+                  label="Redemption in progress"
+                  value={formatUnits(snapshot?.redeemedFrozenMutez ?? null)}
+                  note="Completing the protocol waiting period"
+                  icon={<LockClockOutlinedIcon />}
+                />
+                <PositionCell
+                  label="Claimable XTZ"
+                  value={formatUnits(
+                    snapshot?.redeemedFinalizableMutez ?? null
+                  )}
+                  note="Available to return to your wallet"
+                  positive={Boolean(snapshot?.redeemedFinalizableMutez)}
+                  icon={<CheckCircleOutlineRoundedIcon />}
+                />
+              </>
+            )}
           </div>
         </section>
 
@@ -547,7 +545,7 @@ export const Stez: FC = () => {
             {activeAction === "Finalize" ? (
               <>
                 <div className="stez-amount-field">
-                  <span className="stez-field-label">READY TO FINALIZE</span>
+                  <span className="stez-field-label">CLAIMABLE XTZ</span>
                   <div className="stez-amount-field__value">
                     <strong>
                       {formatUnits(snapshot?.redeemedFinalizableMutez ?? null)}
@@ -568,7 +566,9 @@ export const Stez: FC = () => {
                 <div className="stez-amount-field">
                   <div className="stez-amount-field__topline">
                     <label htmlFor="stez-action-amount">
-                      {activeAction === "Stake" ? "YOU STAKE" : "YOU REDEEM"}
+                      {activeAction === "Stake"
+                        ? "AMOUNT TO STAKE"
+                        : "AMOUNT TO REDEEM"}
                     </label>
                     <button
                       type="button"
@@ -608,8 +608,8 @@ export const Stez: FC = () => {
                 <div className="stez-amount-field">
                   <span className="stez-field-label">
                     {activeAction === "Stake"
-                      ? "YOU RECEIVE"
-                      : "XTZ ENTERING REDEMPTION"}
+                      ? "ESTIMATED sTEZ"
+                      : "ESTIMATED XTZ"}
                   </span>
                   <div className="stez-amount-field__value">
                     <strong>{formatUnits(quotedOutput)}</strong>

--- a/V2/tezex/src/pages/Stez/style.css
+++ b/V2/tezex/src/pages/Stez/style.css
@@ -278,6 +278,11 @@
   grid-column: 1 / -1;
 }
 
+.stez-position-grid:not(.has-redemption-status)
+  .stez-position-cell:nth-child(3) {
+  border-bottom: 0;
+}
+
 .stez-position-cell__label {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- replace second-person action-field labels with concise amount and estimate labels
- show redemption status only when a redemption actually exists
- rename exit states to Redemption in progress and Claimable XTZ

## Verification
- sTEZ page tests
- TypeScript check
- production build